### PR TITLE
Improved navigation interface, added next() method

### DIFF
--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/Navigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/Navigation.java
@@ -50,7 +50,7 @@ public abstract class Navigation {
    *
    * @return the current Selection result
    */
-  public abstract Selection getCurrentItem();
+  public abstract Selection getSelection();
 
   /**
    * check if the element match the user defined condition

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/Navigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/Navigation.java
@@ -19,6 +19,7 @@
 package org.odftoolkit.odfdom.incubator.search;
 
 import org.w3c.dom.Node;
+import org.odftoolkit.odfdom.pkg.OdfElement;
 
 /**
  * Abstract class Navigation used to navigate the document and find the matched element by the user
@@ -35,6 +36,14 @@ public abstract class Navigation {
    */
   public abstract boolean hasNext();
   // abstract public void gotoPrevious();
+
+  /*
+   * Return the element from the current matching selection.
+   * Use hasNext() to navigate to the next element.
+   *
+   * @return OdfElement of the current item or null if not element exists.
+   */
+  public abstract OdfElement next();
 
   /**
    * get the current Selection result

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextNavigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextNavigation.java
@@ -162,11 +162,16 @@ public class TextNavigation extends Navigation {
     int nextIndex = -1;
     Matcher matcher = mPattern.matcher(content);
     // start from the end index of the selected item
-    if (matcher.find(index + selected.getText().length())) {
-      // here just consider \n\r\t occupy one char
-      nextIndex = matcher.start();
-      int eIndex = matcher.end();
-      mCurrentText = content.substring(nextIndex, eIndex);
+    try {
+      if (matcher.find(index + selected.getText().length())) {
+        // here just consider \n\r\t occupy one char
+        nextIndex = matcher.start();
+        int eIndex = matcher.end();
+        mCurrentText = content.substring(nextIndex, eIndex);
+      }
+    } catch (IndexOutOfBoundsException e) {
+      // can occur in case the text length is equal the pattern length
+      return -1;
     }
     return nextIndex;
   }
@@ -187,6 +192,20 @@ public class TextNavigation extends Navigation {
   public boolean hasNext() {
     mCurrentSelectedItem = findnext(mCurrentSelectedItem);
     return (mCurrentSelectedItem != null);
+  }
+
+  /*
+   * Return the element from the current matching selection.
+   * Use hasNext() to navigate to the next element.
+   *
+   * @return OdfElement of the current item or null if not element exists.
+   */
+  @Override
+  public OdfElement next() {
+    if (getCurrentItem()!=null) {
+      return getCurrentItem().getElement();
+    }
+    return null;
   }
 
   /**

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextNavigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextNavigation.java
@@ -170,8 +170,8 @@ public class TextNavigation extends Navigation {
         mCurrentText = content.substring(nextIndex, eIndex);
       }
     } catch (IndexOutOfBoundsException e) {
-      // can occur in case the text length is equal the pattern length
-      return -1;
+       // can occur in case the text of the selection was manipulated from the client
+       return -1;
     }
     return nextIndex;
   }
@@ -180,7 +180,7 @@ public class TextNavigation extends Navigation {
    * @see org.odftoolkit.odfdom.incubator.search.Navigation#getCurrentItem()
    */
   @Override
-  public Selection getCurrentItem() {
+  public Selection getSelection() {
     Selection.SelectionManager.registerItem(mCurrentSelectedItem);
     return mCurrentSelectedItem;
   }
@@ -202,8 +202,8 @@ public class TextNavigation extends Navigation {
    */
   @Override
   public OdfElement next() {
-    if (getCurrentItem()!=null) {
-      return getCurrentItem().getElement();
+    if (getSelection()!=null) {
+      return getSelection().getElement();
     }
     return null;
   }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
@@ -128,6 +128,20 @@ public class TextStyleNavigation extends Navigation {
     return (mCurrentSelectedItem != null);
   }
 
+  /*
+   * Return the element from the current matching selection.
+   * Use hasNext() to navigate to the next element.
+   *
+   * @return OdfElement of the current item or null if not element exists.
+   */
+  @Override
+  public OdfElement next() {
+    if (getCurrentItem()!=null) {
+      return getCurrentItem().getElement();
+    }
+    return null;
+  }
+
   /**
    * check if the element has the specified style properties
    *

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
@@ -113,7 +113,7 @@ public class TextStyleNavigation extends Navigation {
    * @see org.odftoolkit.odfdom.incubator.search.Navigation#getCurrentItem()
    */
   @Override
-  public Selection getCurrentItem() {
+  public Selection getSelection() {
     Selection.SelectionManager.registerItem(mCurrentSelectedItem);
     return mCurrentSelectedItem;
   }
@@ -136,8 +136,8 @@ public class TextStyleNavigation extends Navigation {
    */
   @Override
   public OdfElement next() {
-    if (getCurrentItem()!=null) {
-      return getCurrentItem().getElement();
+    if (getSelection()!=null) {
+      return getSelection().getElement();
     }
     return null;
   }

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableRowColumnTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableRowColumnTest.java
@@ -203,7 +203,7 @@ public class TableRowColumnTest {
     // get the text content contains "cell"
     TextNavigation search = new TextNavigation("cell", odtdoc);
     while (search.hasNext()) {
-      TextSelection item = (TextSelection) search.getCurrentItem();
+      TextSelection item = (TextSelection) search.getSelection();
       OdfElement containerEle = item.getContainerElement();
       if (containerEle instanceof OdfTextParagraph) {
         Node ele = containerEle.getParentNode();

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/MONPTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/MONPTest.java
@@ -45,7 +45,7 @@ public class MONPTest {
 
       int i = 0;
       while (search.hasNext()) {
-        TextSelection item = (TextSelection) search.getCurrentItem();
+        TextSelection item = (TextSelection) search.getSelection();
         try {
           item.replaceWith("success");
           i++;

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/TextNavigationTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/TextNavigationTest.java
@@ -69,7 +69,7 @@ public class TextNavigationTest {
     search = new TextNavigation("delete", doc);
 
     while (search.hasNext()) {
-      TextSelection item = (TextSelection) search.getCurrentItem();
+      TextSelection item = (TextSelection) search.getSelection();
       LOG.info(item.toString());
     }
   }
@@ -111,4 +111,52 @@ public class TextNavigationTest {
       Assert.fail("Failed with " + e.getClass().getName() + ": '" + e.getMessage() + "'");
     }
   }
+
+
+
+  /** Test methods hasNext and next of org.odftoolkit.odfdom.incubator.search.TextNavigation */
+  @Test
+  public void testHasNextNext() {
+    String phrase="";
+    try {
+      phrase="<%NAME%>";
+			search = new TextNavigation(phrase, doc);
+			while (search.hasNext()) {
+        TextSelection item = (TextSelection) search.getSelection();
+        LOG.info(item.toString());
+        OdfElement element =search.next();
+
+				String text=element.getTextContent();
+				Logger logger = Logger.getLogger(TextNavigationTest.class.getName());
+        logger.log(Level.INFO," Current Item Text="+text);
+				element.setTextContent("John Doe");
+			}
+
+
+      // test the phrase 'ODFDOM' which should occur in 4 paragraphs
+      phrase="ODFDOM";
+      int countParagraphs=0;
+			search = new TextNavigation(phrase, doc);
+			while (search.hasNext()) {
+
+        TextSelection item = (TextSelection) search.getSelection();
+        LOG.info(item.toString());
+
+				OdfElement element = search.next();
+				String text=element.getTextContent();
+				Logger logger = Logger.getLogger(TextNavigationTest.class.getName());
+        logger.log(Level.INFO," Current Item Text="+text);
+        text=text.replace(phrase, "Software Project");
+				element.setTextContent(text);
+        countParagraphs++;
+
+			}
+      Assert.assertEquals(4,countParagraphs);
+
+		} catch (Exception e) {
+      Logger.getLogger(TextNavigationTest.class.getName()).log(Level.SEVERE, e.getMessage(), e);
+      Assert.fail("Failed with " + e.getClass().getName() + ": '" + e.getMessage() + "'");
+		}
+  }
+
 }

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/TextSelectionTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/TextSelectionTest.java
@@ -95,11 +95,11 @@ public class TextSelectionTest {
     TextSelection nextSelect = null;
     TextNavigation nextsearch = new TextNavigation("next", doc);
     if (nextsearch.hasNext()) {
-      nextSelect = (TextSelection) nextsearch.getCurrentItem();
+      nextSelect = (TextSelection) nextsearch.getSelection();
     }
     int i = 0;
     while (search.hasNext()) {
-      TextSelection item = (TextSelection) search.getCurrentItem();
+      TextSelection item = (TextSelection) search.getSelection();
       i++;
       try {
         item.cut();
@@ -140,12 +140,12 @@ public class TextSelectionTest {
 
     TextNavigation search1 = new TextNavigation("change", doc);
     if (search1.hasNext()) {
-      sel = (TextSelection) search1.getCurrentItem();
+      sel = (TextSelection) search1.getSelection();
     }
 
     int i = 0;
     while (search.hasNext()) {
-      TextSelection item = (TextSelection) search.getCurrentItem();
+      TextSelection item = (TextSelection) search.getSelection();
       i++;
       try {
         sel.pasteAtFrontOf(item);
@@ -181,12 +181,12 @@ public class TextSelectionTest {
 
     TextNavigation search1 = new TextNavigation("change", doc);
     if (search1.hasNext()) {
-      sel = (TextSelection) search1.getCurrentItem();
+      sel = (TextSelection) search1.getSelection();
     }
 
     int i = 0;
     while (search.hasNext()) {
-      TextSelection item = (TextSelection) search.getCurrentItem();
+      TextSelection item = (TextSelection) search.getSelection();
       i++;
       try {
         sel.pasteAtEndOf(item);
@@ -228,7 +228,7 @@ public class TextSelectionTest {
     Assert.assertNotNull(style);
 
     while (search.hasNext()) {
-      TextSelection item = (TextSelection) search.getCurrentItem();
+      TextSelection item = (TextSelection) search.getSelection();
       try {
         item.applyStyle(style);
       } catch (InvalidNavigationException e) {
@@ -256,7 +256,7 @@ public class TextSelectionTest {
     TextSelection nextSelect = null;
     TextNavigation nextsearch = new TextNavigation("next", doc);
     if (nextsearch.hasNext()) {
-      nextSelect = (TextSelection) nextsearch.getCurrentItem();
+      nextSelect = (TextSelection) nextsearch.getSelection();
     }
 
     // replace all the "ODFDOM" to "Odf Toolkit"
@@ -267,7 +267,7 @@ public class TextSelectionTest {
     int i = 0;
     while (search.hasNext()) {
       if (i > 0) {
-        TextSelection item = (TextSelection) search.getCurrentItem();
+        TextSelection item = (TextSelection) search.getSelection();
         try {
           item.replaceWith("Odf Toolkit");
           item.applyStyle(style);
@@ -314,7 +314,7 @@ public class TextSelectionTest {
     navigations.forEach(n -> assertTrue("Navigation " + n + " should have a next", n.hasNext()));
     final List<TextSelection> selections =
         navigations.stream()
-            .map(n -> (TextSelection) n.getCurrentItem())
+            .map(n -> (TextSelection) n.getSelection())
             .collect(Collectors.toList());
     try {
       selections.get(0).replaceWith("Xmultiple___X");
@@ -346,7 +346,7 @@ public class TextSelectionTest {
     search = null;
     search = new TextNavigation("^delete", doc);
     while (search.hasNext()) {
-      TextSelection item = (TextSelection) search.getCurrentItem();
+      TextSelection item = (TextSelection) search.getSelection();
       // LOG.info(item);
       try {
         item.addHref(new URL("http://www.ibm.com"));
@@ -375,7 +375,7 @@ public class TextSelectionTest {
     search = new TextNavigation("<%([^>]*)%>", doc);
 
     while (search.hasNext()) {
-      TextSelection item = (TextSelection) search.getCurrentItem();
+      TextSelection item = (TextSelection) search.getSelection();
       try {
         String text = item.getText();
         text = text.substring(2, text.length() - 2);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigationTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigationTest.java
@@ -92,14 +92,14 @@ public class TextStyleNavigationTest {
 
     TextSelection itemstyle = null;
     if (search1.hasNext()) {
-      itemstyle = (TextSelection) search1.getCurrentItem();
+      itemstyle = (TextSelection) search1.getSelection();
       LOG.info(itemstyle.toString());
     }
     int i = 0;
     if (itemstyle != null) {
       while (search2.hasNext()) {
         i++;
-        TextSelection itemtext = (TextSelection) search2.getCurrentItem();
+        TextSelection itemtext = (TextSelection) search2.getSelection();
         try {
           itemstyle.pasteAtFrontOf(itemtext);
         } catch (InvalidNavigationException e) {
@@ -137,14 +137,14 @@ public class TextStyleNavigationTest {
     search3 = new TextNavigation("deleteRoman16 Romanl16", doc);
     TextSelection itemstyle = null;
     if (search1.hasNext()) {
-      itemstyle = (TextSelection) search1.getCurrentItem();
+      itemstyle = (TextSelection) search1.getSelection();
       LOG.info(itemstyle.toString());
     }
     int i = 0;
     if (itemstyle != null) {
       while (search2.hasNext()) {
         i++;
-        TextSelection itemtext = (TextSelection) search2.getCurrentItem();
+        TextSelection itemtext = (TextSelection) search2.getSelection();
         try {
           itemstyle.pasteAtEndOf(itemtext);
         } catch (InvalidNavigationException e) {
@@ -181,7 +181,7 @@ public class TextStyleNavigationTest {
     search2 = new TextNavigation("Century22", doc);
 
     while (search1.hasNext()) {
-      TextSelection item = (TextSelection) search1.getCurrentItem();
+      TextSelection item = (TextSelection) search1.getSelection();
       try {
         item.cut();
       } catch (InvalidNavigationException e) {
@@ -222,7 +222,7 @@ public class TextStyleNavigationTest {
     int i = 0;
     while (search1.hasNext()) {
       i++;
-      TextSelection item = (TextSelection) search1.getCurrentItem();
+      TextSelection item = (TextSelection) search1.getSelection();
       // LOG.info(item);
       try {
         item.applyStyle(style);


### PR DESCRIPTION
This is a smaller improvement of the `org.odftoolkit.odfdom.incubator.search.Navigation` Interface.  

Using this feature in my own project I recognized that the `TextNavigation` was not working correctly - especially in case the search pattern occur multiple times in one document or paragraph. 

The following example shows how to replace all matches of a regex with a text using the new implementation:

```java
	private void replaceODFTextFragment(OdfTextDocument doc, String pattern, String replace)
			throws InvalidNavigationException {
		try {			
			TextNavigation searchPattern = new TextNavigation(pattern, doc);
			while (searchPattern.hasNext()) {
				OdfElement element = searchPattern.next(); //.getCurrentItem().getElement();
				String text=element.getTextContent();
				logger.info(" Current Item Text="+text);
				element.setTextContent(replace);
			}
		} catch (Exception e) {
			e.printStackTrace();
		}
	}
```

The method `TextNavigation.next()` is new and a convenient method for `getCurrentItem().getElement();`

An important bugfix is in the method `setCurrentTextAndGetIndex`. This method runs in a outOfBounds Exception in case the pattern length was equals to the replacement text length. This is now also fixed.

I have tested the new code in my [own project](https://github.com/imixs/imixs-adapters/tree/master/imixs-adapters-odf) and it works now perfect - even with text in embedded table cells. 