### PR TITLE
FIXING: Logging error message, when executing ODFDOM JAR by command line

### DIFF
--- a/docs/website-development.html
+++ b/docs/website-development.html
@@ -96,13 +96,12 @@
       <h2 id="building-javadoc-and-publishing-the-javadoc">Building JavaDoc and publishing the JavaDoc</h2> 
       <p>JavaDoc is generated as part of by calling from the root of the project the command:</p> 
       <div class="codehilite">
-        <pre><code class="language-shell">mvn clean install
+        <pre><code class="language-shell">(mvn install &amp;&amp; cd odfdom &amp;&amp; mvn javadoc:javadoc)
 </code></pre>
       </div> 
       <p>Run <code>copy-javadoc.sh</code> to build &amp; copy the created API directories into the &lt;ODFTOOLKIT_ROOT&gt;/docs/api directory and remove any prior files within.</p> 
       <div class="codehilite">
-        <pre><code class="language-shell">cd odftoolkit/src/site/java
-./copy-javadoc.sh
+        <pre><code class="language-shell">(cd src/site/java &amp;&amp; ./copy-javadoc.sh)
 </code></pre>
       </div> 
       <h2 id="submitting-your-results">Submitting your results</h2> 

--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -86,25 +86,16 @@
             <artifactId>json</artifactId>
             <version>20190722</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-jdk14
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.8.0-beta4</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.8.0-beta4</version>
-        </dependency>-->
-        <!-- http://logging.apache.org/log4j/2.x/log4j-slf4j-impl/index.html
-        NOTE: SLF4J and LOG4J dependencies are given directly in pom.xml
+            <version>1.7.32</version>
+        </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j18-impl</artifactId>
-            <version>2.12.1</version>
-        </dependency>-->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.32</version>
+        </dependency>
         <dependency>
             <groupId>io.github.git-commit-id</groupId>
             <artifactId>git-commit-id-maven-plugin</artifactId>
@@ -208,7 +199,7 @@
                                    org.odftoolkit.odfdom;version="${osgi.import.range}",
                                    org.odftoolkit.odfdom.*;version="${osgi.import.range}",
                                    *
-                                </Import-Package>
+</Import-Package>
                             </instructions>
                         </configuration>
                     </execution>
@@ -459,7 +450,7 @@
         portable to any object-oriented language.
 
         The current reference implementation is written in Java.
-    </description>
+</description>
     <url>https://odftoolkit.org/odfdom/</url>
     <inceptionYear>2008</inceptionYear>
 


### PR DESCRIPTION
You some test ODT, for instance, https://tdf.github.io/odftoolkit/docs/presentations/character-styles.odt
And use the latest release JAR (with all dependencies), you may find here:
https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.10.0/odfdom-java-0.10.0-jar-with-dependencies.jar

java -jar .\odfdom-java-0.10.0-jar-with-dependencies.jar character-styles.odt

The following error message will be displayed ahead of the ODT expressed as change operations:
_SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details._

Applying the fix described on [StackOverflow](https://stackoverflow.com/questions/7421612/slf4j-failed-to-load-class-org-slf4j-impl-staticloggerbinder) worked.

Any comments or improvements?