### PR TITLE
Fixes #276: set failOnNoGitDirectory property for git-commit-id-maven…

### DIFF
--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -187,6 +187,7 @@
                     <excludeProperties>
                         <excludeProperty>git.*.user.*</excludeProperty>
                     </excludeProperties>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <prefix>git</prefix>
                     <verbose>true</verbose>
                     <skipPoms>false</skipPoms>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -92,6 +92,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                 </configuration>
             </plugin>


### PR DESCRIPTION
…-plugin

Obviously release source zip files don't contain a .git directory, so avoid failing the build in this case.