### PR TITLE
Releasing ODF Toolkit 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ build system. To build ODF Toolkit, use the following command in this directory:
 
 ## Recent Releases
 
-1. We have a *release 0.11.0* using >=JDK 11 for ODF 1.2-
-   Doing a full refactoring of the ODFDOM code generation and containing updates to the [new collaboration API](https://tdf.github.io/odftoolkit/odfdom/operations/operations.html):
-    *RELEASE (0.11.0)*:
-    * [ODFDOM](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.11.0/)
-    * [ODF Validator](https://repo1.maven.org/maven2/org/odftoolkit/odfvalidator/0.11.0/)
-    * [XSLT Runner](https://repo1.maven.org/maven2/org/odftoolkit/xslt-runner/0.11.0/)
+1. We have a *release 0.12.0* using >=JDK 11 for ODF 1.2-
+   Mainly maintenance updating the dependenciy versions<br/>
+    **RELEASE (0.12.0)**:
+    * [ODFDOM](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.12.0/)
+    * [ODF Validator](https://repo1.maven.org/maven2/org/odftoolkit/odfvalidator/0.12.0/)
+    * [XSLT Runner](https://repo1.maven.org/maven2/org/odftoolkit/xslt-runner/0.12.0/)
 
-For more details see the [release notes](https://tdf.github.io/odftoolkit/ReleaseNotes.html).
+For more details see the [release notes](https://tdf.github.io/odftoolkit/ReleaseNotes.html).</br>
+   *NOTE*: The prior 0.11.0 release was doing a full refactoring of the ODFDOM code generation and containing updates to the [new collaboration API](https://tdf.github.io/odftoolkit/odfdom/operations/operations.html).<br/>
 
 ## Documentation
 
@@ -72,14 +73,14 @@ For more details see the [release notes](https://tdf.github.io/odftoolkit/Releas
 Discussion about ODF Toolkit takes place on the following mailing lists:
 
 * Development and Users Mailing List
-  * Subscribe: dev+subscribe@odftoolkit.org
-  * Post (after subscription): dev@odftoolkit.org
-  * Unsubscribe: dev+unsubscribe@odftoolkit.org
+  * Subscribe: <dev+subscribe@odftoolkit.org>
+  * Post (after subscription): <dev@odftoolkit.org>
+  * Unsubscribe: <dev+unsubscribe@odftoolkit.org>
   * [Mail archives](https://listarchives.odftoolkit.org/dev/)
 
 The mailing lists are open to anyone and publicly archived.
 
-* To confidentially report a **security issue**, please mail to: security@documentfoundation.org
+* To confidentially report a **security issue**, please mail to: <security@documentfoundation.org>
 
 ## Issue Tracker
 

--- a/src/site/site/content/odftoolkit_website/ReleaseNotes.mdtext
+++ b/src/site/site/content/odftoolkit_website/ReleaseNotes.mdtext
@@ -1,5 +1,32 @@
 # ODF Toolkit Release Notes
 
+## Release 0.12.0
+
+[ODFDOM 0.12.0](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.12.0/) is released on December 20th, 2023. Git tag: "odftoolkit-0.12.0".
+
+### GitHub issues (and feature pull requests) closed for this release 0.12.0
+
+* [#204](https://github.com/tdf/odftoolkit/issues/204) ODF 1.3 new mimetype: Text master template - by mistmist (Michael Stahl) was merged on Feb 1
+* [#215](https://github.com/tdf/odftoolkit/issues/215) Integrate ODF Validator using Maven - by Asbjoedt was closed on May 23
+* [#218](https://github.com/tdf/odftoolkit/issues/218) Cloning fails on Windows - by Asbjoedt was closed on May 24
+* [#235](https://github.com/tdf/odftoolkit/issues/235) Unable to replace paragraph in ODF Text Document - by rsoika was closed on Jun 23
+* [#236](https://github.com/tdf/odftoolkit/issues/236) Improved navigation interface, added next() method - by rsoika was merged on Jun 23
+* [#240](https://github.com/tdf/odftoolkit/issues/240) Text Selection refactoring of Ralph - continuation of PR #238 - by rsoika was merged on Jul 13
+* [#241](https://github.com/tdf/odftoolkit/issues/242) added a new doc page 'change_api" and minor changes - by rsoika was merged on Jul 13
+* [#242](https://github.com/tdf/odftoolkit/issues/242) Determine font, font size, bold/italic/underline styles - by j-dimension was closed on Jul 14
+* [#243](https://github.com/tdf/odftoolkit/issues/243) Diskussion Forum documentation (Documentation) - by rsoika was closed on Jul 19
+* [#251](https://github.com/tdf/odftoolkit/issues/251) OdfEditableTextExtractor extracts only a last part of the text - by sergeych was closed on Sep 4
+* [#254](https://github.com/tdf/odftoolkit/issues/255) Fix OSGI Implementation Details - by Boarschti42 was closed on Oct 18
+
+### Major updates with this version
+
+We added a new ODF 1.3 mimetype "Text master template".
+Aside of minor improvements this release was rather our yearly maintenance release - the refactoring of the generation is ongoing.
+
+#### Maven
+
+Updated to latest Maven dependency versions - improving overall security!
+
 ## Release 0.11.0
 
 [ODFDOM 0.11.0](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.11.0/) is released on December 21th, 2022. Git tag: "odftoolkit-0.11.0".

--- a/src/site/site/content/odftoolkit_website/downloads.mdtext
+++ b/src/site/site/content/odftoolkit_website/downloads.mdtext
@@ -2,58 +2,64 @@
 
 ## Current Version
 
-The current version is the 0.11.0 supporting ODF 1.2. The future development is based on the [master branch](https://github.com/tdf/odftoolkit).</br>
-The releases of 0.11.0 was on December 21th, 2022.
+The current version is the 0.12.0 supporting ODF 1.2. The future development is based on the [master branch](https://github.com/tdf/odftoolkit).</br>
+The releases of 0.12.0 was on December 20th, 2023.
 
 ## Releases (latest)
 
-The release 0.11.0 is using JDK 11 implementing [ODF 1.2](http://docs.oasis-open.org/office/v1.2/os/).</br>
+The release 0.12.0 is using JDK 11 implementing [ODF 1.2](http://docs.oasis-open.org/office/v1.2/os/).</br>
 For more details see the [release notes](./ReleaseNotes.html). People interested should also follow the [mail list](mailing-lists.html) to track progress.
 
 ## Project Releases for Maven (latest)
 
 ### Project Releases for Maven on ODF 1.2
 
-* **[ODFDOM](./odfdom/index.html): [0.11.0](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.11.0/)**
+* **[ODFDOM](./odfdom/index.html): [0.12.0](https://repo1.maven.org/maven2/org/odftoolkit/odfdom-java/0.12.0/)**
 
 ```shell
 <dependency>
     <groupId>org.odftoolkit</groupId>
     <artifactId>odfdom-java</artifactId>
-    <version>0.11.0</version>
+    <version>0.12.0</version>
 </dependency>
 ```
 
-* **[ODF Validator](./conformance/ODFValidator.html): [0.11.0](https://repo1.maven.org/maven2/org/odftoolkit/odfvalidator/0.11.0/)**
+* **[ODF Validator](./conformance/ODFValidator.html): [0.12.0](https://repo1.maven.org/maven2/org/odftoolkit/odfvalidator/0.12.0/)**
 
 ```shell
 <dependency>
     <groupId>org.odftoolkit</groupId>
     <artifactId>odfvalidator</artifactId>
-    <version>0.11.0</version>
+    <version>0.12.0</version>
 </dependency>
 ```
 
-* **[XSLT Runner](./xsltrunner/ODFXSLTRunner.html): [0.11.0](https://repo1.maven.org/maven2/org/odftoolkit/xslt-runner/0.11.0/)**
+* **[XSLT Runner](./xsltrunner/ODFXSLTRunner.html): [0.12.0](https://repo1.maven.org/maven2/org/odftoolkit/xslt-runner/0.12.0/)**
 
 ```shell
 <dependency>
     <groupId>org.odftoolkit</groupId>
     <artifactId>xslt-runner</artifactId>
-    <version>0.11.0</version>
+    <version>0.12.0</version>
 </dependency>
 
 ```
 
 ## ODF Toolkit Release Bundles (latest)
 
+### ODF Toolkit 0.12.0 Release Bundle (ODF 1.2 using JDK 11)
+
+* Sources: [odftoolkit-0.12.0-src.zip](https://github.com/tdf/odftoolkit/releases/download/v0.12.0/odftoolkit-0.12.0-src.zip) [[sha](https://github.com/tdf/odftoolkit/releases/download/v0.12.0/odftoolkit-0.12.0-src.zip.sha)]
+* Binaries: [odftoolkit-0.12.0-bin.zip](https://github.com/tdf/odftoolkit/releases/download/v0.12.0/odftoolkit-0.12.0-bin.zip) [[sha](https://github.com/tdf/odftoolkit/releases/download/v0.12.0/odftoolkit-0.12.0-bin.zip.sha)]
+* Documentation: [odftoolkit-0.12.0-doc.zip](https://github.com/tdf/odftoolkit/releases/download/v0.12.0/odftoolkit-0.12.0-doc.zip) [[sha](https://github.com/tdf/odftoolkit/releases/download/v0.12.0/odftoolkit-0.12.0-doc.zip.sha)]
+
+## Former ODF Toolkit Release Bundles
+
 ### ODF Toolkit 0.11.0 Release Bundle (ODF 1.2 using JDK 11)
 
 * Sources: [odftoolkit-0.11.0-src.zip](https://github.com/tdf/odftoolkit/releases/download/v0.11.0/odftoolkit-0.11.0-src.zip) [[sha](https://github.com/tdf/odftoolkit/releases/download/v0.11.0/odftoolkit-0.11.0-src.zip.sha)]
 * Binaries: [odftoolkit-0.11.0-bin.zip](https://github.com/tdf/odftoolkit/releases/download/v0.11.0/odftoolkit-0.11.0-bin.zip) [[sha](https://github.com/tdf/odftoolkit/releases/download/v0.11.0/odftoolkit-0.11.0-bin.zip.sha)]
 * Documentation: [odftoolkit-0.11.0-doc.zip](https://github.com/tdf/odftoolkit/releases/download/v0.11.0/odftoolkit-0.11.0-doc.zip) [[sha](https://github.com/tdf/odftoolkit/releases/download/v0.11.0/odftoolkit-0.11.0-doc.zip.sha)]
-
-## Former ODF Toolkit Release Bundles
 
 ### ODF Toolkit 0.10.0 Release Bundle (ODF 1.2 using JDK 11)
 

--- a/src/site/site/content/odftoolkit_website/release-guide.mdtext
+++ b/src/site/site/content/odftoolkit_website/release-guide.mdtext
@@ -39,6 +39,7 @@ There are two kinds of releases a quick SNAPSHOT release, where the SNAPSHOT wil
     ```
 
    The following documents need currently manual adjustment:
+   **NOTE**: To gather the release notes information it is helpful to go backward through issues and pull requests in GitHub!
 
     ```shell
     ./README.md


### PR DESCRIPTION
I have already updated the release documentation (at least the README.md and release notes in markdown) and will now generate the HTML documentation before doing the Maven release.
The sources were built/tested locally successfully on Linux with JDK 11 and Windows 10 with JDK 21.01
