### PR TITLE
Update Maven JavaDoc plugin due to: 'Error while generating Javadoc: …

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -43,7 +43,6 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
                     <configuration>
                         <!-- defined in the parent pom.xml -->
                         <source>${jdk.version}</source>
@@ -55,7 +54,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -68,7 +66,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <!-- Workaround: Build the project using the same JDK version as the project is targetting.
                         see https://issues.apache.org/jira/browse/MJAVADOC-562

--- a/generator/schema2template-maven-plugin/pom.xml
+++ b/generator/schema2template-maven-plugin/pom.xml
@@ -77,7 +77,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.4</version>
                 <configuration>
                     <goalPrefix>schema2template</goalPrefix>
                 </configuration>
@@ -85,7 +85,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <!-- Workaround: Build the project using the same JDK version as the project is targetting.
                         see https://issues.apache.org/jira/browse/MJAVADOC-562
@@ -116,7 +115,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/generator/schema2template/pom.xml
+++ b/generator/schema2template/pom.xml
@@ -55,12 +55,12 @@
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>neo4j-gremlin</artifactId>
-            <version>3.5.2</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>tinkergraph-gremlin</artifactId>
-            <version>3.5.2</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -85,7 +85,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <index>true</index>
@@ -127,7 +126,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
                     <!-- defined in the parent pom.xml -->
                     <source>${jdk.version}</source>
@@ -138,7 +136,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <!-- Workaround: Build the project using the same JDK version as the project is targetting.
                         see https://issues.apache.org/jira/browse/MJAVADOC-562
@@ -169,7 +166,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -185,7 +181,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <doctitle>Schema2template</doctitle>
                     <!-- JDK 8 as workaround for exception,

--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -112,7 +112,6 @@
         <skipTests>false</skipTests>
         <maven.javadoc.skip>false</maven.javadoc.skip>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss</maven.build.timestamp.format>
     </properties>
 
@@ -122,38 +121,14 @@
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-webdav-jackrabbit</artifactId>
-                <version>3.4.3</version>
+                <version>3.5.1</version>
             </extension>
         </extensions>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <!-- defined in the parent pom.xml -->
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                    <testSource>${jdk.version}</testSource>
-                    <testTarget>${jdk.version}</testTarget>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <!--
-                    <compilerArgs>
-                        <arg>-Xlint:unchecked</arg>
-                        <arg>-Xlint:deprecation</arg>
-                    </compilerArgs>
-                    -->
-                    <!--
-                    <compilerArgs>
-                        <arg>-verbose</arg>
-                        <arg>-Xlint:all,-options,-path</arg>
-                    </compilerArgs>
-                    -->
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.2</version>
                 <configuration>
                     <archive>
                         <index>true</index>
@@ -186,7 +161,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.2</version>
+                <version>5.1.4</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -255,7 +230,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <!-- Workaround: Build the project using the same JDK version as the project is targetting.
                         see https://issues.apache.org/jira/browse/MJAVADOC-562
@@ -307,7 +281,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>23</version>
+        <version>26</version>
         <relativePath/>
     </parent>
 
@@ -230,6 +230,51 @@
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <!-- defined in the parent pom.xml -->
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <testSource>${jdk.version}</testSource>
+                    <testTarget>${jdk.version}</testTarget>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <!--
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                        <arg>-Xlint:deprecation</arg>
+                    </compilerArgs>
+                    -->
+                    <!--
+                    <compilerArgs>
+                        <arg>-verbose</arg>
+                        <arg>-Xlint:all,-options,-path</arg>
+                    </compilerArgs>
+                    -->
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.0</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+            </plugin>
             <plugin>
                 <groupId>com.cosium.code</groupId>
                 <artifactId>git-code-format-maven-plugin</artifactId>

--- a/taglets/pom.xml
+++ b/taglets/pom.xml
@@ -39,18 +39,8 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <!-- defined in the parent pom.xml -->
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <!-- Workaround: Build the project using the same JDK version as the project is targetting.
                         see https://issues.apache.org/jira/browse/MJAVADOC-562
@@ -76,18 +66,6 @@
                                 <additionalOption>${javadoc.opts}</additionalOption>
                             </additionalOptions>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -84,7 +84,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
                     <!-- defined in the parent pom.xml -->
                     <source>${jdk.version}</source>
@@ -116,7 +115,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.3.2</version>
                 <configuration>
                     <archive>
                         <index>true</index>
@@ -159,7 +158,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <!-- Workaround: Build the project using the same JDK version as the project is targetting.
                         see https://issues.apache.org/jira/browse/MJAVADOC-562
@@ -190,7 +188,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -269,7 +266,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <doctitle>Validator</doctitle>
                     <links>

--- a/xslt-runner/pom.xml
+++ b/xslt-runner/pom.xml
@@ -240,7 +240,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
                 <configuration>
                     <!-- defined in the parent pom.xml -->
                     <source>${jdk.version}</source>
@@ -275,7 +274,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <!-- Workaround: Build the project using the same JDK version as the project is targetting.
                         see https://issues.apache.org/jira/browse/MJAVADOC-562
@@ -306,7 +304,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
…Unable to compute stale date: Input length = 1' and moving updated mavin plugin versions to root pom.xml

Triggered by a failed build due to a version update: https://github.com/tdf/odftoolkit/actions/runs/2243991608
I ran into a JavaDoc build problem with the latest Oracle JDK 17 build 2 (also with the latest build 3) and the latest Windows 10 updates (succeeded under Ubuntu Linux using OpenJDK 11).

This build problem could be fixed by updating to the latest Maven JavaDoc plugin.

Took the opportunity to update other Maven plugins and the Tinkerpop dependency that failed to build this morning.
Finally, mentioned the common maven plugin version as well in the root pom.xml and neglected the version in the child pom.xml. Sometimes additional configurations are necessary like for JavaDoc and JAR Maven plugin therefore a move was not possible, just a copy without configuration.

@all: Anything I might have overseen? Any further tweaks that come to your mind?
@mistmist Would you be so kind doing the review?

Build tested successfully using the above-mentioned platforms!