### PR TITLE
Renaming release references from upcoming not yet existing releases to existing beta & release candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ build system. To build ODF Toolkit, use the following command in this directory:
 
 ## Recent Releases
 
-1. We have a release 0.10.0 using >=JDK 9 and providing the [new collaboration API](https://tdf.github.io/odftoolkit/odfdom/operations/operations.html):
+1. We have a *beta release of 0.10.0* using >=JDK 9 and providing the [new collaboration API](https://tdf.github.io/odftoolkit/odfdom/operations/operations.html):
+    *RELEASE (0.10.0 BETA)*:
+    (*Note*: the release was earlier called 1.0.0-BETA, but it lacks JDK module API and 1.0 was renamed 0.10)
+    * [ODFDOM](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/1.0.0-BETA1/)
+    * [ODF Validator](https://repo1.maven.org/maven2/org/odftoolkit/odfvalidator/1.0.0-BETA1/)
+    * [XSLT Runner](https://repo1.maven.org/maven2/org/odftoolkit/xslt-runner/1.0.0-BETA1/)
 
-    *RELEASE (0.10.0)*:
-    * [ODFDOM](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.10.0/)
-    * [ODF Validator](https://repo1.maven.org/maven2/org/odftoolkit/odfvalidator/0.10.0/)
-    * [XSLT Runner](https://repo1.maven.org/maven2/org/odftoolkit/xslt-runner/0.10.0/)
+2. We have a *release candidate of 0.9.0* using JDK 8 and for the final time including the Simple API:
 
-2. We have a release 0.9.0 using JDK 8 and for the final time including the Simple API:
-
-    *RELEASE (0.9.0)*:
-    * [ODFDOM](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.9.0/)
-    * [ODF Validator](https://repo1.maven.org/maven2/org/odftoolkit/odfvalidator/0.9.0/)
-    * [XSLT Runner](https://repo1.maven.org/maven2/org/odftoolkit/xslt-runner/0.9.0/)
-    * [Simple API (deprecated)](https://repo1.maven.org/maven2/org/odftoolkit/simple-odf/0.9.0/)
+    *RELEASE (0.9.0 RC)*:
+    * [ODFDOM](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.9.0-RC1/)
+    * [ODF Validator](https://repo1.maven.org/maven2/org/odftoolkit/odfvalidator/0.9.0-RC1/)
+    * [XSLT Runner](https://repo1.maven.org/maven2/org/odftoolkit/xslt-runner/0.9.0-RC1/)
+    * [Simple API (deprecated)](https://repo1.maven.org/maven2/org/odftoolkit/simple-odf/0.9.0-RC1/)
 
 For more details see the [release notes](https://tdf.github.io/odftoolkit/ReleaseNotes.html).
 

--- a/docs/ReleaseNotes.html
+++ b/docs/ReleaseNotes.html
@@ -52,10 +52,10 @@
       <p><a href="https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.10.0/">ODFDOM 0.10.0</a> is released on July 7th, 2021. Major updates are coming with this version:</p> 
       <ul> 
         <li>JDK 9 (or higher) is required to build</li> 
-        <li><strong>Collaboration API</strong>: No developer would ever sent a zipped repository for exchangin work with other developers. Still we are doing this by zipping document and sending those. To be able to dispatch only changes among collaborators new functionalty had bee added: Any OpenDocumen Text can now be transformed into an equal sequence of user changes (<a href="../docs/presentations/character-styles.odt">ODT</a>/<a href="../docs/presentations/character-styles.json">JSON</a>). This list of user changes is like a batch of text operations, similar as if the user would created the document from top to the bottom. Formost, new user changes can be merged into the existing document via JSON. For more details see the <a href="./operations/operations.html">list of supported changes/operations</a></li> 
+        <li><strong>Collaboration API</strong>: No developer would ever sent a zipped repository for exchanging work with other developers. Still we are doing this by zipping document and sending those. To be able to dispatch only changes among collaborators new functionality had bee added: Any OpenDocument Text can now be transformed into an equal sequence of user changes (<a href="../docs/presentations/character-styles.odt">ODT</a>/<a href="../docs/presentations/character-styles.json">JSON</a>). This list of user changes is like a batch of text operations, similar as if the user would created the document from top to the bottom. Foremost, new user changes can be merged into the existing document via JSON. For more details see the <a href="./operations/operations.html">list of supported changes/operations</a></li> 
         <li>Many Fixes &amp; enhancements, which were done over several years by merging (more an overwriting) with the former Open-XChange ODFDOM fork.</li> 
       </ul> 
-      <h3 id="github-issues-fixed-in-this-release:">GitHub issues fixed in this release:</h3> 
+      <h3 id="github-issues-fixed-in-this-release-0.10.0">GitHub issues fixed in this release 0.10.0</h3> 
       <ul> 
         <li>#70 ODFDOM should support XML default namespace</li> 
         <li>#78 Make odfdom-java an OSGi bundle</li> 
@@ -72,19 +72,19 @@
         <li>Many fixes &amp; enhancements</li> 
         <li>Another <a href="https://github.com/tdf/odftoolkit/commit/8256ac43df9559890c6c7d68808383129124cd0a">anomaly in the generator was fixed</a>.</li> 
       </ul> 
-      <h3 id="github-issues-fixed-in-this-release:">GitHub issues fixed in this release:</h3> 
+      <h3 id="github-issues-fixed-in-this-release-0.9.0">GitHub issues fixed in this release 0.9.0</h3> 
       <ul> 
         <li>#7 Clarify Java Version?</li> 
         <li>#12 Travis does not download artifacts from different Maven repos</li> 
         <li>#15 Avoiding Whitespace Noise from Commits by Automation/GitHooks</li> 
-        <li>#23 Small mistake in odftoolkit v0.9RC description?</li> 
+        <li>#23 Small mistake in Odftoolkit v0.9RC description?</li> 
         <li>#30 Add regression tests for MarkDown to HTML creation</li> 
         <li>#49 Memory Leak in ODF Simple API</li> 
         <li>#50 Java Formatter triggered by Maven</li> 
         <li>#55 Update to modern Jena</li> 
         <li>#84 Upgrade libs to prevent security issues - CVE</li> 
       </ul> 
-      <h3 id="asf-jira-issues-fixed-in-this-release:">ASF JIRA issues fixed in this release:</h3> 
+      <h3 id="asf-jira-issues-fixed-in-this-release-0.9.0">ASF JIRA issues fixed in this release 0.9.0</h3> 
       <ul> 
         <li><a href="https://issues.apache.org/jira/browse/ODFTOOLKIT-187">ODFTOOLKIT-187</a> was <a href="https://github.com/tdf/odftoolkit/commit/5e0e6a0ce124f9d6aefc005389bef2cd8e55d0ec">fixed</a>.</li> 
         <li>ODFTOOLKIT-415 Replace/Upgrade jena dependency with org.apache.jena:jena-core:3.x</li> 

--- a/docs/website-development.html
+++ b/docs/website-development.html
@@ -96,13 +96,12 @@
       <h2 id="building-javadoc-and-publishing-the-javadoc">Building JavaDoc and publishing the JavaDoc</h2> 
       <p>JavaDoc is generated as part of by calling from the root of the project the command:</p> 
       <div class="codehilite">
-        <pre><code class="language-shell">mvn clean install
+        <pre><code class="language-shell">(mvn install &amp;&amp; cd odfdom &amp;&amp; mvn javadoc:javadoc)
 </code></pre>
       </div> 
       <p>Run <code>copy-javadoc.sh</code> to build &amp; copy the created API directories into the &lt;ODFTOOLKIT_ROOT&gt;/docs/api directory and remove any prior files within.</p> 
       <div class="codehilite">
-        <pre><code class="language-shell">cd odftoolkit/src/site/java
-./copy-javadoc.sh
+        <pre><code class="language-shell">(cd src/site/java &amp;&amp; ./copy-javadoc.sh)
 </code></pre>
       </div> 
       <h2 id="submitting-your-results">Submitting your results</h2> 

--- a/src/site/site/content/odftoolkit_website/ReleaseNotes.mdtext
+++ b/src/site/site/content/odftoolkit_website/ReleaseNotes.mdtext
@@ -5,12 +5,13 @@
 [ODFDOM 0.10.0](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.10.0/) is released on July 7th, 2021. Major updates are coming with this version:
 
 * JDK 9 (or higher) is required to build
-* **Collaboration API**: No developer would ever sent a zipped repository for exchangin work with other developers. Still we are doing this by zipping document and sending those. To be able to dispatch only changes among collaborators new functionalty had bee added: Any OpenDocumen Text can now be transformed into an equal sequence of user changes ([ODT](../docs/presentations/character-styles.odt)/[JSON](../docs/presentations/character-styles.json)).
- This list of user changes is like a batch of text operations, similar as if the user would created the document from top to the bottom. Formost, new user changes can be merged into the existing document via JSON.
+* **Collaboration API**: No developer would ever sent a zipped repository for exchanging work with other developers. Still we are doing this by zipping document and sending those. To be able to dispatch only changes among collaborators new functionality had bee added: Any OpenDocument Text can now be transformed into an equal sequence of user changes ([ODT](../docs/presentations/character-styles.odt)/[JSON](../docs/presentations/character-styles.json)).
+ This list of user changes is like a batch of text operations, similar as if the user would created the document from top to the bottom. Foremost, new user changes can be merged into the existing document via JSON.
  For more details see the [list of supported changes/operations](./operations/operations.html)
 * Many Fixes & enhancements, which were done over several years by merging (more an overwriting) with the former Open-XChange ODFDOM fork.
 
-### GitHub issues fixed in this release:
+### GitHub issues fixed in this release 0.10.0
+
 * #70 ODFDOM should support XML default namespace
 * #78 Make odfdom-java an OSGi bundle
 
@@ -27,18 +28,20 @@
 * Many fixes & enhancements
 * Another [anomaly in the generator was fixed](https://github.com/tdf/odftoolkit/commit/8256ac43df9559890c6c7d68808383129124cd0a).
 
-### GitHub issues fixed in this release:
+### GitHub issues fixed in this release 0.9.0
+
 * #7 Clarify Java Version?
 * #12 Travis does not download artifacts from different Maven repos
 * #15 Avoiding Whitespace Noise from Commits by Automation/GitHooks
-* #23 Small mistake in odftoolkit v0.9RC description?
+* #23 Small mistake in Odftoolkit v0.9RC description?
 * #30 Add regression tests for MarkDown to HTML creation
 * #49 Memory Leak in ODF Simple API
 * #50 Java Formatter triggered by Maven
 * #55 Update to modern Jena
 * #84 Upgrade libs to prevent security issues - CVE
 
-### ASF JIRA issues fixed in this release:
+### ASF JIRA issues fixed in this release 0.9.0
+
 * [ODFTOOLKIT-187](https://issues.apache.org/jira/browse/ODFTOOLKIT-187) was [fixed](https://github.com/tdf/odftoolkit/commit/5e0e6a0ce124f9d6aefc005389bef2cd8e55d0ec).
 * ODFTOOLKIT-415 Replace/Upgrade jena dependency with org.apache.jena:jena-core:3.x
 * ODFTOOLKIT-448 Upgrade Java version to JDK 8
@@ -50,4 +53,3 @@
 [Historic release notes from ASF incubator times can be found here](https://github.com/tdf/odftoolkit/blob/master/CHANGES.txt)
 
 [Historic release notes of ODFDOM can be found here](./odfdom/HistoricReleaseNotes.html)
-

--- a/src/site/site/content/odftoolkit_website/index.mdtext
+++ b/src/site/site/content/odftoolkit_website/index.mdtext
@@ -28,11 +28,9 @@ People interested should follow the [mail list](mailing-lists.html) to track pro
 
 ## History
 
-### 2021-07-07 - ODF Toolkit releases of 0.9.0 and 0.10.0
+### 2020-01-29 - ODF Toolkit releases of 0.9.0-rc and 0.10.0-beta (earlier/yet named 1.0.0-beta)
 
 See the [downloads page](downloads.html) for more details on the releases.
-
-### 2020-01-29 - ODF Toolkit releases of 0.9.0-rc and 1.0.0-beta
 
 ### 2018-12-18 - ODF Toolkit becomes a project of The Document Foundation (TDF)
 


### PR DESCRIPTION
I have finally updated the once broken reference in the README.md (which happened some time ago when the master branch was renamed).

The release 0.10.0 requires an update of the code generation, which contained several "unknown unknown" problems and took much longer than expected, see https://github.com/svanteschubert/odftoolkit/tree/odf12-codegen
(I have created a milestone last week and had to postpone the work to October due to a release from a different project of mine).

Note that the 1.0.0 release was renamed to 0.10.0 as the Java package module was not yet added and deemed as a minimum for =>JDK 9.