### PR TITLE
validator: put git revision on main page of webapp

### DIFF
--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -92,6 +92,25 @@
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.4</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -115,6 +134,7 @@
                                 <manifestEntries>
                                     <ODFVALIDATOR-Name>odfvalidator</ODFVALIDATOR-Name>
                                     <ODFVALIDATOR-Version>${project.version}</ODFVALIDATOR-Version>
+                                    <ODFVALIDATOR-SCM>${git.commit.id}</ODFVALIDATOR-SCM>
                                     <ODFVALIDATOR-Website>${project.url}</ODFVALIDATOR-Website>
                                     <ODFVALIDATOR-Built-Date>${build.timestamp}</ODFVALIDATOR-Built-Date>
                                     <ODFVALIDATOR-Supported-Odf-Version>1.2</ODFVALIDATOR-Supported-Odf-Version>
@@ -195,6 +215,7 @@
                                 <manifestEntries>
                                     <ODFVALIDATOR-Name>odfvalidator</ODFVALIDATOR-Name>
                                     <ODFVALIDATOR-Version>${project.version}</ODFVALIDATOR-Version>
+                                    <ODFVALIDATOR-SCM>${git.commit.id}</ODFVALIDATOR-SCM>
                                     <ODFVALIDATOR-Website>${project.url}</ODFVALIDATOR-Website>
                                     <ODFVALIDATOR-Built-Date>${build.timestamp}</ODFVALIDATOR-Built-Date>
                                     <ODFVALIDATOR-Supported-Odf-Version>1.2</ODFVALIDATOR-Supported-Odf-Version>

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/JarManifest.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/JarManifest.java
@@ -46,6 +46,7 @@ public class JarManifest {
   private static final String INNER_JAR_MANIFEST_PATH = "META-INF/MANIFEST.MF";
   private static String ODFVALIDATOR_NAME;
   private static String ODFVALIDATOR_VERSION;
+  private static String ODFVALIDATOR_SCM;
   private static String ODFVALIDATOR_WEBSITE;
   private static String ODFVALIDATOR_BUILD_DATE;
   private static String ODFVALIDATOR_SUPPORTED_ODF_VERSION;
@@ -56,6 +57,7 @@ public class JarManifest {
       Attributes attr = manifest.getEntries().get("ODFVALIDATOR");
       ODFVALIDATOR_NAME = attr.getValue("ODFVALIDATOR-Name");
       ODFVALIDATOR_VERSION = attr.getValue("ODFVALIDATOR-Version");
+      ODFVALIDATOR_SCM = attr.getValue("ODFVALIDATOR-SCM");
       ODFVALIDATOR_WEBSITE = attr.getValue("ODFVALIDATOR-Website");
       ODFVALIDATOR_BUILD_DATE = attr.getValue("ODFVALIDATOR-Built-Date");
       ODFVALIDATOR_SUPPORTED_ODF_VERSION = attr.getValue("ODFVALIDATOR-Supported-Odf-Version");
@@ -71,9 +73,15 @@ public class JarManifest {
   private static InputStream getManifestAsStream() {
     String versionRef =
         JarManifest.class.getClassLoader().getResource(CURRENT_CLASS_RESOURCE_PATH).toString();
-    String manifestRef =
-        versionRef.substring(0, versionRef.lastIndexOf(CURRENT_CLASS_RESOURCE_PATH))
-            + INNER_JAR_MANIFEST_PATH;
+    String rootRef = versionRef.substring(0, versionRef.lastIndexOf(CURRENT_CLASS_RESOURCE_PATH));
+    // 1. in war file, manifest is in top-level META-INF but classes in subdir
+    // 2. somehow the URL is wrong, it's a file url to a directory named after
+    //    the .war file but without .war extension - fix it to look like the
+    //    one from .jar file
+    if (rootRef.endsWith("/WEB-INF/classes/")) {
+      rootRef = "jar:" + rootRef.substring(0, rootRef.lastIndexOf("/WEB-INF/classes/")) + ".war!/";
+    }
+    String manifestRef = rootRef + INNER_JAR_MANIFEST_PATH;
     URL manifestURL = null;
     InputStream in = null;
     try {
@@ -167,6 +175,11 @@ public class JarManifest {
    */
   public static String getVersion() {
     return ODFVALIDATOR_VERSION;
+  }
+
+  /** @return the git commit id */
+  public static String getSCMRevision() {
+    return ODFVALIDATOR_SCM;
   }
 
   /**

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/Main.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/Main.java
@@ -42,6 +42,7 @@ public class Main {
 
   // Versions of ODFDOM and ODF Validator are equal
   private static final String VERSION = JarManifest.getVersion();
+  private static final String SCM = JarManifest.getSCMRevision();
 
   /** Creates a new instance of Main */
   public Main() {}
@@ -152,6 +153,7 @@ public class Main {
     if (bPrintVersion) {
       System.out.print("odfvalidator v");
       System.out.println(VERSION);
+      System.out.println(SCM);
       System.exit(0);
     }
 

--- a/validator/src/main/webapp/jsp/validate.jsp
+++ b/validator/src/main/webapp/jsp/validate.jsp
@@ -24,6 +24,7 @@
 		 org.apache.commons.fileupload.FileItemIterator,
 		 org.apache.commons.fileupload.FileItemStream,
 		 org.apache.commons.fileupload.util.Streams,
+		 org.odftoolkit.odfvalidator.JarManifest,
 		 org.odftoolkit.odfvalidator.ODFValidator,
 		 org.odftoolkit.odfvalidator.Logger,
 		 org.odftoolkit.odfvalidator.Configuration,
@@ -189,6 +190,14 @@ if(ServletFileUpload.isMultipartContent(request)) {
 			alt="To reset this formular press this button." -->		
 		<input type="reset"  value="Reset"  />
 	</p>
+<p>Version info:
+<%
+    out.println(JarManifest.getLibraryName());
+    out.println(JarManifest.getVersion());
+    out.println(JarManifest.getSCMRevision());
+    out.println(JarManifest.getBuildDate());
+%>
+</p>
 </form>
 <%
 }


### PR DESCRIPTION
So that it's obvious to see what is deployed on odfvalidator.org.

Also print it in jar file when invoked with -V, because why not.

Use git-commit-id-plugin maven plugin for this.