### PR TITLE
Remove spurious dependencies to org.json and git-commit-id-maven plugin.

### DIFF
--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -86,12 +86,6 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.json/json -->
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20190722</version>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -101,11 +95,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.32</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.git-commit-id</groupId>
-            <artifactId>git-commit-id-maven-plugin</artifactId>
-            <version>5.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -86,6 +86,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20190722</version>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
Fixes #142.

New dependencies:
```
[INFO] org.odftoolkit:odfdom-java:jar:0.11.0-SNAPSHOT
[INFO] +- xerces:xercesImpl:jar:2.12.1:compile
[INFO] +- xalan:serializer:jar:2.7.2:compile
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.apache.jena:jena-core:jar:4.3.0:compile
[INFO] |  +- org.apache.jena:jena-base:jar:4.3.0:compile
[INFO] |  |  +- org.apache.jena:jena-shaded-guava:jar:4.3.0:compile
[INFO] |  |  +- org.apache.commons:commons-csv:jar:1.9.0:compile
[INFO] |  |  +- commons-io:commons-io:jar:2.11.0:compile
[INFO] |  |  +- commons-codec:commons-codec:jar:1.15:compile
[INFO] |  |  \- com.github.andrewoma.dexx:collection:jar:0.7:compile
[INFO] |  +- org.apache.jena:jena-iri:jar:4.3.0:compile
[INFO] |  \- commons-cli:commons-cli:jar:1.5.0:compile
[INFO] +- org.apache.jena:jena-core:jar:tests:4.3.0:test
[INFO] +- net.rootdev:java-rdfa:jar:1.0.0-BETA1:compile
[INFO] +- commons-validator:commons-validator:jar:1.7:compile
[INFO] |  +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] |  +- commons-digester:commons-digester:jar:2.1:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] +- org.slf4j:slf4j-api:jar:1.7.32:compile
[INFO] +- org.slf4j:slf4j-simple:jar:1.7.32:compile
[INFO] \- org.apache.commons:commons-compress:jar:1.21:compile
```