### PR TITLE
Maven cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ local.properties
 .loadpath
 .recommenders
 
+### Netbeans ###
+nb-configuration.xml
+
 # External tool builders
 .externalToolBuilders/
 
@@ -195,3 +198,5 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 
 # End of https://www.gitignore.io/api/java,maven,eclipse,intellij+all
+/xslt-runner/nbproject/private/
+/xslt-runner-task/nbproject/private/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,10 @@
-Apache ODF Toolkit Change Log
+ODF Toolkit Change Log
 =============================
+======= Release 0.9.0 =======
+
+First release at the Document Foundation, resembling the latest state of the sources from Apache ODF Toolkit.
+Release is based on JDK 1.8, the next release will be start working based on JDK 11.
+Last release including the Simple API, which includes too many copied sources from ODFDOM and has not sufficient development support.
 
 ======= Release 0.6.2 =======
 

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -1,22 +1,40 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.odftoolkit</groupId>
-    <artifactId>odftoolkit</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>org.odftoolkit</groupId>
+        <artifactId>odftoolkit</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
 
     <!-- The Basics -->
     <artifactId>schema2template-pom</artifactId>
     <version>0.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
+    </properties>
 
     <!-- Build Settings -->
     <build>
@@ -36,7 +54,7 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                     <configuration>
-                        <!-- Workaround for http://jira.codehaus.org/browse/MGPG-9 -->
+                        <!-- Workaround for https://jira.codehaus.org/browse/MGPG-9 -->
                         <mavenExecutorId>forked-path</mavenExecutorId>
                     </configuration>
                 </plugin>
@@ -55,32 +73,29 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>
+            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.1.0</version>
                 <configuration>
                     <doctitle>Schema2template</doctitle>
                     <splitindex>true</splitindex>
-                    <windowtitle>Schema2template v${project.version} - http://incubator.apache.org/odftoolkit/</windowtitle>
-                    <links>
-                        <link>http://download.oracle.com/javase/8/docs/api/</link>
-                    </links>
+                    <windowtitle>Schema2template v${project.version} - https://odftoolkit.org/</windowtitle>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <attach>true</attach>
+                    <additionalOptions>${javadoc.opts}</additionalOptions>
                 </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
-                        </goals>                        
+                        </goals>
                         <configuration>
-                            <additionalparam>${javadoc.opts}</additionalparam>
+                            <additionalOptions>${javadoc.opts}</additionalOptions>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
--->            
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
@@ -88,7 +103,7 @@
         </plugins>
     </build>
 
-  <!-- Multimodule build -->
+    <!-- Multimodule build -->
     <modules>
         <module>schema2template</module>
         <module>schema2template-maven-plugin</module>
@@ -97,12 +112,12 @@
     <!-- More Project Information -->
     <name>XML Schema to Template Mapping Tool: Parent POM</name>
     <description>Parent project for XML Schema to Template Mapping Tool</description>
-    <url>http://odftoolkit.org</url>
+    <url>https://odftoolkit.org</url>
     <inceptionYear>2010</inceptionYear>
     <licenses>
         <license>
             <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
     <organization>
@@ -110,19 +125,19 @@
         <url>https://www.documentfoundation.org/</url>
     </organization>
     <scm>
-		<connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
-		<developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
-		<url>https://github.com/tdf/odftoolkit/tree/trunk/generator</url>		
+        <connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
+        <developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
+        <url>https://github.com/tdf/odftoolkit/tree/trunk/generator</url>
     </scm>
 
     <profiles>
-    <!-- Profile for deploying to the Sonatype repository, which
-         requires GPG signatures
-         see
-         https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
-         https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven
-         https://issues.sonatype.org/browse/OSSRH-960
-         -->
+        <!-- Profile for deploying to the Sonatype repository, which
+        requires GPG signatures
+        see
+        https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
+        https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven
+        https://issues.sonatype.org/browse/OSSRH-960
+        -->
         <profile>
             <id>release</id>
             <activation>
@@ -134,7 +149,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>                    
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.1</version>
                         <executions>
@@ -143,7 +158,7 @@
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
-                                </goals>            
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -155,16 +170,16 @@
                     <name>ODFDOM Java Toolkit Project</name>
                     <url>dav:https://odftoolkit.org/website/odfdom/${project.version}/codegeneration/schema2template-pom</url>
                 </site>
-            </distributionManagement> -->        
+            </distributionManagement> -->
         </profile>
         <profile>
-          <id>doclint-java8-disable</id>
-          <activation>
-            <jdk>[1.8,)</jdk>
-          </activation>
-          <properties>
-            <javadoc.opts>-Xdoclint:none</javadoc.opts>
-          </properties>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/generator/schema2template-maven-plugin/pom.xml
+++ b/generator/schema2template-maven-plugin/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -9,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -21,14 +20,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.odftoolkit</groupId>
-    <artifactId>schema2template-pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>org.odftoolkit</groupId>
+        <artifactId>schema2template-pom</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
   
     <!-- The Basics -->
+    <name>XML Schema to Template Mapping Tool: Maven2 Plugin</name>
     <artifactId>schema2template-maven-plugin</artifactId>
+    <description>Maven Plugin for XML Schema to Template Mapping Tool</description>
     <version>0.9.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <dependencies>
@@ -41,7 +42,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <scope>provided</scope>
-            <version>3.3.9</version>
+            <version>3.6.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -53,7 +54,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <scope>provided</scope>
-            <version>3.3.9</version>
+            <version>3.6.1</version>
         </dependency>
     </dependencies>
 
@@ -69,26 +70,52 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <!-- defined in the parent pom.xml -->
-					<source>${jdk.version}</source>
-					<target>${jdk.version}</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5</version>
+                <version>3.6.0</version>
                 <configuration>
                     <goalPrefix>schema2template</goalPrefix>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <doctitle>Schema2template maven plugin</doctitle>
+                    <splitindex>true</splitindex>
+                    <windowtitle>Schema2template Maven plugin v${project.version} - https://odftoolkit.org/</windowtitle>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <attach>true</attach>
+                    <doclint>none</doclint>
+                    <additionalOptions>${javadoc.opts}</additionalOptions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <additionalOptions>${javadoc.opts}</additionalOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
-    <!-- More Project Information -->
-    <name>XML Schema to Template Mapping Tool: Maven2 Plugin</name>
-    <description>Maven Plugin for XML Schema to Template Mapping Tool</description>
-    <url>http://incubator.apache.org/odftoolkit/</url>
-    <organization>
-        <name>The Apache Software Foundation</name>
-        <url>http://www.apache.org/</url>
-    </organization>
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/generator/schema2template/pom.xml
+++ b/generator/schema2template/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -9,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -19,155 +18,158 @@
   under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.odftoolkit</groupId>
-    <artifactId>schema2template-pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>org.odftoolkit</groupId>
+        <artifactId>schema2template-pom</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
   
-	<!-- The Basics -->
-	<artifactId>schema2template</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
-	<dependencies>
+    <!-- The Basics -->
+    <artifactId>schema2template</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <dependencies>
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
             <version>2.0</version>
         </dependency>
-		<dependency>
-			<groupId>xerces</groupId>
-			<artifactId>xercesImpl</artifactId>
-		</dependency>        
-		<dependency>
-			<groupId>net.java.dev.msv</groupId>
-			<artifactId>msv-core</artifactId>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.msv</groupId>
+            <artifactId>msv-core</artifactId>
             <version>2013.6.1</version>
-		</dependency>
+        </dependency>
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
         </dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
     </properties>
 	
-	<!-- Build Settings -->
-	<build>
-		<extensions>
-			<extension>
-				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-webdav-jackrabbit</artifactId>
-				<version>1.0</version>
-			</extension>
-		</extensions>
-		<plugins>
-			<plugin>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
-				<configuration>
-					<archive>
-						<index>true</index>
-						<manifest>
-							<mainClass>schema2template.example.odf.OdfHelper</mainClass>
-						</manifest>
-						<manifestEntries>
-							<version>${project.version}</version>
-						</manifestEntries>
-						<manifestSections>
-							<manifestSection>
-								<name>schema2template</name>
-								<manifestEntries>
-									<Application-Name>schema2template</Application-Name>
-									<Application-Version>${project.version}</Application-Version>
-									<Application-Website>http://incubator.apache.org/odftoolkit/</Application-Website>
-									<Built-By>${user.name}</Built-By>
-									<Built-Date>${build.timestamp}</Built-Date>
-								</manifestEntries>
-							</manifestSection>
-						</manifestSections>
-					</archive>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<!-- Explizit version required for fix on systemPropertyVariables -->
-				<version>2.19.1</version>
-				<configuration>
-					<systemPropertyVariables>
-						<odfdom.version>${project.version}</odfdom.version>
-						<odfdom.timestamp>${build.timestamp}</odfdom.timestamp>
-					</systemPropertyVariables>
-					<excludes>
-						<exclude>**/integrationtest/**</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
-				<configuration>
+    <!-- Build Settings -->
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-webdav-jackrabbit</artifactId>
+                <version>1.0</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <archive>
+                        <index>true</index>
+                        <manifest>
+                            <mainClass>schema2template.example.odf.OdfHelper</mainClass>
+                        </manifest>
+                        <manifestEntries>
+                            <version>${project.version}</version>
+                        </manifestEntries>
+                        <manifestSections>
+                            <manifestSection>
+                                <name>schema2template</name>
+                                <manifestEntries>
+                                    <Application-Name>schema2template</Application-Name>
+                                    <Application-Version>${project.version}</Application-Version>
+                                    <Application-Website>${project.url}</Application-Website>
+                                    <Built-By>${user.name}</Built-By>
+                                    <Built-Date>${build.timestamp}</Built-Date>
+                                </manifestEntries>
+                            </manifestSection>
+                        </manifestSections>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- Explizit version required for fix on systemPropertyVariables -->
+                <version>2.19.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <odfdom.version>${project.version}</odfdom.version>
+                        <odfdom.timestamp>${build.timestamp}</odfdom.timestamp>
+                    </systemPropertyVariables>
+                    <excludes>
+                        <exclude>**/integrationtest/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
+                <configuration>
                     <!-- defined in the parent pom.xml -->
-					<source>${jdk.version}</source>
-					<target>${jdk.version}</target>
-					<showDeprecation>true</showDeprecation>
-				</configuration>
-			</plugin>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
                     <excludes>
-                    	<exclude>src/test/resources/examples/odf/*.ref</exclude>
-						<exclude>src/main/resources/examples/odf/odfdom-python/OdfTextDocument.odt</exclude>
-						<exclude>src/main/resources/examples/odf/odf-schemas/*.rng</exclude>
+                        <exclude>src/test/resources/examples/odf/*.ref</exclude>
+                        <exclude>src/main/resources/examples/odf/odfdom-python/OdfTextDocument.odt</exclude>
+                        <exclude>src/main/resources/examples/odf/odf-schemas/*.rng</exclude>
                     </excludes>
                 </configuration>
             </plugin>
-		</plugins>
-	</build>
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>			
-				<version>3.1.0</version>
-				<configuration>
-					<doctitle>Schema2template</doctitle>
-					<links>
-						<link>http://docs.oracle.com/javase/8/docs/api/</link>
-					</links>
-					<splitindex>true</splitindex>
-					<windowtitle>Schema2template v${project.version} - https://odftoolkit.org</windowtitle>
-					<bottom>Copyright &#169; {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved2..</bottom>
-				</configuration>
-			</plugin>
+        </plugins>
+    </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <doctitle>Schema2template</doctitle>
+                    <additionalOptions>${javadoc.opts}</additionalOptions>
+                    <docfilessubdirs>true</docfilessubdirs>
+                    <doclint>none</doclint>                    
+                    <links>
+                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                    </links>
+                    <splitindex>true</splitindex>
+                    <windowtitle>Schema2template v${project.version} - https://odftoolkit.org</windowtitle>
+                    <bottom>Copyright &#169; {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved.</bottom>
+                </configuration>
+            </plugin>
 
-			<!-- Code Coverage Testing generated by Cobertura -->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<instrumentation>
-						<excludes>
-							<exclude>org/odftoolkit/**/*Test.class</exclude>
-						</excludes>
-					</instrumentation>
-				</configuration>
-			</plugin>
-		</plugins>
-	</reporting>
+            <!-- Code Coverage Testing generated by Cobertura -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <instrumentation>
+                        <excludes>
+                            <exclude>org/odftoolkit/**/*Test.class</exclude>
+                        </excludes>
+                    </instrumentation>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
     <profiles>
         <profile>
             <id>doclint-java8-disable</id>
@@ -178,12 +180,12 @@
                 <javadoc.opts>-Xdoclint:none</javadoc.opts>
             </properties>
         </profile>
-	</profiles>
-	<!-- More Project Information -->
-	<name>XML Schema to Template Mapping Tool: Library</name>
-	<description>XML Schema to Template Mapping Tool: Library</description>
-	<organization>	
-        <name>The Document Foundation</name>        
+    </profiles>
+    <!-- More Project Information -->
+    <name>XML Schema to Template Mapping Tool: Library</name>
+    <description>XML Schema to Template Mapping Tool: Library</description>
+    <organization>
+        <name>The Document Foundation</name>
         <url>https://www.documentfoundation.org/</url>
-    </organization>    
+    </organization>
 </project>

--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -9,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -18,246 +17,253 @@
   specific language governing permissions and limitations
   under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-
-	<parent>
-		<groupId>org.odftoolkit</groupId>
-		<artifactId>odftoolkit</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
-	</parent>
-  
-	<artifactId>odfdom-java</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
-
-	<dependencies>
-		<dependency>
-			<groupId>xerces</groupId>
-			<artifactId>xercesImpl</artifactId>
-		</dependency>
+    <modelVersion>4.0.0</modelVersion>
+	
+    <parent>
+        <groupId>org.odftoolkit</groupId>
+        <artifactId>odftoolkit</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
+	
+    <artifactId>odfdom-java</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+	
+    <dependencies>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </dependency>
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
         </dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
         </dependency>
         <dependency>
-			<groupId>org.apache.jena</groupId>
-			<artifactId>jena-core</artifactId>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-core</artifactId>
             <classifier>tests</classifier>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>net.rootdev</groupId>
-			<artifactId>java-rdfa</artifactId>
-		</dependency>        
-		<dependency>
-			<groupId>commons-validator</groupId>
-			<artifactId>commons-validator</artifactId>
-		</dependency>
-	</dependencies>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
-	</properties>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.rootdev</groupId>
+            <artifactId>java-rdfa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+        </dependency>
+    </dependencies>
+    <properties>
+        <skipTests>false</skipTests>
+        <maven.javadoc.skip>false</maven.javadoc.skip>
+        <maven.javadoc.failOnError>false</maven.javadoc.failOnError>        
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
+    </properties>
 
-	<!-- Build Settings -->
-	<build>
-		<extensions>
-			<extension>
-				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-webdav-jackrabbit</artifactId>
-				<version>2.12</version>
-			</extension>
-		</extensions>
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
-				<configuration>
+    <!-- Build Settings -->
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-webdav-jackrabbit</artifactId>
+                <version>3.3.2</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
                     <!-- defined in the parent pom.xml -->
-					<source>${jdk.version}</source>
-					<target>${jdk.version}</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
-				<configuration>
-					<archive>
-						<index>true</index>
-						<manifest>
-							<mainClass>org.odftoolkit.odfdom.JarManifest</mainClass>
-						</manifest>
-						<manifestEntries>
-							<version>${project.version}</version>
-						</manifestEntries>
-						<manifestSections>
-							<manifestSection>
-								<name>ODFDOM</name>
-								<manifestEntries>
-									<ODFDOM-Name>odfdom</ODFDOM-Name>
-									<ODFDOM-Version>${project.version}</ODFDOM-Version>
-									<ODFDOM-Website>https://odftoolkit.org/odfdom/index.html</ODFDOM-Website>
-									<ODFDOM-Built-Date>${build.timestamp}</ODFDOM-Built-Date>
-									<ODFDOM-Supported-Odf-Version>1.2</ODFDOM-Supported-Odf-Version>
-								</manifestEntries>
-							</manifestSection>
-						</manifestSections>
-					</archive>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
-				<configuration>
-					<!-- Workaround for http://jira.codehaus.org/browse/MGPG-9 -->
-					<mavenExecutorId>forked-path</mavenExecutorId>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>				
-				<version>2.20</version>
-				<configuration>
-					<forkMode>pertest</forkMode>
-					<systemPropertyVariables>
-						<odfdom.version>${project.version}</odfdom.version>
-						<odfdom.timestamp>${build.timestamp}</odfdom.timestamp>
-						<org.odftoolkit.odfdom.validation>org.odftoolkit.odfdom.pkg.DefaultErrorHandler</org.odftoolkit.odfdom.validation>
-					</systemPropertyVariables>
-				</configuration>
-			</plugin><!--
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.0</version>
-				<configuration>
-					<doctitle>ODFDOM</doctitle>
-					<links>
-						<link>http://docs.oracle.com/javase/8/docs/api/</link>
-						<link>http://xerces.apache.org/xerces-j/apiDocs/</link>						
-					</links>
-					<splitindex>true</splitindex>
-					<windowtitle>ODFDOM API v${project.version} - https://odftoolkit.org</windowtitle>
-					<bottom>Something.. odfdom</bottom>
-					<taglets>
-						<taglet>
-							<tagletClass>org.odftoolkit.odfdom.taglet.OdfElementTaglet</tagletClass>
-						</taglet>
-						<taglet>
-							<tagletClass>org.odftoolkit.odfdom.taglet.OdfAttributeTaglet</tagletClass>
-						</taglet>
-						<taglet>
-							<tagletClass>org.odftoolkit.odfdom.taglet.OdfDatatypeTaglet</tagletClass>
-						</taglet>
-					</taglets>
-					<tagletArtifact>
-						<groupId>${project.groupId}</groupId>
-						<artifactId>taglets</artifactId>
-						<version>${project.version}</version>
-					</tagletArtifact>
-					<additionalparam>${javadoc.opts}</additionalparam>
-				</configuration>
-				<executions> 
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>                        
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <archive>
+                        <index>true</index>
+                        <manifest>
+                            <mainClass>org.odftoolkit.odfdom.JarManifest</mainClass>
+                        </manifest>
+                        <manifestEntries>
+                            <version>${project.version}</version>
+                        </manifestEntries>
+                        <manifestSections>
+                            <manifestSection>
+                                <name>ODFDOM</name>
+                                <manifestEntries>
+                                    <ODFDOM-Name>odfdom</ODFDOM-Name>
+                                    <ODFDOM-Version>${project.version}</ODFDOM-Version>
+                                    <ODFDOM-Website>${project.url}</ODFDOM-Website>
+                                    <ODFDOM-Built-Date>${build.timestamp}</ODFDOM-Built-Date>
+                                    <ODFDOM-Supported-Odf-Version>1.2</ODFDOM-Supported-Odf-Version>
+                                </manifestEntries>
+                            </manifestSection>
+                        </manifestSections>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <!-- Workaround for https://jira.codehaus.org/browse/MGPG-9 -->
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <forkMode>pertest</forkMode>
+                    <systemPropertyVariables>
+                        <odfdom.version>${project.version}</odfdom.version>
+                        <odfdom.timestamp>${build.timestamp}</odfdom.timestamp>
+                        <org.odftoolkit.odfdom.validation>org.odftoolkit.odfdom.pkg.DefaultErrorHandler</org.odftoolkit.odfdom.validation>
+                        <skipTests>${skipTests}</skipTests>                        
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <doctitle>ODFDOM v${project.version}</doctitle>
+                    <bottom>Copyright &#169; {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved.</bottom>
+                    <isOffline>false</isOffline>
+                    <links>						
+
+                        <link>https://xerces.apache.org/xerces-j/apiDocs/</link>						
+                    </links>
+                    <splitindex>true</splitindex>
+                    <windowtitle>ODFDOM API v${project.version} - https://odftoolkit.org/</windowtitle>
+
+                    <taglets>
+                        <taglet>
+                            <tagletClass>org.odftoolkit.odfdom.taglet.OdfElementTaglet</tagletClass>
+                        </taglet>
+                        <taglet>
+                            <tagletClass>org.odftoolkit.odfdom.taglet.OdfAttributeTaglet</tagletClass>
+                        </taglet>
+                        <taglet>
+                            <tagletClass>org.odftoolkit.odfdom.taglet.OdfDatatypeTaglet</tagletClass>
+                        </taglet>
+                    </taglets>
+                    <tagletArtifact>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>taglets</artifactId>
+                        <version>${project.version}</version>
+                    </tagletArtifact>
+                    <docfilessubdirs>true</docfilessubdirs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
                         <configuration>
+                            <doclint>none</doclint>
                             <additionalOptions>${javadoc.opts}</additionalOptions>
                         </configuration>
-					</execution>          
-				</executions>
-			</plugin>-->
-			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>3.0.1</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<archive>
-						<index>true</index>
-						<manifest>
-							<mainClass>org.odftoolkit.odfdom.JarManifest</mainClass>
-						</manifest>
-						<manifestEntries>
-							<version>${project.version}</version>
-						</manifestEntries>
-						<manifestSections>
-							<manifestSection>
-								<name>ODFDOM</name>
-								<manifestEntries>
-									<ODFDOM-Name>odfdom</ODFDOM-Name>
-									<ODFDOM-Version>${project.version}</ODFDOM-Version>
-									<ODFDOM-Website>https://odftoolkit.org/odfdom/index.html</ODFDOM-Website>
-									<ODFDOM-Built-Date>${build.timestamp}</ODFDOM-Built-Date>
-									<ODFDOM-Supported-Odf-Version>1.2</ODFDOM-Supported-Odf-Version>
-								</manifestEntries>
-							</manifestSection>
-						</manifestSections>
-					</archive>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
-				<executions>
-					<execution>
-						<id>single</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.rat</groupId>
-				<artifactId>apache-rat-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>src/main/resources/**</exclude>
-						<exclude>src/test/resources/**</exclude>
-						<exclude>src/main/javadoc/doc-files/OpenDocument-v1.2-part1.html</exclude>
-						<exclude>src/main/javadoc/doc-files/OpenDocument-v1.2-part3.html</exclude>
-						<exclude>src/codegen/resources/dom/*.rng</exclude>
-						<exclude>src/codegen/resources/pkg/*.rng</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <index>true</index>
+                        <manifest>
+                            <mainClass>org.odftoolkit.odfdom.JarManifest</mainClass>
+                        </manifest>
+                        <manifestEntries>
+                            <version>${project.version}</version>
+                        </manifestEntries>
+                        <manifestSections>
+                            <manifestSection>
+                                <name>ODFDOM</name>
+                                <manifestEntries>
+                                    <ODFDOM-Name>odfdom</ODFDOM-Name>
+                                    <ODFDOM-Version>${project.version}</ODFDOM-Version>
+                                    <ODFDOM-Website>${project.url}</ODFDOM-Website>
+                                    <ODFDOM-Built-Date>${build.timestamp}</ODFDOM-Built-Date>
+                                    <ODFDOM-Supported-Odf-Version>1.2</ODFDOM-Supported-Odf-Version>
+                                </manifestEntries>
+                            </manifestSection>
+                        </manifestSections>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>single</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>src/main/resources/**</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                        <exclude>src/main/javadoc/resources/OpenDocument-v1.2-part1.html</exclude>
+                        <exclude>src/main/javadoc/resources/OpenDocument-v1.2-part3.html</exclude>
+                        <exclude>src/codegen/resources/dom/*.rng</exclude>
+                        <exclude>src/codegen/resources/pkg/*.rng</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.2</version>
                 <configuration>
-                    <excludes>                                        
+                    <excludes>
                         <exclude>**/PerformanceIT.java</exclude>
                     </excludes>
-					<systemPropertyVariables>
-						<odfdom.version>${project.version}</odfdom.version>
-						<org.odftoolkit.odfdom.validation>org.odftoolkit.odfdom.pkg.DefaultErrorHandler</org.odftoolkit.odfdom.validation>
-					</systemPropertyVariables>
-                </configuration>                
+                    <systemPropertyVariables>
+                        <odfdom.version>${project.version}</odfdom.version>
+                        <org.odftoolkit.odfdom.validation>org.odftoolkit.odfdom.pkg.DefaultErrorHandler</org.odftoolkit.odfdom.validation>
+                    </systemPropertyVariables>
+                </configuration>
                 <executions>
                     <execution>
                         <id>failsafe-it</id>
@@ -267,262 +273,246 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>     
-		</plugins>
-	</build>
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.0</version>
-				<configuration>
-					<doctitle>ODFDOM</doctitle>
-					<minmemory>512m</minmemory>
-					<maxmemory>1024m</maxmemory>
-					<links>
-						<link>http://docs.oracle.com/javase/8/docs/api/</link>
-						<link>http://xerces.apache.org/xerces-j/apiDocs/</link>
-					</links>
-					<splitindex>true</splitindex>
-					<windowtitle>ODFDOM API v${project.version} - - https://odftoolkit.org</windowtitle>
-					<additionalOptions>${javadoc.opts}</additionalOptions>
-					<bottom>Copyright &#169; {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved3..</bottom>					
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.0</version>
-				<configuration>
-					<doctitle>ODFDOM</doctitle>
-					<minmemory>512m</minmemory>
-					<maxmemory>1024m</maxmemory>					
-					<links>
-						<link>http://docs.oracle.com/javase/8/docs/api/</link>
-						<link>http://xerces.apache.org/xerces-j/apiDocs/</link>						
-					</links>
-					<splitindex>true</splitindex>
-					<windowtitle>ODFDOM API v${project.version} - https://odftoolkit.org</windowtitle>
-					<additionalparam>${javadoc.opts}</additionalparam>
-					<bottom>Something.. odfdom</bottom>
-					<taglets>
-						<taglet>
-							<tagletClass>org.odftoolkit.odfdom.taglet.OdfElementTaglet</tagletClass>
-						</taglet>
-						<taglet>
-							<tagletClass>org.odftoolkit.odfdom.taglet.OdfAttributeTaglet</tagletClass>
-						</taglet>
-						<taglet>
-							<tagletClass>org.odftoolkit.odfdom.taglet.OdfDatatypeTaglet</tagletClass>
-						</taglet>
-					</taglets>
-					<tagletArtifact>
-						<groupId>${project.groupId}</groupId>
-						<artifactId>taglets</artifactId>
-						<version>${project.version}</version>
-					</tagletArtifact>
-					<additionalparam>${javadoc.opts}</additionalparam>
-				</configuration>
-			</plugin>			
-			<!-- Code Coverage Testing generated by Cobertura -->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<instrumentation>
-						<excludes>
-							<exclude>org/odftoolkit/**/*Test.class</exclude>
-						</excludes>
-					</instrumentation>
-				</configuration>
-			</plugin>
-			<!-- Reporting integration test results -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.20</version>
-				<reportSets>
-					<reportSet>
-						<id>integration-tests</id>
-						<reports>
-							<report>report-only</report>
-						</reports>
-						<configuration>
-							<outputName>failsafe-report</outputName>
-						</configuration>
-					</reportSet>
-				</reportSets>
-			</plugin>
-		</plugins>
-	</reporting>
+            </plugin>
+        </plugins>
+    </build>
+    <reporting>
+        <plugins>          
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <doctitle>ODFDOM v${project.version}</doctitle>
+                    <minmemory>512m</minmemory>
+                    <maxmemory>1024m</maxmemory>
+                    <links>
+                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                        <link>https://xerces.apache.org/xerces-j/apiDocs/</link>
+                    </links>
+                    <isOffline>false</isOffline>                    
+                    <splitindex>true</splitindex>
+                    <windowtitle>ODFDOM API v${project.version} - https://odftoolkit.org/</windowtitle>
+                    <bottom>Copyright &#169; {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved.</bottom>					
+                    <taglets>
+                        <taglet>
+                            <tagletClass>org.odftoolkit.odfdom.taglet.OdfElementTaglet</tagletClass>
+                        </taglet>
+                        <taglet>
+                            <tagletClass>org.odftoolkit.odfdom.taglet.OdfAttributeTaglet</tagletClass>
+                        </taglet>
+                        <taglet>
+                            <tagletClass>org.odftoolkit.odfdom.taglet.OdfDatatypeTaglet</tagletClass>
+                        </taglet>
+                    </taglets>
+                    <tagletArtifact>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>taglets</artifactId>
+                        <version>${project.version}</version>
+                    </tagletArtifact>
+                    <doclint>none</doclint>
+                    <additionalOptions>${javadoc.opts}</additionalOptions>
+                    <docfilessubdirs>true</docfilessubdirs>
+                </configuration>
+            </plugin>
+            <!-- Code Coverage Testing generated by Cobertura -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <instrumentation>
+                        <excludes>
+                            <exclude>org/odftoolkit/**/*Test.class</exclude>
+                        </excludes>
+                    </instrumentation>
+                </configuration>
+            </plugin>
+            <!-- Reporting integration test results -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <reportSets>
+                    <reportSet>
+                        <id>integration-tests</id>
+                        <reports>
+                            <report>report-only</report>
+                        </reports>
+                        <configuration>
+                            <outputName>failsafe-report</outputName>
+                        </configuration>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 
-	<!-- More Project Information -->
-	<name>ODFDOM</name>
-	<description>
-		ODFDOM is an OpenDocument Format (ODF) framework. Its purpose
-		is to provide an easy common way to create, access and
-		manipulate ODF files, without requiring detailed knowledge of
-		the ODF specification. It is designed to provide the ODF
-		developer community with an easy lightwork programming API
-		portable to any object-oriented language.
+    <!-- More Project Information -->
+    <name>ODFDOM</name>
+    <description>
+        ODFDOM is an OpenDocument Format (ODF) framework. Its purpose
+        is to provide an easy common way to create, access and
+        manipulate ODF files, without requiring detailed knowledge of
+        the ODF specification. It is designed to provide the ODF
+        developer community with an easy lightwork programming API
+        portable to any object-oriented language.
 
-		The current reference implementation is written in Java.
-	</description>
-	<url>http://incubator.apache.org/odftoolkit/odfdom/index.html</url>
-	<inceptionYear>2008</inceptionYear>
-    
-	<licenses>
-		<license>
-			<name>Apache 2</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-		</license>
-	</licenses>
+        The current reference implementation is written in Java.
+    </description>	
+    <url>https://odftoolkit.org/odfdom/</url>
+    <inceptionYear>2008</inceptionYear>
+	
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
     <organization>
         <name>The Document Foundation</name>
         <url>https://www.documentfoundation.org/</url>
     </organization>
     <scm>
-		<connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
-		<developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
-		<url>https://github.com/tdf/odftoolkit/tree/trunk/odfdom</url>		
-	</scm>
-	<profiles>
-		<profile>
-			<id>codegen</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>wagon-maven-plugin</artifactId>
-						<version>1.0</version>
-						<executions>
-							<execution>
-								<id>download-odf-schema-v1.2</id>
-								<phase>validate</phase>
-								<goals>
-									<goal>download-single</goal>
-								</goals>
-								<configuration>
-									<url>dav:http://docs.oasis-open.org/office/v1.2</url>
-									<fromFile>os/OpenDocument-v1.2-os-schema.rng</fromFile>
-									<toDir>${project.build.directory}/odf-schemas</toDir>
-								</configuration>
-							</execution>
-							<execution>
-								<id>download-odf-manifest-schema-v1.2</id>
-								<phase>validate</phase>
-								<goals>
-									<goal>download-single</goal>
-								</goals>
-								<configuration>
-									<url>dav:http://docs.oasis-open.org/office/v1.2</url>
-									<fromFile>os/OpenDocument-v1.2-os-manifest-schema.rng</fromFile>
-									<toDir>${project.build.directory}/odf-schemas</toDir>
-								</configuration>
-							</execution>
-							<execution>
-								<id>download-odf-dsig-schema-v1.2</id>
-								<phase>validate</phase>
-								<goals>
-									<goal>download-single</goal>
-								</goals>
-								<configuration>
-									<url>dav:http://docs.oasis-open.org/office/v1.2</url>
-									<fromFile>os/OpenDocument-v1.2-os-dsig-schema.rng</fromFile>
-									<toDir>${project.build.directory}/odf-schemas</toDir>
-								</configuration>
-							</execution>
-							<execution>
-								<id>download-odf-schema-v1.1</id>
-								<phase>validate</phase>
-								<goals>
-									<goal>download-single</goal>
-								</goals>
-								<configuration>
-									<url>dav:http://docs.oasis-open.org/office/v1.1</url>
-									<fromFile>OS/OpenDocument-schema-v1.1.rng</fromFile>
-									<toDir>${project.build.directory}/odf-schemas</toDir>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>${project.groupId}</groupId>
-						<artifactId>schema2template-maven-plugin</artifactId>
-						<version>${project.version}</version>
-						<executions>
-							<execution>
-								<id>dom</id>
-								<phase>generate-sources</phase>
-								<goals>
-									<goal>codegen</goal>
-								</goals>
-								<!-- DOM LAYER CONFIGURATION -->
-								<configuration>
-									<targetRoot>${basedir}/src/main/java/</targetRoot>
-									<domResourceRoot>${basedir}/src/codegen/resources/dom/template</domResourceRoot>
-									<pkgResourceRoot>${basedir}/src/codegen/resources/pkg/template</pkgResourceRoot>
-									<odf12SchemaFile>${project.build.directory}/odf-schemas/OpenDocument-v1.2-os-schema.rng</odf12SchemaFile>
-									<odf11SchemaFile>${project.build.directory}/odf-schemas/OpenDocument-schema-v1.1.rng</odf11SchemaFile>
-									<signatureSchemaFile>${project.build.directory}/odf-schemas/OpenDocument-v1.2-os-dsig-schema.rng</signatureSchemaFile>
-									<manifestSchemaFile>${project.build.directory}/odf-schemas/OpenDocument-v1.2-os-manifest-schema.rng</manifestSchemaFile>
-									<configFile>${basedir}/src/codegen/resources/config.xml</configFile>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<!--
-		<profile>
-			<id>codegen-pkg</id>
-			<activation>
-			  <activeByDefault>true</activeByDefault>
-			</activation>
-			<build>
-				<defaultGoal>install</defaultGoal>
-				<plugins>
-					<plugin>
-						<groupId>org.odftoolkit</groupId>
-						<artifactId>maven-codegen-plugin</artifactId>
-						<version>0.8</version>
-						<executions>
-							<execution>
-								<id>pkg</id>
-								<phase>generate-sources</phase>
-								<goals>
-									<goal>codegen</goal>
-								</goals>
-								<configuration>
-									<sourceRoot>${basedir}/src/main/java</sourceRoot>
-									<schemaFile>${basedir}/src/codegen/resources/pkg/OpenDocument-manifest-schema-v1.2-draft7.rng</schemaFile>
-									<configFile>${basedir}/src/codegen/resources/pkg/config.xml</configFile>
-									<templateFile>${basedir}/src/codegen/resources/pkg/javacodetemplate.xml</templateFile>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		-->
-		<profile>
-			<id>integration-test</id>
-			<activation>
-				<property>
-					<name>integration-test</name>
-				</property>
-			</activation>
-			<build>
-				<defaultGoal>verify</defaultGoal>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-failsafe-plugin</artifactId>
-						<version>2.20</version>
+        <connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
+        <developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
+        <url>https://github.com/tdf/odftoolkit/tree/trunk/odfdom</url>
+    </scm>
+    <profiles>
+        <profile>
+            <id>codegen</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>wagon-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>download-odf-schema-v1.2</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>download-single</goal>
+                                </goals>
+                                <configuration>
+                                    <url>dav:https://docs.oasis-open.org/office/v1.2</url>
+                                    <fromFile>os/OpenDocument-v1.2-os-schema.rng</fromFile>
+                                    <toDir>${project.build.directory}/odf-schemas</toDir>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>download-odf-manifest-schema-v1.2</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>download-single</goal>
+                                </goals>
+                                <configuration>
+                                    <url>dav:https://docs.oasis-open.org/office/v1.2</url>
+                                    <fromFile>os/OpenDocument-v1.2-os-manifest-schema.rng</fromFile>
+                                    <toDir>${project.build.directory}/odf-schemas</toDir>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>download-odf-dsig-schema-v1.2</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>download-single</goal>
+                                </goals>
+                                <configuration>
+                                    <url>dav:https://docs.oasis-open.org/office/v1.2</url>
+                                    <fromFile>os/OpenDocument-v1.2-os-dsig-schema.rng</fromFile>
+                                    <toDir>${project.build.directory}/odf-schemas</toDir>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>download-odf-schema-v1.1</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>download-single</goal>
+                                </goals>
+                                <configuration>
+                                    <url>dav:https://docs.oasis-open.org/office/v1.1</url>
+                                    <fromFile>OS/OpenDocument-schema-v1.1.rng</fromFile>
+                                    <toDir>${project.build.directory}/odf-schemas</toDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>schema2template-maven-plugin</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <id>dom</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>codegen</goal>
+                                </goals>
+                                <!-- DOM LAYER CONFIGURATION -->
+                                <configuration>
+                                    <targetRoot>${basedir}/src/main/java/</targetRoot>
+                                    <domResourceRoot>${basedir}/src/codegen/resources/dom/template</domResourceRoot>
+                                    <pkgResourceRoot>${basedir}/src/codegen/resources/pkg/template</pkgResourceRoot>
+                                    <odf12SchemaFile>${project.build.directory}/odf-schemas/OpenDocument-v1.2-os-schema.rng</odf12SchemaFile>
+                                    <odf11SchemaFile>${project.build.directory}/odf-schemas/OpenDocument-schema-v1.1.rng</odf11SchemaFile>
+                                    <signatureSchemaFile>${project.build.directory}/odf-schemas/OpenDocument-v1.2-os-dsig-schema.rng</signatureSchemaFile>
+                                    <manifestSchemaFile>${project.build.directory}/odf-schemas/OpenDocument-v1.2-os-manifest-schema.rng</manifestSchemaFile>
+                                    <configFile>${basedir}/src/codegen/resources/config.xml</configFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
+        <profile>
+            <id>codegen-pkg</id>
+            <activation>
+              <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <defaultGoal>install</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.odftoolkit</groupId>
+                        <artifactId>maven-codegen-plugin</artifactId>
+                        <version>0.8</version>
+                        <executions>
+                            <execution>
+                                <id>pkg</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>codegen</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceRoot>${basedir}/src/main/java</sourceRoot>
+                                    <schemaFile>${basedir}/src/codegen/resources/pkg/OpenDocument-manifest-schema-v1.2-draft7.rng</schemaFile>
+                                    <configFile>${basedir}/src/codegen/resources/pkg/config.xml</configFile>
+                                    <templateFile>${basedir}/src/codegen/resources/pkg/javacodetemplate.xml</templateFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        -->
+        <profile>
+            <id>integration-test</id>
+            <activation>
+                <property>
+                    <name>integration-test</name>
+                </property>
+            </activation>
+            <build>
+                <defaultGoal>verify</defaultGoal>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.22.2</version>
                         <configuration>
                             <systemPropertyVariables>
                                 <testresourcefolder>performance</testresourcefolder>
@@ -531,73 +521,73 @@
                             </systemPropertyVariables>
                         </configuration>
                         <executions>
-							<execution>
-								<id>failsafe-it</id>
-								<phase>integration-test</phase>
-								<goals>
-									<goal>integration-test</goal>
-									<goal>verify</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>						
-						<version>2.20</version>
-						<configuration>
-							<systemPropertyVariables>
-								<odfdom.version>${project.version}</odfdom.version>
-								<odfdom.timestamp>${build.timestamp}</odfdom.timestamp>
-								<org.odftoolkit.odfdom.validation>true</org.odftoolkit.odfdom.validation>
-							</systemPropertyVariables>
-							<skip>true</skip>						
+                            <execution>
+                                <id>failsafe-it</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.2</version>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <odfdom.version>${project.version}</odfdom.version>
+                                <odfdom.timestamp>${build.timestamp}</odfdom.timestamp>
+                                <org.odftoolkit.odfdom.validation>true</org.odftoolkit.odfdom.validation>
+                            </systemPropertyVariables>
+                            <skipTests>${skipTests}</skipTests>
                         </configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<!-- Profile for deploying to the Sonatype repository, which
-		requires GPG signatures 
-		see
-		https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
-		https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven
-		https://issues.sonatype.org/browse/OSSRH-960
-		-->
-		<profile>
-			<id>release-sign-artifacts</id>
-			<activation>
-				<property>
-					<name>performRelease</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-			<!-- <distributionManagement>
-				<site>
-					<id>odfdom</id>
-					<name>ODFDOM Java Toolkit Project</name>
-					<url>dav:https://odftoolkit.org/website/odfdom/${project.version}/odfdom</url>
-				</site>
-			</distributionManagement> -->
-		</profile>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Profile for deploying to the Sonatype repository, which
+        requires GPG signatures 
+        see
+        https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
+        https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven
+        https://issues.sonatype.org/browse/OSSRH-960
+        -->
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <!-- <distributionManagement>
+                <site>
+                    <id>odfdom</id>
+                    <name>ODFDOM Java Toolkit Project</name>
+                    <url>dav:https://odftoolkit.org/website/odfdom/${project.version}/odfdom</url>
+                </site>
+            </distributionManagement> -->
+        </profile>
         <profile>
             <id>doclint-java8-disable</id>
             <activation>
@@ -607,5 +597,5 @@
                 <javadoc.opts>-Xdoclint:none</javadoc.opts>
             </properties>
         </profile>
-	</profiles>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -9,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -18,7 +17,6 @@
   specific language governing permissions and limitations
   under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -30,20 +28,18 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>18</version>
+        <version>19</version>
     </parent>
 
     <properties>
         <jdk.version>1.8</jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>        
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity</artifactId>
-                <version>1.7</version>
-            </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
@@ -52,7 +48,7 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -62,13 +58,13 @@
             <dependency>
                 <groupId>org.apache.jena</groupId>
                 <artifactId>jena-core</artifactId>
-                <version>3.2.0</version>
+                <version>3.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.jena</groupId>
                 <artifactId>jena-core</artifactId>
                 <classifier>tests</classifier>
-                <version>3.2.0</version>
+                <version>3.9.0</version>
             </dependency>
             <dependency>
                 <groupId>net.rootdev</groupId>
@@ -121,7 +117,7 @@
         runtime manipulation of heavy-weight editors via an automation
         interface, the ODF Toolkit is lightweight and ideal for server use.
     </description>
-    <url>http://odftoolkit.org</url>
+    <url>https://odftoolkit.org</url>
     <organization>
         <name>The Document Foundation</name>
         <url>https://www.documentfoundation.org/</url>
@@ -133,20 +129,20 @@
     </scm>
 
     <issueManagement>
-        <system>jira</system>
-        <url>https://issues.apache.org/jira/browse/ODFTOOLKIT</url>
+        <system>github</system>
+        <url>https://github.com/tdf/odftoolkit/issues</url>
     </issueManagement>
 
     <ciManagement>
-        <system>jenkins</system>
-        <url>https://builds.apache.org</url>
+        <system>travis</system>
+        <url>https://travis-ci.community</url>
     </ciManagement>
 
     <distributionManagement>
         <!-- not used for deployment but only for site:stage goal -->
         <site>
-            <id>incubator.apache.org/odftoolkit/</id>
-            <url>http://incubator.apache.org/odftoolkit/reports/${project.version}/</url>
+            <id>odftoolkit.org</id>
+            <url>https://odftoolkit.org/reports/${project.version}/</url>
         </site>
     </distributionManagement>
 
@@ -167,7 +163,7 @@
             <id>mst</id>
             <name>Michael</name>
             <organization>CIB Software</organization>
-            <organizationUrl>http://www.cib.de/</organizationUrl>
+            <organizationUrl>https://www.cib.de/</organizationUrl>
             <roles>
                 <role>developer</role>
             </roles>
@@ -177,25 +173,21 @@
 
     <mailingLists>
         <mailingList>
-            <name>User List</name>
-            <post>odf-users@incubator.apache.org</post>
-            <subscribe>odf-users-subscribe@incubator.apache.org</subscribe>
-            <unsubscribe>odf-users-unsubscribe@incubator.apache.org</unsubscribe>
-            <archive>http://mail-archives.apache.org/mod_mbox/incubator-odf-users/</archive>
-        </mailingList>
-        <mailingList>
             <name>Developer List</name>
-            <post>odf-dev@incubator.apache.org</post>
-            <subscribe>odf-dev-subscribe@incubator.apache.org</subscribe>
-            <unsubscribe>odf-dev-unsubscribe@incubator.apache.org</unsubscribe>
-            <archive>http://mail-archives.apache.org/mod_mbox/incubator-odf-dev/</archive>
+            <post>dev@odftoolkit.org</post>
+            <!--2DO
+          <subscribe></subscribe>
+          <unsubscribe>odf-users-unsubscribe@odftoolkit.org</unsubscribe>
+          <archive>https://mail-archives.odftoolkit.org/mod_mbox/dev/</archive>
+            -->
         </mailingList>
+        <!-- Watch GitHub ?
         <mailingList>
             <name>Commits</name>
-            <subscribe>odf-commits-subscribe@incubator.apache.org</subscribe>
-            <unsubscribe>odf-commmits-unsubscribe@incubator.apache.org</unsubscribe>
-            <archive>http://mail-archives.apache.org/mod_mbox/incubator-odf-commits/</archive>
-        </mailingList>
+            <subscribe>commits-subscribe@odftoolkit.org</subscribe>
+            <unsubscribe>commmits-unsubscribe@odftoolkit</unsubscribe>
+            <archive>https://mail-archives.odftoolkit.org/mod_mbox/commits/</archive>
+        </mailingList>-->
     </mailingLists>
 
 
@@ -226,6 +218,7 @@
                             <excludes>
                                 <exclude>CHANGES.txt</exclude>
                                 <exclude>.gitignore</exclude>
+                                <exclude>README.md</exclude>
                                 <exclude>DEPENDENCIES</exclude>
                             </excludes>
                         </configuration>
@@ -367,35 +360,10 @@
                                                 <include name="*-doc.*"/>
                                             </fileset>
                                         </copy>
-                                        <echo file="${basedir}/target/vote.txt">
-                                            From: ${username}@apache.org
-                                            To: odf-dev@incubator.apache.org
-                                            Subject: [VOTE] Release Apache ODF Toolkit ${project.version}
-
-                                            A candidate for the ODF Toolkit ${project.version} release is available at:
-
-                                            http://repository.apache.org/snapshots/odftoolkit/
-
-                                            The release candidate is a zip archive of the sources in:
-
-                                            https://svn.apache.org/repos/asf/incubator/odf/tags/${project.version}/
-
-                                            The SHA-512 checksum of the archive is ${checksum}.
-
-                                            Please vote on releasing this package as Apache ODF Toolkit
-                                            ${project.version}.
-                                            The vote is open for the next 72 hours and passes if a majority
-                                            of at least three +1 ODF Toolkit PMC votes are cast.
-
-                                            [ ] +1 Release this package as Apache ODF Toolkit ${project.version}
-                                            [ ] -1 Do not release this package because...${line.separator}
-                                        </echo>
                                         <echo/>
                                         <echo>
                                             The release candidate has been prepared in:
                                             ${basedir}/target/${project.version}
-                                            A release vote template has been generated for you:
-                                            file://${basedir}/target/vote.txt
                                         </echo>
                                         <echo/>
                                     </tasks>
@@ -411,7 +379,7 @@
                         </dependencies>
                     </plugin>
                     <plugin>
-                        <!-- see http://maven.apache.org/plugins/maven-gpg-plugin/usage.html -->
+                        <!-- see https://maven.apache.org/plugins/maven-gpg-plugin/usage.html -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -172,24 +172,19 @@
     </developers>
 
     <mailingLists>
-        <mailingList>
-            <name>Developer List</name>
-            <post>dev@odftoolkit.org</post>
-            <!--2DO
-          <subscribe></subscribe>
-          <unsubscribe>odf-users-unsubscribe@odftoolkit.org</unsubscribe>
-          <archive>https://mail-archives.odftoolkit.org/mod_mbox/dev/</archive>
-            -->
-        </mailingList>
-        <!-- Watch GitHub ?
-        <mailingList>
-            <name>Commits</name>
-            <subscribe>commits-subscribe@odftoolkit.org</subscribe>
-            <unsubscribe>commmits-unsubscribe@odftoolkit</unsubscribe>
-            <archive>https://mail-archives.odftoolkit.org/mod_mbox/commits/</archive>
-        </mailingList>-->
+      <mailingList>
+        <!--
+        Help: <dev+help@odftoolkit.org>
+        Digest subscription: <dev+subscribe-digest@odftoolkit.org>
+        No-mail subscription: <dev+subscribe-nomail@odftoolkit.org>
+        -->
+        <post>dev@odftoolkit.org</post>
+        <subscribe>dev+subscribe@odftoolkit.org</subscribe>
+        <unsubscribe>dev+unsubscribe@odftoolkit.org</unsubscribe>
+        <archive>https://listarchives.odftoolkit.org/dev/</archive>
+        <name>dev.odftoolkit.org</name><!-- List-Id -->
+      </mailingList>
     </mailingLists>
-
 
     <profiles>
         <profile>

--- a/simple/pom.xml
+++ b/simple/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -9,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -18,13 +17,12 @@
   specific language governing permissions and limitations
   under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-      <groupId>org.odftoolkit</groupId>
-      <artifactId>odftoolkit</artifactId>
-      <version>0.9.0-SNAPSHOT</version>
+        <groupId>org.odftoolkit</groupId>
+        <artifactId>odftoolkit</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>simple-odf</artifactId>
@@ -33,9 +31,9 @@
 
     <dependencies>
         <dependency>
-           <groupId>${project.groupId}</groupId>
-           <artifactId>odfdom-java</artifactId>
-           <version>0.9.0-SNAPSHOT</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>odfdom-java</artifactId>
+            <version>0.9.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>
@@ -61,7 +59,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <!-- defined in the parent pom.xml -->
                     <source>${jdk.version}</source>
@@ -74,7 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.1.1</version>
                 <configuration>
                     <archive>
                         <index>true</index>
@@ -90,7 +88,7 @@
                                 <manifestEntries>
                                     <SIMPLE-ODF-Name>Simple Java API for ODF(Simple ODF)</SIMPLE-ODF-Name>
                                     <SIMPLE-ODF-Version>${project.version}</SIMPLE-ODF-Version>
-                                    <SIMPLE-ODF-Website>http://incubator.apache.org/odftoolkit/simple/index.html</SIMPLE-ODF-Website>
+                                    <SIMPLE-ODF-Website>${project.url}</SIMPLE-ODF-Website>
                                     <SIMPLE-ODF-Built-By>${user.name}</SIMPLE-ODF-Built-By>
                                     <SIMPLE-ODF-Built-Date>${build.timestamp}</SIMPLE-ODF-Built-Date>
                                     <SIMPLE-ODF-Supported-ODF-Version>1.2</SIMPLE-ODF-Supported-ODF-Version>
@@ -104,7 +102,7 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.3</version>
                 <configuration>
-                    <!-- Workaround for http://jira.codehaus.org/browse/MGPG-9 -->
+                    <!-- Workaround for https://jira.codehaus.org/browse/MGPG-9 -->
                     <mavenExecutorId>forked-path</mavenExecutorId>
                 </configuration>
             </plugin>
@@ -115,12 +113,12 @@
                 <configuration>
                     <doctitle>Simple Java API for ODF (Simple ODF)</doctitle>
                     <links>
-						<link>http://docs.oracle.com/javase/8/docs/api/</link>
-                        <link>http://xerces.apache.org/xerces-j/apiDocs/</link>                        
+                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                        <link>https://xerces.apache.org/xerces-j/apiDocs/</link>                        
                     </links>
                     <splitindex>true</splitindex>
-                    <windowtitle>Simple ODF v${project.version} - http://odftoolkit.org</windowtitle>
-					<bottom>Copyright &#169; {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved4..</bottom>					
+                    <windowtitle>Simple ODF v${project.version} - https://odftoolkit.org</windowtitle>
+                    <bottom>Copyright &#169; {inceptionYear}&#x2013;{currentYear} {organizationName}. All rights reserved.</bottom>					
                 </configuration>
                 <executions>
                     <execution>
@@ -139,7 +137,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <simple.version>${project.version}</simple.version>
@@ -216,7 +214,7 @@
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-webdav-jackrabbit</artifactId>
-                <version>2.12</version>
+                <version>3.3.2</version>
             </extension>
         </extensions>
     </build>
@@ -230,12 +228,11 @@
                     <doctitle>Simple Java API for ODF(Simple ODF)</doctitle>
                     <minmemory>512m</minmemory>
                     <maxmemory>1024m</maxmemory>
-                    <links>
-                        <link>http://download.oracle.com/javase/6/docs/api/</link>
-                        <link>http://xerces.apache.org/xerces-j/apiDocs/</link>
+                    <links>                        
+                        <link>https://xerces.apache.org/xerces-j/apiDocs/</link>
                     </links>
                     <splitindex>true</splitindex>
-                    <windowtitle>Simple ODF API v${project.version} - http://odftoolkit.org/</windowtitle>
+                    <windowtitle>Simple ODF API v${project.version} - https://odftoolkit.org/</windowtitle>
                 </configuration>
             </plugin>
             <!-- Code Coverage Testing generated by Cobertura -->
@@ -255,7 +252,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.22.2</version>
                 <reportSets>
                     <reportSet>
                         <id>integration-tests</id>
@@ -273,12 +270,12 @@
     <!-- More Project Information -->
     <name>Simple Java API for ODF (Simple ODF)</name>
     <description>A simple API for easy manipulation of ODF documents.</description>
-    <url>http://odftoolkit.org/simple/index.html</url>
+    <url>https://odftoolkit.org/simple/index.html</url>
     <inceptionYear>2010</inceptionYear>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -287,9 +284,9 @@
         <url>https://www.documentfoundation.org/</url>
     </organization>
     <scm>
-		<connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
-		<developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
-		<url>https://github.com/tdf/odftoolkit/tree/trunk/simple</url>		
+        <connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
+        <developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
+        <url>https://github.com/tdf/odftoolkit/tree/trunk/simple</url>		
     </scm>
     <profiles>
         <profile>
@@ -374,7 +371,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.5</version>
+                        <version>2.22.2</version>
                         <executions>
                             <execution>
                                 <id>failsafe-it</id>
@@ -397,7 +394,7 @@
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <!-- Explizit version required for fix on systemPropertyVariables -->
-                        <version>2.5</version>
+                        <version>2.22.2</version>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
@@ -405,8 +402,8 @@
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <source>1.5</source>
-                            <target>1.5</target>
+                            <source>${jdk.version}</source>
+                            <target>${jdk.version}</target>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -437,11 +434,11 @@
         <profile>
             <id>doclint-java8-disable</id>
             <activation>
-              <jdk>[1.8,)</jdk>
+                <jdk>[1.8,)</jdk>
             </activation>
             <properties>
-              <javadoc.opts>-Xdoclint:none</javadoc.opts>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
             </properties>
-      </profile>        
+        </profile>        
     </profiles>
 </project>

--- a/taglets/pom.xml
+++ b/taglets/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -9,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -31,10 +30,10 @@
     <version>0.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
+    </properties>
     <!-- Build Settings -->
     <build>
         <plugins>
@@ -43,8 +42,8 @@
                 <version>3.6.1</version>
                 <configuration>
                     <!-- defined in the parent pom.xml -->
-					<source>${jdk.version}</source>
-					<target>${jdk.version}</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -105,12 +104,12 @@
      <!-- More Project Information -->
     <name>ODF Custom Javadoc Taglets</name>
     <description>Javadoc taglets for ODFDOM</description>
-    <url>http://odftoolkit.org/odfdom/index.html</url>
+    <url>https://odftoolkit.org/odfdom/index.html</url>
     <inceptionYear>2008</inceptionYear>
     <licenses>
         <license>
             <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
     <organization>
@@ -118,47 +117,47 @@
         <url>https://www.documentfoundation.org/</url>
     </organization>
     <scm>
-		<connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
-		<developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
-		<url>https://github.com/tdf/odftoolkit/tree/trunk/taglets</url>		
+        <connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
+        <developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
+        <url>https://github.com/tdf/odftoolkit/tree/trunk/taglets</url>
     </scm>
     <profiles>
-		<profile>
-			<id>tools.jar</id><!-- For JDK 7 and later - with Oracle Brand --> 
-			<activation>
-				<property>
-					<name>java.vendor</name>
-					<value>Oracle Corporation</value>
-				</property>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>com.sun</groupId>
-					<artifactId>tools</artifactId>
+        <profile>
+            <id>tools.jar</id><!-- For JDK 7 and later - with Oracle Brand -->
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>Oracle Corporation</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
                     <version>1.7.0</version>
-					<scope>system</scope>
-					<systemPath>${java.home}/../lib/tools.jar</systemPath>
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
-			<id>tools-sun.jar</id><!-- For JDK 6 and OpenJDK - with Sun Brand --> 
-			<activation>
-				<property>
-					<name>java.vendor</name>
-					<value>Sun Microsystems Inc.</value>
-				</property>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>com.sun</groupId>
-					<artifactId>tools</artifactId>
-					<version>1.5.0</version>
-					<scope>system</scope>
-					<systemPath>${java.home}/../lib/tools.jar</systemPath>
-				</dependency>
-			</dependencies>
-		</profile>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>tools-sun.jar</id><!-- For JDK 6 and OpenJDK - with Sun Brand -->
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>Sun Microsystems Inc.</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>1.5.0</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>release-sign-artifacts</id>
             <activation>
@@ -187,13 +186,13 @@
             </build>
         </profile>
         <profile>
-          <id>doclint-java8-disable</id>
-          <activation>
-            <jdk>[1.8,)</jdk>
-          </activation>
-          <properties>
-            <javadoc.opts>-Xdoclint:none</javadoc.opts>
-          </properties>
-        </profile>        
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -9,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -18,180 +17,179 @@
   specific language governing permissions and limitations
   under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.odftoolkit</groupId>
-		<artifactId>odftoolkit</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
-	</parent>
-	<artifactId>odfvalidator</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
-	<packaging>war</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.odftoolkit</groupId>
+        <artifactId>odftoolkit</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>odfvalidator</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+    <packaging>war</packaging>
 
-	<dependencies>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>odfdom-java</artifactId>
-			<version>0.9.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-			<version>1.3.3</version>
-		</dependency>
-		<dependency>
-			<groupId>net.java.dev.msv</groupId>
-			<artifactId>msv-core</artifactId>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.jopendocument/isorelax-jaxp-bridge-ILM -->
-		<dependency>
-			<groupId>org.jopendocument</groupId>
-			<artifactId>isorelax-jaxp-bridge-ILM</artifactId>
-			<version>1.1</version>
-		</dependency>
-		<dependency>
-			<groupId>xerces</groupId>
-			<artifactId>xercesImpl</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>odfdom-java</artifactId>
+            <version>0.9.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.msv</groupId>
+            <artifactId>msv-core</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.jopendocument/isorelax-jaxp-bridge-ILM -->
+        <dependency>
+            <groupId>org.jopendocument</groupId>
+            <artifactId>isorelax-jaxp-bridge-ILM</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+        </dependency>
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
         </dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
-	</properties>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
+    </properties>
 
-	<!-- Build Settings -->
-	<build>
-		<extensions>
-			<extension>
-				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-webdav-jackrabbit</artifactId>
-				<version>2.12</version>
-			</extension>
-		</extensions>
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
-				<configuration>
+    <!-- Build Settings -->
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-webdav-jackrabbit</artifactId>
+                <version>3.3.2</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
                     <!-- defined in the parent pom.xml -->
-					<source>${jdk.version}</source>
-					<target>${jdk.version}</target>
-					<meminitial>512m</meminitial>
-					<maxmem>1024m</maxmem>
-					<showDeprecation>true</showDeprecation>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
-				<configuration>
-					<archive>
-						<index>true</index>
-						<manifestEntries>
-							<version>${project.version}</version>
-						</manifestEntries>
-						<manifestSections>
-							<manifestSection>
-								<name>odfvalidator</name>
-								<manifestEntries>
-									<ODFDOM-Name>ODFDOM Validator</ODFDOM-Name>
-									<ODFDOM-Version>${project.version}</ODFDOM-Version>
-									<ODFDOM-Website>http://incubator.apache.org/odftoolkit/conformance/ODFValidator.html</ODFDOM-Website>
-									<ODFDOM-Built-Date>${build.timestamp}</ODFDOM-Built-Date>
-									<ODFDOM-Supported-Odf-Version>1.2</ODFDOM-Supported-Odf-Version>
-								</manifestEntries>
-							</manifestSection>
-						</manifestSections>
-					</archive>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
-				<configuration>
-					<!-- Workaround for http://jira.codehaus.org/browse/MGPG-9 -->
-					<mavenExecutorId>forked-path</mavenExecutorId>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>				
-				<version>2.20</version>
-				<configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <meminitial>512m</meminitial>
+                    <maxmem>1024m</maxmem>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <archive>
+                        <index>true</index>
+                        <manifestEntries>
+                            <version>${project.version}</version>
+                        </manifestEntries>
+                        <manifestSections>
+                            <manifestSection>
+                                <name>odfvalidator</name>
+                                <manifestEntries>
+                                    <ODFDOM-Name>ODFDOM Validator</ODFDOM-Name>
+                                    <ODFDOM-Version>${project.version}</ODFDOM-Version>
+                                    <ODFDOM-Website>${project.url}</ODFDOM-Website>
+                                    <ODFDOM-Built-Date>${build.timestamp}</ODFDOM-Built-Date>
+                                    <ODFDOM-Supported-Odf-Version>1.2</ODFDOM-Supported-Odf-Version>
+                                </manifestEntries>
+                            </manifestSection>
+                        </manifestSections>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <!-- Workaround for https://jira.codehaus.org/browse/MGPG-9 -->
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>				
+                <version>2.22.2</version>
+                <configuration>
                     <excludes>                                        
                         <exclude>**/*.java</exclude>
                     </excludes>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>3.0.1</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifestEntries>							
-							<version>${project.version}</version>
-							<Main-Class>org.odftoolkit.odfvalidator.Main</Main-Class>
-						</manifestEntries>
-					</archive>
-					<descriptors>					
-						<descriptor>src/main/assembly/src.xml</descriptor>
-					</descriptors>
-				</configuration>
-				<executions>
-					<execution>
-						<id>single</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.rat</groupId>
-				<artifactId>apache-rat-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>src/main/resources/**</exclude>
-						<exclude>src/test/resources/**</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>							
+                            <version>${project.version}</version>
+                            <Main-Class>org.odftoolkit.odfvalidator.Main</Main-Class>
+                        </manifestEntries>
+                    </archive>
+                    <descriptors>					
+                        <descriptor>src/main/assembly/src.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>single</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>src/main/resources/**</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.2</version>
                 <configuration>
                     <includes>                                        
                         <include>**/*.java</include>
                     </includes> 
-					<systemPropertyVariables>
-						<odfvalidator.version>${project.version}</odfvalidator.version>
-						<org.odftoolkit.odfdom.validation>org.odftoolkit.odfdom.pkg.DefaultErrorHandler</org.odftoolkit.odfdom.validation>
-					</systemPropertyVariables>                                                       
+                    <systemPropertyVariables>
+                        <odfvalidator.version>${project.version}</odfvalidator.version>
+                        <org.odftoolkit.odfdom.validation>org.odftoolkit.odfdom.pkg.DefaultErrorHandler</org.odftoolkit.odfdom.validation>
+                    </systemPropertyVariables>                                                       
                 </configuration>                
                 <executions>
                     <execution>
@@ -203,113 +201,115 @@
                     </execution>
                 </executions>
             </plugin>		            
-		</plugins>
-	</build>
-	<reporting>
-		<plugins>
-			<!-- Code Coverage Testing generated by Cobertura -->
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<instrumentation>
-						<excludes>
-							<exclude>org/odftoolkit/**/*Test.class</exclude>
-						</excludes>
-					</instrumentation>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.0</version>
-				<configuration>
-					<doctitle>Validator</doctitle>
-					<links>
-						<link>http://download.oracle.com/javase/8/docs/api/</link>
-						<link>http://xerces.apache.org/xerces-j/apiDocs/</link>
-					</links>
-					<splitindex>true</splitindex>
-					<windowtitle>Validator API v${project.version} - http://incubator.apache.org/odftoolkit/</windowtitle>
-				</configuration>
-			</plugin>
-			<!-- Reporting integration test results -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.20</version>
-				<reportSets>
-					<reportSet>
-						<id>integration-tests</id>
-						<reports>
-							<report>report-only</report>
-						</reports>
-						<configuration>
-							<outputName>failsafe-report</outputName>
-						</configuration>
-					</reportSet>
-				</reportSets>
-			</plugin>
-		</plugins>
-	</reporting>
+        </plugins>
+    </build>
+    <reporting>
+        <plugins>
+            <!-- Code Coverage Testing generated by Cobertura -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <instrumentation>
+                        <excludes>
+                            <exclude>org/odftoolkit/**/*Test.class</exclude>
+                        </excludes>
+                    </instrumentation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <doctitle>Validator</doctitle>
+                    <links>
+                        <link>https://download.oracle.com/javase/8/docs/api/</link>
+                        <link>https://xerces.apache.org/xerces-j/apiDocs/</link>
+                    </links>
+                    <doclint>none</doclint>
+                    <splitindex>true</splitindex>
+                    <validateLinks>true</validateLinks>
+                    <windowtitle>Validator API v${project.version} - https://odftoolkit.org/</windowtitle>
+                </configuration>
+            </plugin>
+            <!-- Reporting integration test results -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <reportSets>
+                    <reportSet>
+                        <id>integration-tests</id>
+                        <reports>
+                            <report>report-only</report>
+                        </reports>
+                        <configuration>
+                            <outputName>failsafe-report</outputName>
+                        </configuration>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 
-	<!-- More Project Information -->
-	<name>ODF Validator</name>
-	<description>
-		ODF Validator is a tool that validates OpenDocument files and checks them for certain conformance criteria.
-	</description>
-	<url>http://incubator.apache.org/odftoolkit/conformance/ODFValidator.html</url>
-	<inceptionYear>2008</inceptionYear>
-	<licenses>
-		<license>
-			<name>Apache 2</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-		</license>
-	</licenses>
+    <!-- More Project Information -->
+    <name>ODF Validator</name>
+    <description>
+        ODF Validator is a tool that validates OpenDocument files and checks them for certain conformance criteria.
+    </description>	
+    <url>https://odfvalidator.org/</url>
+    <inceptionYear>2008</inceptionYear>
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
     <organization>
         <name>The Document Foundation</name>
         <url>https://www.documentfoundation.org/</url>
     </organization>
     <scm>
-		<connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
-		<developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
-		<url>https://github.com/tdf/odftoolkit/tree/trunk/validator</url>		
-	</scm>
-	<profiles>
-		<!-- Profile for deploying to the Sonatype repository, which
-  requires GPG signatures 
-  see
-  https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
-  https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven
-  https://issues.sonatype.org/browse/OSSRH-960
-  -->
-		<profile>
-			<id>release-sign-artifacts</id>
-			<activation>
-				<property>
-					<name>performRelease</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+        <connection>scm:git:git://github.com/tdf/odftoolkit.git</connection>
+        <developerConnection>scm:git:git@github.com:tdf/odftoolkit.git</developerConnection>
+        <url>https://github.com/tdf/odftoolkit/tree/trunk/validator</url>		
+    </scm>
+    <profiles>
+        <!-- Profile for deploying to the Sonatype repository, which
+        requires GPG signatures 
+        see
+        https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
+        https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven
+        https://issues.sonatype.org/browse/OSSRH-960
+        -->
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/xslt-runner-task/pom.xml
+++ b/xslt-runner-task/pom.xml
@@ -1,4 +1,5 @@
- <!-- 
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file
        distributed with this work for additional information
@@ -7,7 +8,7 @@
        "License"); you may not use this file except in compliance
        with the License.  You may obtain a copy of the License at
 
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
 
        Unless required by applicable law or agreed to in writing,
        software distributed under the License is distributed on an
@@ -17,63 +18,63 @@
        under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.odftoolkit</groupId>
-    <artifactId>odftoolkit</artifactId>
+    <parent>
+        <groupId>org.odftoolkit</groupId>
+        <artifactId>odftoolkit</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xslt-runner-task</artifactId>
+    <name>ODF XSLT-Runner Ant Task</name>
     <version>0.9.0-SNAPSHOT</version>
-  </parent>
-
-  <artifactId>xslt-runner-task</artifactId>
-  <name>ODF XSLT-Runner Ant Task</name>
-  <version>0.9.0-SNAPSHOT</version>
   
-  <organization>
-	<name>The Document Foundation</name>
-	<url>https://www.documentfoundation.org/</url>
-  </organization>
-  <dependencies>
-	<dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>xslt-runner</artifactId>
-      <version>0.9.0-SNAPSHOT</version>
-	</dependency>	
-    <dependency>
-      <groupId>org.apache.ant</groupId>
-      <artifactId>ant</artifactId>
-    </dependency>
-  </dependencies>
-  <properties>
-	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
-  </properties>
+    <organization>
+        <name>The Document Foundation</name>
+        <url>https://www.documentfoundation.org/</url>
+    </organization>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>xslt-runner</artifactId>
+            <version>0.9.0-SNAPSHOT</version>
+        </dependency>	
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+        </dependency>
+    </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
+    </properties>
 
 
-  <!-- Build Settings -->
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <!-- defined in the parent pom.xml -->
-		  <source>${jdk.version}</source>
-		  <target>${jdk.version}</target>
-          <meminitial>512m</meminitial>
-          <maxmem>1024m</maxmem>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
-    </plugin>
-        <plugin>
-            <groupId>org.apache.rat</groupId>
-            <artifactId>apache-rat-plugin</artifactId>
-            <configuration>
-                <excludes>
-                    <exclude>nbproject/**</exclude>
-                </excludes>
-            </configuration>
-        </plugin>
- </plugins>
-</build>
+    <!-- Build Settings -->
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <!-- defined in the parent pom.xml -->
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <meminitial>512m</meminitial>
+                    <maxmem>1024m</maxmem>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>nbproject/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/xslt-runner/pom.xml
+++ b/xslt-runner/pom.xml
@@ -1,4 +1,5 @@
- <!-- 
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
        Licensed to the Apache Software Foundation (ASF) under one
        or more contributor license agreements.  See the NOTICE file
        distributed with this work for additional information
@@ -7,7 +8,7 @@
        "License"); you may not use this file except in compliance
        with the License.  You may obtain a copy of the License at
 
-         http://www.apache.org/licenses/LICENSE-2.0
+         https://www.apache.org/licenses/LICENSE-2.0
 
        Unless required by applicable law or agreed to in writing,
        software distributed under the License is distributed on an
@@ -16,88 +17,88 @@
        specific language governing permissions and limitations
        under the License.
 -->
- <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.odftoolkit</groupId>
-    <artifactId>odftoolkit</artifactId>
+    <parent>
+        <groupId>org.odftoolkit</groupId>
+        <artifactId>odftoolkit</artifactId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xslt-runner</artifactId>
+    <name>ODF XSLT-Runner</name>
     <version>0.9.0-SNAPSHOT</version>
-  </parent>
-
-  <artifactId>xslt-runner</artifactId>
-  <name>ODF XSLT-Runner</name>
-  <version>0.9.0-SNAPSHOT</version>
   
-   <organization>
-     <name>The Document Foundation</name>
-     <url>https://www.documentfoundation.org/</url>
-   </organization>
+    <organization>
+        <name>The Document Foundation</name>
+        <url>https://www.documentfoundation.org/</url>
+    </organization>
   
-  <dependencies>
-	<dependency>
-      <groupId>${project.groupId}</groupId>
-	  <artifactId>odfdom-java</artifactId>
-      <version>0.9.0-SNAPSHOT</version>
-	</dependency>
-    <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-    </dependency>	
-  </dependencies>
-  <properties>
-	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
-  </properties> 
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>odfdom-java</artifactId>
+            <version>0.9.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </dependency>	
+    </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
+    </properties> 
 
-  <!-- Build Settings -->
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>        
-        <configuration>
-          <!-- defined in the parent pom.xml -->
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
-          <meminitial>512m</meminitial>
-          <maxmem>1024m</maxmem>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
-    </plugin>
-        <plugin>
-            <groupId>org.apache.rat</groupId>
-            <artifactId>apache-rat-plugin</artifactId>
-            <configuration>
-                <excludes>
-                    <exclude>manifest.mf</exclude>
-                    <exclude>misc/odf-attribute-xref.ods</exclude>
-                    <exclude>nbproject/**</exclude>
-                </excludes>
-            </configuration>
-        </plugin>
-        <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <configuration>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-                <archive>
-                    <manifest>
-                        <mainClass>org.odftoolkit.odfxsltrunner.Main</mainClass>
-                    </manifest>
-                </archive>
-            </configuration>
-            <executions>
-                <execution>
-                    <id>make-assembly</id>
-                    <phase>package</phase>
-                    <goals>
-                        <goal>single</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
-    </plugins>
-</build>
+    <!-- Build Settings -->
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>        
+                <configuration>
+                    <!-- defined in the parent pom.xml -->
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <meminitial>512m</meminitial>
+                    <maxmem>1024m</maxmem>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>manifest.mf</exclude>
+                        <exclude>misc/odf-attribute-xref.ods</exclude>
+                        <exclude>nbproject/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.odftoolkit.odfxsltrunner.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
I have removed (hopefully) the final namings of Apache (aside the license) and updated the Maven pom.xml to a recent edition so the current [JDK 11 / 1.0.0-SNAPSHOT branch](https://github.com/svanteschubert/odftoolkit/tree/odf-changes) is using the same plugins as our JDK 8 master branch.

Our new mailing list is now available and added:
`<mailingList>`
`<!--`
`Help: <dev+help@odftoolkit.org>`
`Digest subscription: <dev+subscribe-digest@odftoolkit.org>`
`No-mail subscription: <dev+subscribe-nomail@odftoolkit.org>`
`-->`
`<post>dev@odftoolkit.org</post>`
`<subscribe>dev+subscribe@odftoolkit.org</subscribe>`
`<unsubscribe>dev+unsubscribe@odftoolkit.org</unsubscribe>`
`<archive>https://listarchives.odftoolkit.org/dev/</archive>`
`<name>dev.odftoolkit.org</name><!-- List-Id -->`
`</mailingList>`
