### PR TITLE
Odfdom osgi bundle

### DIFF
--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -165,6 +165,7 @@
                 <configuration>
                     <archive>
                         <index>true</index>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         <manifest>
                             <mainClass>org.odftoolkit.odfdom.JarManifest</mainClass>
                         </manifest>
@@ -189,6 +190,29 @@
                         </manifestSections>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.1</version>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Import-Package>
+                                   org.odftoolkit.odfdom;version="${osgi.import.range}",
+                                   org.odftoolkit.odfdom.*;version="${osgi.import.range}",
+                                   *
+                                </Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>pl.project13.maven</groupId>

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/RDFaParser.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/RDFaParser.java
@@ -36,7 +36,6 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 import net.rootdev.javardfa.Constants;
-import net.rootdev.javardfa.ProfileCollector;
 import net.rootdev.javardfa.Setting;
 import net.rootdev.javardfa.literal.LiteralCollector;
 import net.rootdev.javardfa.uri.IRIResolver;
@@ -62,12 +61,7 @@ class RDFaParser extends net.rootdev.javardfa.Parser {
       XMLOutputFactory outputFactory,
       XMLEventFactory eventFactory,
       URIExtractor extractor) {
-    super(
-        sink,
-        outputFactory,
-        eventFactory,
-        new URIExtractor10(new IRIResolver()),
-        ProfileCollector.EMPTY_COLLECTOR);
+    super(sink, outputFactory, eventFactory, new URIExtractor10(new IRIResolver()));
     this.sink = sink;
     this.eventFactory = eventFactory;
     this.settings = EnumSet.noneOf(Setting.class);

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>net.rootdev</groupId>
                 <artifactId>java-rdfa</artifactId>
-                <version>1.0.0-BETA1-SNAPSHOT</version>
+                <version>1.0.0-BETA1</version>
             </dependency>
             <dependency>
                 <groupId>commons-validator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <release.zip.bin>odftoolkit-${project.version}-bin.zip</release.zip.bin>
         <release.zip.doc>odftoolkit-${project.version}-doc.zip</release.zip.doc>
         <release.zip.src>odftoolkit-${project.version}-src.zip</release.zip.src>
+        <osgi.import.range>[1.0,2)</osgi.import.range>
     </properties>
 
 
@@ -95,7 +96,7 @@
             <dependency>
                 <groupId>net.rootdev</groupId>
                 <artifactId>java-rdfa</artifactId>
-                <version>0.4.2</version>
+                <version>1.0.0-BETA1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>commons-validator</groupId>


### PR DESCRIPTION
This branch builds against the new java-rdfa-1.0.0-BETA1 release prepared by us.
Thus, it cleans up many dependency problems.
Additionally, it add OSGi bundle headers to the oodfdom jar file, which fixes #78 