### PR TITLE
Remove @deprecated annotations from original API - fixes #56

### DIFF
--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfChartDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfChartDocument.java
@@ -32,8 +32,6 @@ import org.xml.sax.SAXException;
 /**
  * This class represents an empty ODF document , which will be in general embedded
  * in an existing ODF (Spreadsheet) document.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.ChartDocument} in Simple API.
  */
 public class OdfChartDocument extends OdfDocument {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfGraphicsDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfGraphicsDocument.java
@@ -31,8 +31,6 @@ import org.xml.sax.SAXException;
 
 /**
  * This class represents an empty ODF graphics document.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.GraphicsDocument} in Simple API.
  */
 public class OdfGraphicsDocument extends OdfDocument {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
@@ -65,8 +65,6 @@ import org.xml.sax.SAXException;
 
 /**
  * This class represents an empty ODF presentation.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.PresentationDocument} in Simple API.
  */
 public class OdfPresentationDocument extends OdfDocument {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfSpreadsheetDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfSpreadsheetDocument.java
@@ -31,8 +31,6 @@ import org.xml.sax.SAXException;
 
 /**
  * This class represents an empty ODF spreadsheet document.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.SpreadsheetDocument} in Simple API.
  */
 public class OdfSpreadsheetDocument extends OdfDocument {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfTextDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfTextDocument.java
@@ -33,8 +33,6 @@ import org.xml.sax.SAXException;
 
 /**
  * This class represents an empty ODF text document.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.TextDocument} in Simple API.
  */
 public class OdfTextDocument extends OdfDocument {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/presentation/OdfPresentationNotes.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/presentation/OdfPresentationNotes.java
@@ -33,8 +33,6 @@ import org.w3c.dom.NodeList;
 
 /**
  * Convenient functionality for the parent ODF OpenDocument element
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.presentation.Notes} in Simple API.
  */
 public class OdfPresentationNotes
 {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/presentation/OdfSlide.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/presentation/OdfSlide.java
@@ -32,8 +32,6 @@ import org.w3c.dom.NodeList;
 /**
  * <code>OdfSlide</code> represents the presentation slide feature of the ODF document.
  * <code>OdfSlide</code> provides methods to get the slide index,get the content of the current slide, etc.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.presentation.Slide} in Simple API.
  */
 public class OdfSlide {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
@@ -71,8 +71,6 @@ import org.w3c.dom.NodeList;
  * OdfTable represents the table feature in ODF spreadsheet and text documents.
  * <p>
  * OdfTable provides methods to get/add/delete/modify table column/row/cell.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.table.Table} in Simple API.
  */
 public class OdfTable {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableCell.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableCell.java
@@ -73,8 +73,6 @@ import org.w3c.dom.Node;
  * OdfTableCell represents table cell feature in ODF document.
  * <p>
  * OdfTable provides methods to get/set/modify the cell content and cell properties.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.table.Cell} in Simple API.
  */
 public class OdfTableCell {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableCellRange.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableCellRange.java
@@ -43,8 +43,6 @@ import org.odftoolkit.odfdom.dom.element.table.TableTableCellElement;
  * OdfTableCellRange represent a rang of cells that are adjacent with each other
  * <p>
  * OdfTableCellRange provides methods to get/set/modify the properties of cell range.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.table.CellRange} in Simple API.
  */
 public class OdfTableCellRange {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableColumn.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableColumn.java
@@ -48,8 +48,6 @@ import org.w3c.dom.Node;
  * OdfTableColumn represents table column feature in ODF document.
  * <p>
  * OdfTableColumn provides methods to get table cells that belong to this table column.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.table.Column} in Simple API.
  */
 public class OdfTableColumn {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableRow.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableRow.java
@@ -59,8 +59,6 @@ import org.w3c.dom.Node;
  * OdfTableRow represents table row feature in ODF document.
  * <p>
  * OdfTableRow provides methods to get table cells that belong to this table row.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.table.Row} in Simple API.
  */
 public class OdfTableRow {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/draw/OdfDrawFrame.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/draw/OdfDrawFrame.java
@@ -28,8 +28,6 @@ import org.odftoolkit.odfdom.dom.element.draw.DrawFrameElement;
 
 /**
  * Convenient functionalty for the parent ODF OpenDocument element
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.draw.Frame} in Simple API.
  */
 public class OdfDrawFrame extends DrawFrameElement
 {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/draw/OdfDrawImage.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/draw/OdfDrawImage.java
@@ -48,8 +48,6 @@ import org.w3c.dom.NodeList;
 
 /**
  * Convenient functionalty for the parent ODF OpenDocument element
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.draw.Image} in Simple API.
  */
 public class OdfDrawImage extends DrawImageElement {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfEditableTextExtractor.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfEditableTextExtractor.java
@@ -45,8 +45,6 @@ import org.w3c.dom.NodeList;
  * header and footer in styles.xml, meta data in meta.xml.
  *
  * <p>This function can be used by search engine, and text analytic operations. </p>
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.EditableTextExtractor} in Simple API.
  */
 public class OdfEditableTextExtractor extends OdfTextExtractor {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextExtractor.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextExtractor.java
@@ -37,8 +37,6 @@ import org.w3c.dom.Node;
  * returned, without any tag information.</p>
  * <p> It implements part of white space handling fuctions: text:p, text:h, text:s, text:tab, text:linebreak are processed
  * according to ODF specification.</p>
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.TextExtractor} in Simple API.
  */
 public class OdfTextExtractor extends DefaultElementVisitor {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextHeading.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextHeading.java
@@ -27,8 +27,6 @@ import org.odftoolkit.odfdom.dom.element.text.TextHElement;
 
 /**
  * Convenient functionalty for the parent ODF OpenDocument element
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.text.Paragraph} in Simple API.
  */
 public class OdfTextHeading extends TextHElement
 {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextList.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextList.java
@@ -36,8 +36,6 @@ import org.w3c.dom.Node;
 
 /**
  * Convenient functionalty for the parent ODF OpenDocument element
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.text.list.List} in Simple API.
  */
 public class OdfTextList extends TextListElement {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextParagraph.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextParagraph.java
@@ -26,8 +26,6 @@ import org.odftoolkit.odfdom.dom.element.text.TextPElement;
 
 /**
  * Convenient functionalty for the parent ODF OpenDocument element
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.text.Paragraph} in Simple API.
  */
 public class OdfTextParagraph extends TextPElement {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextSpan.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextSpan.java
@@ -27,8 +27,6 @@ import org.odftoolkit.odfdom.dom.element.text.TextSpanElement;
 
 /**
  * Convenient functionalty for the parent ODF OpenDocument element
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.text.Span} in Simple API.
  */
 public class OdfTextSpan extends TextSpanElement
 {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfWhitespaceProcessor.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfWhitespaceProcessor.java
@@ -34,7 +34,6 @@ import org.w3c.dom.Node;
  * It's a tool class to help process white space.
  *
  * @author J David Eisenberg
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.WhitespaceProcessor} in Simple API.
  */
 public class OdfWhitespaceProcessor {
 	private int nSpaces;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/meta/OdfMetaDocumentStatistic.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/meta/OdfMetaDocumentStatistic.java
@@ -27,8 +27,6 @@ import org.odftoolkit.odfdom.dom.element.meta.MetaDocumentStatisticElement;
 /**
  * <code>OdfMetaDocumentStatistic</code> feature specifies the statistics about
  * the document.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.meta.DocumentStatistic} in Simple API.
  */
 public class OdfMetaDocumentStatistic {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/meta/OdfOfficeMeta.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/meta/OdfOfficeMeta.java
@@ -56,8 +56,6 @@ import org.odftoolkit.odfdom.type.Duration;
  * <code>OdfOfficeMeta</code> represent the meta data feature in the ODF document.
  * <p>
  * It provides convenient method to get meta data info.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.meta.Meta} in Simple API.
  */
 public class OdfOfficeMeta {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/InvalidNavigationException.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/InvalidNavigationException.java
@@ -23,8 +23,6 @@ package org.odftoolkit.odfdom.incubator.search;
 /**
  * Thrown to indicate that the navigation operation can not be processed on
  * selections
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.navigation.InvalidNavigationException} in Simple API.
  */
 public class InvalidNavigationException extends Exception {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/Navigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/Navigation.java
@@ -25,8 +25,6 @@ import org.w3c.dom.Node;
 /**
  * Abstract class Navigation used to navigate the document
  * and find the matched element by the user defined conditions
- *
- *@deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.navigation.Navigation} in Simple API.
  */
 public abstract class Navigation {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/Selection.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/Selection.java
@@ -29,8 +29,6 @@ import org.odftoolkit.odfdom.pkg.OdfElement;
  * Abstract class Selection describe one of the matched results The selection
  * can be recognized by the container mElement, the start mIndex of the text
  * content of this mElement and the text content.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.navigation.Selection} in Simple API.
  */
 public abstract class Selection {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextNavigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextNavigation.java
@@ -37,8 +37,6 @@ import org.w3c.dom.NodeList;
  * A derived Navigation class used for navigate the text content
  * it is used to search the document and find the matched text
  * and would return TextSelection instance
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.navigation.TextNavigation} in Simple API.
  */
 public class TextNavigation extends Navigation {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextSelection.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextSelection.java
@@ -48,8 +48,6 @@ import org.w3c.dom.Node;
  * it is recognized by the container element(which type should be OdfTextParagraph or
  *  OdfTextHeadingt), the start index of the text content of the container element and
  *  the text content of this selection.
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.navigation.TextSelection} in Simple API.
  */
 public class TextSelection extends Selection {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
@@ -46,8 +46,6 @@ import org.w3c.dom.NodeList;
  * A derived Navigation class used for navigate the mText content it is used to
  * search the document and find the matched style properties and would return
  * TextSelection instance
- *
- * @deprecated As of release 0.8.8, replaced by {@link org.odftoolkit.simple.common.navigation.TextStyleNavigation} in Simple API.
  */
 public class TextStyleNavigation extends Navigation {
 


### PR DESCRIPTION
Since the recommendation to migrate to the (to be removed) Simple API is misleading, remove the deprecation annotations from the original API.

Fixes #56