### PR TITLE
Fix test failure when default java is older

### DIFF
--- a/odfdom/src/test/java/org/odftoolkit/odfdom/integrationtest/JarManifestIT.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/integrationtest/JarManifestIT.java
@@ -61,7 +61,7 @@ public class JarManifestIT {
             String firstOutputLine = null;
             String secondOutputLine = null;
             try {
-                ProcessBuilder builder = new ProcessBuilder("java",  "-jar", jarPath);
+                ProcessBuilder builder = new ProcessBuilder(System.getenv("JAVA_HOME") +"/bin/java",  "-jar", jarPath);
                 builder.redirectErrorStream(true);
                 Process p = builder.start();
                 BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream()));

--- a/validator/src/test/java/org/odftoolkit/odfvalidator/jar/ITJarTest.java
+++ b/validator/src/test/java/org/odftoolkit/odfvalidator/jar/ITJarTest.java
@@ -48,7 +48,7 @@ public class ITJarTest {
             // java -jar .m2/repository/org/apache/odftoolkit/odfvalidator/1.2.0-incubating-SNAPSHOT/odfvalidator-1.2.0-incubating-SNAPSHOT-jar-with-dependencies.jar foo.odt
             String odfvalidatorVersion = System.getProperty("odfvalidator.version");
             ProcessBuilder builder = new ProcessBuilder(
-                "java", "-jar", "target" + File.separatorChar + JAR_NAME_PREFIX + odfvalidatorVersion + JAR_NAME_SUFFIX,
+                System.getenv("JAVA_HOME") +"/bin/java", "-jar", "target" + File.separatorChar + JAR_NAME_PREFIX + odfvalidatorVersion + JAR_NAME_SUFFIX,
                 "target" + File.separatorChar + "test-classes" + File.separatorChar + ODT_NAME);
             builder.redirectErrorStream(true);
             Process p = builder.start();


### PR DESCRIPTION
Executing the "java" command uses the default JRE which might be older than what is used during ODFToolkit build (meaning the build fails).

So explicitly use the Java of the current JRE (as set with the JAVA_HOME env var).

