### PR TITLE
Fixes #215: validator: build additional plain jar file

### DIFF
--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -101,6 +101,7 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.3.2</version>
                 <configuration>
+                    <archiveClasses>true</archiveClasses>
                     <archive>
                         <index>true</index>
                         <manifest>


### PR DESCRIPTION
Neither the .war file nor the -with-dependencies.jar file can be easily reused as a Maven dependency; let's try if this works better.