### PR TITLE
Remove dependency to xml-apis:xml-apis.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <!-- never use version 2.0.2 as it is prior version 1.4.01 -->
-                <!-- see https://mvnrepository.com/artifact/xml-apis/xml-apis -->
-                <version>1.4.01</version>
-            </dependency>
-            <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>2.12.1</version>


### PR DESCRIPTION
No longer needed for Java 11 and above.
Also solves compilation problems for users who enforce
Java 9 modular compilation (https://github.com/tdf/odftoolkit/issues/54#issuecomment-968061438)

Closes #131.