### PR TITLE
validator: work around mysterious behavior of maven-assembly-plugin

### DIFF
--- a/validator/src/main/assembly/src.xml
+++ b/validator/src/main/assembly/src.xml
@@ -28,6 +28,37 @@
             <outputDirectory></outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <unpack>true</unpack>
+            <!-- HACK: this suppresses empty files of that name, will get the directories that we want instead
+              FIXME: WHY DOES THIS WORK???
+            -->
+            <unpackOptions>
+                <excludes>
+                    <exclude>META-INF/maven/commons-beanutils</exclude>
+                    <exclude>META-INF/maven/commons-beanutils/commons-beanutils</exclude>
+                    <exclude>META-INF/maven/com.google.code.findbugs</exclude>
+                    <exclude>META-INF/maven/com.google.code.findbugs/jsr305</exclude>
+                    <exclude>META-INF/maven/com.sun.xml.bind.jaxb</exclude>
+                    <exclude>META-INF/maven/org.slf4j</exclude>
+                    <exclude>META-INF/maven/org.codehaus.plexus/plexus-component-annotations</exclude>
+                    <exclude>META-INF/maven/commons-logging</exclude>
+                    <exclude>META-INF/maven/net.java.dev.msv/xsdlib</exclude>
+                    <exclude>META-INF/maven/org.codehaus.plexus</exclude>
+                    <exclude>META-INF/maven/com.google.j2objc/j2objc-annotations</exclude>
+                    <exclude>META-INF/maven/org.slf4j/slf4j-api</exclude>
+                    <exclude>META-INF/maven/org.codehaus.plexus/plexus-classworlds</exclude>
+                    <exclude>META-INF/maven/net.java.dev.msv</exclude>
+                    <exclude>META-INF/maven/org.codehaus.plexus/plexus-utils</exclude>
+                    <exclude>META-INF/maven/com.jcraft</exclude>
+                    <exclude>META-INF/maven/com.jcraft/jsch</exclude>
+                    <exclude>META-INF/maven/commons-logging/commons-logging</exclude>
+                    <exclude>META-INF/maven/com.google.j2objc</exclude>
+                    <exclude>META-INF/maven/com.sun.xml.bind.jaxb/isorelax</exclude>
+                    <exclude>META-INF/maven/commons-io</exclude>
+                    <exclude>META-INF/maven/commons-io/commons-io</exclude>
+                    <exclude>META-INF/maven/org.codehaus.plexus/plexus-interpolation</exclude>
+                    <exclude>META-INF/maven/net.java.dev.msv/msv-core</exclude>
+                </excludes>
+            </unpackOptions>
             <scope>runtime</scope>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
The problem is that somehow directories in dependency jars become empty
files in the -jar-with-dependencies jars.  Not an issue when invoked via
java -jar, but Guilhem reports that this prevents the web app from
starting.

Good:

       0  Stored        0   0% 05-26-2014 21:18 00000000  META-INF/maven/commons-beanutils/

Bad:

       0  Defl:N        2   0% 05-26-2014 21:18 00000000  META-INF/maven/commons-beanutils

So the affected directories were found with
> unzip -v validator/target/odfvalidator-1.0.0-BETA2-SNAPSHOT-jar-with-dependencies.jar | grep "Defl:N *2 "

The jars in odfdom, xslt-runner are also affected.

Bisecting shows this started with:

commit 2a6d4fc2b45eed57f83604c5de92941629508ece

    Merging the ODF collaboration work from https://github.com/svanteschubert/odftoolkit/tree/odf-changes

... and bisecting in that git repo gives:

commit b04c5828ba32987adde85396d3ec82374c255124

    Merge of collaboration feature branch with main trunc. Becoming 1.0.0-SNAPSHOT of the ODF Toolkit at The Document Foundation (TDF)

... but it's not obvious what change caused this.

The only obvious work-around is not actually obvious but at least it's
quite undeniably ridiculous, and i disclaim any insight of why it
appears to give the correct result.

Note: i hope somebody has a better idea than this nonsense? Maybe @sebkur :)