### PR TITLE
Fixing package name for validator main class

### DIFF
--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -105,7 +105,7 @@
                     <archive>
                         <index>true</index>
                         <manifest>
-                            <mainClass>org.odftoolkit.validator.Main</mainClass>
+                            <mainClass>org.odftoolkit.odfvalidator.Main</mainClass>
                         </manifest>
                         <manifestEntries>
                             <version>${project.version}</version>
@@ -295,7 +295,7 @@
     <name>ODF Validator</name>
     <description>
         ODF Validator is a tool that validates OpenDocument files and checks them for certain conformance criteria.
-    </description>
+</description>
     <url>https://odfvalidator.org/</url>
     <inceptionYear>2008</inceptionYear>
     <licenses>


### PR DESCRIPTION
Realized there the package of the main class was wrong when I tested the JAR of the SNAPSHOT:
https://oss.sonatype.org/content/repositories/snapshots/org/odftoolkit/odfvalidator/0.12.0-SNAPSHOT/odfvalidator-0.12.0-20230525.140541-5-classes.jar
