### PR TITLE
Fixes #254: ODFDOM: remove OSGI version constraints

### DIFF
--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -162,8 +162,8 @@
                         <configuration>
                             <instructions>
                                 <Import-Package>
-                                    org.odftoolkit.odfdom;version="${osgi.import.range}",
-                                    org.odftoolkit.odfdom.*;version="${osgi.import.range}",
+                                    !org.odftoolkit.odfdom,
+                                    !org.odftoolkit.odfdom.*,
                                     *
                                 </Import-Package>
                             </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
         <release.zip.bin>odftoolkit-${project.version}-bin.zip</release.zip.bin>
         <release.zip.doc>odftoolkit-${project.version}-doc.zip</release.zip.doc>
         <release.zip.src>odftoolkit-${project.version}-src.zip</release.zip.src>
-        <osgi.import.range>[1.0,2)</osgi.import.range>
         <supported-odf-version>1.2</supported-odf-version>
         <skipTests>false</skipTests>
         <!-- to skip even compiling the tests is honored by Surefire, Failsafe and Compiler Plugin -->


### PR DESCRIPTION
Apply patch proposed by Boarschti42 to remove incorrect version constraints. (Possibly they were added at a time when the version number was 1.0.0-BETA...)