### PR TITLE
numbering of sorted Lists with lower greek symbols did not work and is now repaired

### DIFF
--- a/simple/src/main/java/org/odftoolkit/simple/text/list/List.java
+++ b/simple/src/main/java/org/odftoolkit/simple/text/list/List.java
@@ -51,7 +51,10 @@ import org.w3c.dom.Node;
 public class List {
 
 	private TextListElement listElement;
-	private ListDecorator decorator;
+	/**
+	 * decorator is visible in package for testing purpose
+	 */
+	ListDecorator decorator;
 
 	/**
 	 * Constructor ListItem, AbstractListContainer and List use only.

--- a/simple/src/main/java/org/odftoolkit/simple/text/list/NumberedGreekLowerDecorator.java
+++ b/simple/src/main/java/org/odftoolkit/simple/text/list/NumberedGreekLowerDecorator.java
@@ -39,6 +39,6 @@ public class NumberedGreekLowerDecorator extends NumberDecoratorBase {
 	 *            the Document which this NumberDecorator will be used on.
 	 */
 	public NumberedGreekLowerDecorator(Document doc) {
-	    	super(doc, "Simple_Default_greek_lower_List", "Numbering_20_Symbols", "Î±, Î², ... (gr)", ")", null);
+	    	super(doc, "Simple_Default_greek_lower_List", "Numbering_20_Symbols", "\u03B1, \u03B2, ... (gr)", ")", null);
 	}
 }

--- a/simple/src/test/java/org/odftoolkit/simple/text/list/NumberedListTest.java
+++ b/simple/src/test/java/org/odftoolkit/simple/text/list/NumberedListTest.java
@@ -18,7 +18,6 @@ public class NumberedListTest{
 		try {
 			TextDocument doc = TextDocument.newTextDocument();
 			List greekList = doc.addList(new NumberedGreekLowerDecorator(doc));
-			System.out.println(greekList.decorator);
 			NumberedGreekLowerDecorator greekListdecorator = (NumberedGreekLowerDecorator)greekList.decorator;
 			OdfTextListStyle listStyle = greekListdecorator.getListStyle();
 			Element odfTextListLevelStyleNumberEle = listStyle.getFirstElementChild();

--- a/simple/src/test/java/org/odftoolkit/simple/text/list/NumberedListTest.java
+++ b/simple/src/test/java/org/odftoolkit/simple/text/list/NumberedListTest.java
@@ -23,7 +23,7 @@ public class NumberedListTest{
 			OdfTextListStyle listStyle = greekListdecorator.getListStyle();
 			Element odfTextListLevelStyleNumberEle = listStyle.getFirstElementChild();
 			String styleNumFormat = odfTextListLevelStyleNumberEle.getAttribute("style:num-format");
-			// Test if the Number3eStyle starts with lower greek alfa,
+			// Test if the number style starts with lower greek alfa:
 			Assert.assertTrue(styleNumFormat.indexOf(lowerGreekAlfa) == 0);
 		} catch (Exception e) {
 			Logger.getLogger(NumberedListTest.class.getName()).log(Level.SEVERE, null, e);

--- a/simple/src/test/java/org/odftoolkit/simple/text/list/NumberedListTest.java
+++ b/simple/src/test/java/org/odftoolkit/simple/text/list/NumberedListTest.java
@@ -1,0 +1,34 @@
+package org.odftoolkit.simple.text.list;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+import org.odftoolkit.odfdom.incubator.doc.text.OdfTextListStyle;
+import org.odftoolkit.simple.TextDocument;
+import org.w3c.dom.Element;
+import junit.framework.Assert;
+
+public class NumberedListTest{
+
+	private static final char lowerGreekAlfa = '\u03B1';
+
+	@Test
+	public void testSetExtendedNumberedGreekListDecorator() {
+		try {
+			TextDocument doc = TextDocument.newTextDocument();
+			List greekList = doc.addList(new NumberedGreekLowerDecorator(doc));
+			System.out.println(greekList.decorator);
+			NumberedGreekLowerDecorator greekListdecorator = (NumberedGreekLowerDecorator)greekList.decorator;
+			OdfTextListStyle listStyle = greekListdecorator.getListStyle();
+			Element odfTextListLevelStyleNumberEle = listStyle.getFirstElementChild();
+			String styleNumFormat = odfTextListLevelStyleNumberEle.getAttribute("style:num-format");
+			// Test if the Number3eStyle starts with lower greek alfa,
+			Assert.assertTrue(styleNumFormat.indexOf(lowerGreekAlfa) == 0);
+		} catch (Exception e) {
+			Logger.getLogger(NumberedListTest.class.getName()).log(Level.SEVERE, null, e);
+			Assert.fail(e.getMessage());
+		}
+	}
+
+}


### PR DESCRIPTION
In the cobnstructor of NumberedGreekLowerDecorator the greek symbols 'alfa' and 'beta' had been got lost, probably for characterset reasons. Now they are written directly in utf-8.