### PR TITLE
ODFTOOLKIT-187: fix results of PuzzlePiece.extractPuzzlePieces()

### DIFF
--- a/generator/schema2template/src/main/java/schema2template/model/PuzzlePiece.java
+++ b/generator/schema2template/src/main/java/schema2template/model/PuzzlePiece.java
@@ -192,7 +192,7 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, QNamedPuzzleCompone
     if (retval != 0) {
       return retval;
     }
-    return hashCode() - o.hashCode();
+    return Integer.compare(hashCode(), o.hashCode());
   }
 
   /*

--- a/generator/schema2template/src/test/java/schema2template/example/odf/PuzzlePieceTest.java
+++ b/generator/schema2template/src/test/java/schema2template/example/odf/PuzzlePieceTest.java
@@ -35,7 +35,6 @@ import java.io.PrintWriter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import schema2template.model.MSVExpressionIterator;
 import schema2template.model.PuzzlePiece;
@@ -54,7 +53,7 @@ public class PuzzlePieceTest {
   private static final String OUTPUT_REF_ODF12 =
       TEST_REFERENCE_DIR + File.separator + "odf12-msvtree.ref";
   private static final int ODF12_ELEMENT_DUPLICATES = 7;
-  private static final int ODF12_ATTRIBUTE_DUPLICATES = 134;
+  private static final int ODF12_ATTRIBUTE_DUPLICATES = 116;
 
   /**
    * Test: Use the MSV
@@ -155,7 +154,6 @@ public class PuzzlePieceTest {
    * extract PuzzlePieces out of a XML schema
    */
   @Test
-  @Ignore // due to issue https://issues.apache.org/jira/browse/ODFTOOLKIT-180
   public void testExtractPuzzlePieces() {
     try {
       PuzzlePieceSet allElements_ODF11 = new PuzzlePieceSet();
@@ -189,7 +187,6 @@ public class PuzzlePieceTest {
    * extract PuzzlePieces out of a XML schema
    */
   @Test
-  @Ignore
   public void testExtractPuzzlePiecesWithDuplicates() {
     try {
       PuzzlePieceSet allElements_ODF12 = new PuzzlePieceSet();


### PR DESCRIPTION
This created nondeterministic and wrong results, somewhere in
reduceAttributes().

The reason appears to be that there are ordered containers like a
TreeSet<PuzzlePiece> in uniteDefinitionsWithEqualContent() involved
and the PuzzlePiece.compareTo() has a problem with overflow, so it
sometimes returns wrong results and then the TreeSet will be wrongly
sorted and it can't find some elements.

Just compare the integers properly and the result is deterministic.

(cherry picked from commit 335bab81ce988283d4418e4bdec4262c96073478)