### PR TITLE
Automated GitHub Deployment by GitHub Action

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,39 @@
+name: Publish JAR on tagging
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        cache: maven
+    - name: Build with Maven # build, test & package sources & create 3 ZIP for all bin, doc and src deliverables!
+      run: mvn -B install -Ppedantic,prepare-release --file pom.xml
+    - name: Read pom.xml to get version for new release # The following step reads the pom.xml from repo and use its version for the release
+      run: |
+        echo "release_version=$(cat pom.xml | grep -a -m 1 "<version>" | sed 's/.*<version>//p' | head -1 | sed 's/<\/version>//p' | head -1)" >> $GITHUB_ENV
+    - name: Upload binaries as GitHub release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/**/*.*
+        tag: odftoolkit-${{ env.release_version }}  # <--- Use environment variables that was created before
+        overwrite: true
+        file_glob: true
+        body: "Support of **ODF 1.2** and >=**JDK 11**\n
+\n
+Detailed documentation:\n
+https://tdf.github.io/odftoolkit/ReleaseNotes.html#release-${{ env.release_version }}\n
+\n
+Available via Maven repository:\n
+https://oss.sonatype.org/content/groups/public/org/odftoolkit/\n
+\n"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,4 +19,4 @@ jobs:
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package -Ppedantic --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,11 +3,7 @@
 
 name: Java CI with Maven
 
-on:
-  push:
-    branches: [ master, 0.9 ]
-  pull_request:
-    branches: [ master, 0.9 ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -23,4 +19,4 @@ jobs:
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package -Ppedantic --file pom.xml
+      run: mvn -B package --file pom.xml

--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -200,7 +200,7 @@
                                    org.odftoolkit.odfdom;version="${osgi.import.range}",
                                    org.odftoolkit.odfdom.*;version="${osgi.import.range}",
                                    *
-</Import-Package>
+                                </Import-Package>
                             </instructions>
                         </configuration>
                     </execution>
@@ -413,7 +413,7 @@
         portable to any object-oriented language.
 
         The current reference implementation is written in Java.
-</description>
+    </description>
     <url>https://odftoolkit.org/odfdom/</url>
     <inceptionYear>2008</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         (ISO/IEC 26300 == ODF) documents. Unlike other approaches which rely on
         runtime manipulation of heavy-weight editors via an automation
         interface, the ODF Toolkit is lightweight and ideal for server use.
-</description>
+    </description>
     <url>https://odftoolkit.org</url>
     <organization>
         <name>The Document Foundation</name>
@@ -165,7 +165,7 @@
         <repository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-</url>
+            </url>
         </repository>
         <!-- not used for deployment but only for site:stage goal -->
         <site>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -311,7 +311,7 @@
     <name>ODF Validator</name>
     <description>
         ODF Validator is a tool that validates OpenDocument files and checks them for certain conformance criteria.
-</description>
+    </description>
     <url>https://odfvalidator.org/</url>
     <inceptionYear>2008</inceptionYear>
     <licenses>


### PR DESCRIPTION
I have started looking into GitHub actions over the holidays and created GitHub action that makes an automatic GitHub deployment whenever a Git tag is being added. 

For example:
- git tag -sm 0.11.0-SNAPSHOT 0.11.0-SNAPSHOT
- git push --follow-tags

results to https://github.com/svanteschubert/odftoolkit/releases/tag/odftoolkit-0.11.0-SNAPSHOT
(Note: I used a test tag 0.10.11 instead of 0.11.0-SNAPSHOT, but the version is being extracted in the action from the pom)

If someone does not like the commit message as part of the title (like me), it still seems an easy manual tweak - as I have not found out how this is handled by the plugin https://github.com/svenstaro/upload-release-action I am using. ;-)
There was once an official GitHub plugin, but this is for some unknown reason no longer supported: https://github.com/actions/create-release

I have not completely wrapped my head around their actions concepts, for instance, I am not able to limit the events, currently, it is building the toolkit sometimes twice, once for the push event and once for the tag event, but only skimmed their documentation: https://docs.github.com/en/actions/quickstart

There is also a way to do an automated maven release see https://blog.frankel.ch/github-actions-maven-releases/
Might try such action for the next release for some special tag :-)

