### PR TITLE
#62 OdfSpreadsheetDocument: getTables and getTableList

### DIFF
--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfDocument.java
@@ -831,14 +831,31 @@ public abstract class OdfDocument extends OdfSchemaDocument {
   }
 
   /**
-   * Return a list of table features in this document.
+   * Return a list of table features in this document. For general ODF documents it searches for
+   * them recursively through the document. For ODF documents, there is a getOdsTableList
    *
+   * @see OdfSpreadsheetDocument:getSpreadsheetTables
    * @return a list of table features in this document.
    */
+  @Deprecated(
+      since =
+          "It was not clear that this is searching recursively, especialy in OdfSpreadsheetDocuments")
   public List<OdfTable> getTableList() {
+    return getTableList(false);
+  }
+
+  /**
+   * Return a list of table features in this document. For general ODF documents it searches for
+   * tables recursively through the document.
+   *
+   * @see OdfSpreadsheetDocument:getSpreadsheetTables
+   * @param doRecursiveSearch In spreadsheet documents you do not need a recursive search.
+   * @return a list of table features in this document.
+   */
+  public List<OdfTable> getTableList(boolean doRecursiveSearch) {
     List<OdfTable> tableList = null;
     try {
-      List<TableTableElement> tableElementList = getTables();
+      List<TableTableElement> tableElementList = getTables(doRecursiveSearch);
       tableList = new ArrayList<OdfTable>(tableElementList.size());
       for (int i = 0; i < tableElementList.size(); i++) {
         tableList.add(OdfTable.getInstance(tableElementList.get(i)));

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfSpreadsheetDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfSpreadsheetDocument.java
@@ -25,6 +25,8 @@ package org.odftoolkit.odfdom.doc;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.List;
+import org.odftoolkit.odfdom.doc.table.OdfTable;
 import org.odftoolkit.odfdom.dom.element.office.OfficeSpreadsheetElement;
 import org.odftoolkit.odfdom.pkg.MediaType;
 import org.odftoolkit.odfdom.pkg.OdfPackage;
@@ -176,5 +178,16 @@ public class OdfSpreadsheetDocument extends OdfDocument {
    */
   public void changeMode(OdfMediaType mediaType) {
     setOdfMediaType(mediaType.mMediaType);
+  }
+
+  /**
+   * Return a list of table features in this document. For general ODF documents it searches for
+   * them recursively through the document. For ODF documents, there is a getOdsTableList
+   *
+   * @see OdfDocument:getTableList
+   * @return a list of table features in this document.
+   */
+  public List<OdfTable> getSpreadsheetTables() {
+    return getTableList(true);
   }
 }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
@@ -1915,7 +1915,8 @@ public class OdfTable {
    */
   public void setTableName(String tableName) {
     // check if the table name is already exist
-    List<OdfTable> tableList = mDocument.getTableList();
+    boolean isSpreadsheet = mDocument instanceof OdfSpreadsheetDocument;
+    List<OdfTable> tableList = mDocument.getTableList(!isSpreadsheet);
     for (int i = 0; i < tableList.size(); i++) {
       OdfTable table = tableList.get(i);
       if (tableName.equals(table.getTableName())) {

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellRangeTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellRangeTest.java
@@ -227,7 +227,7 @@ public class TableCellRangeTest {
       swCell.setStringValue("Merge A1:E2");
       swCellRange.merge();
       odt.save(ResourceUtilities.getTestOutputFile(odtfilename + "MergeTextExpandCell.odt"));
-      swTable = odt.getTableList().get(0);
+      swTable = odt.getTableList(true).get(0); // is never an ODS document
       Assert.assertTrue(swTable.getColumnCount() == 1);
       Assert.assertTrue(swTable.getRowCount() == 1);
     } catch (Exception ex) {

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
@@ -298,7 +298,7 @@ public class TableTest {
       mOdtDoc =
           OdfTextDocument.loadDocument(
               ResourceUtilities.getAbsoluteInputPath(mOdtTestFileName + ".odt"));
-      List<OdfTable> tableList = mOdtDoc.getTableList();
+      List<OdfTable> tableList = mOdtDoc.getTableList(true);
       int count = tableList.size();
 
       OdfTable table = mOdtDoc.getTableByName("DeletedTable");
@@ -310,7 +310,7 @@ public class TableTest {
       mOdtDoc =
           OdfTextDocument.loadDocument(
               ResourceUtilities.getAbsoluteOutputPath(mOdtTestFileName + "Out.odt"));
-      tableList = mOdtDoc.getTableList();
+      tableList = mOdtDoc.getTableList(true);
       Assert.assertEquals(count - 1, tableList.size());
     } catch (Exception e) {
       Logger.getLogger(TableTest.class.getName()).log(Level.SEVERE, null, e);
@@ -342,7 +342,7 @@ public class TableTest {
       mOdtDoc =
           OdfTextDocument.loadDocument(
               ResourceUtilities.getAbsoluteInputPath(mOdtTestFileName + ".odt"));
-      List<OdfTable> tableList = mOdtDoc.getTableList();
+      List<OdfTable> tableList = mOdtDoc.getTableList(true);
       for (int i = 0; i < tableList.size(); i++) {
         OdfTable table = tableList.get(i);
         int clmnum = table.getColumnCount();
@@ -1096,7 +1096,7 @@ public class TableTest {
           (OdfSpreadsheetDocument)
               OdfSpreadsheetDocument.loadDocument(
                   ResourceUtilities.getAbsoluteInputPath("testGetCellAt.ods"));
-      OdfTable odfTable = doc.getTableList().get(0);
+      OdfTable odfTable = doc.getTableList(false).get(0);
       OdfTableRow valueRows = odfTable.getRowByIndex(0);
       for (int i = 0; i < 4; i++) {
         OdfTableCell cell = valueRows.getCellByIndex(i);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/EmbeddedDocumentTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/EmbeddedDocumentTest.java
@@ -142,7 +142,7 @@ public class EmbeddedDocumentTest {
       Assert.assertNotNull(docB);
       Assert.assertNull(odtRootDoc.loadSubDocument("DOCA/DOCB/"));
       docB.newImage(ResourceUtilities.getTestInputURI(TEST_PIC_ANOTHER));
-      OdfTable table1 = docB.getTableList().get(0);
+      OdfTable table1 = docB.getTableList(true).get(0);
       table1.setTableName("NewTable");
       updateFrameForEmbeddedDoc(contentA, "./DOCB", "DOCA/DOCB");
       // if user want to save the docA with the side by side embedded document
@@ -199,7 +199,7 @@ public class EmbeddedDocumentTest {
       addFrameForEmbeddedDoc(contentA, lastPara, "./DOCB");
       OdfDocument docB = odtDoc1.loadSubDocument("DOCA/DOCB/");
       docB.newImage(ResourceUtilities.getTestInputURI(TEST_PIC_ANOTHER));
-      OdfTable table1 = docB.getTableList().get(0);
+      OdfTable table1 = docB.getTableList(true).get(0);
       table1.setTableName("NewTable");
       Assert.assertNotNull(docB);
       Assert.assertNull(odtDoc1.loadSubDocument("DOCB/"));


### PR DESCRIPTION
ODS documents do not need a recursive search for the "tables". Adding additional API into getTables() and use that in the tests.
The old API is marked as Deprecated.