### PR TITLE
Fix #285: Skip repeated rows and columns when possible

### DIFF
--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
@@ -2276,16 +2276,27 @@ public class OdfTable {
   List<CellCoverInfo> getCellCoverInfos(int nStartCol, int nStartRow, int nEndCol, int nEndRow) {
     List<CellCoverInfo> coverList = new ArrayList<CellCoverInfo>();
     int nColSpan, nRowSpan;
-    for (int i = nStartCol; i < nEndCol + 1; i++) {
-      for (int j = nStartRow; j < nEndRow + 1; j++) {
-        OdfTableCell cell = getCellByPosition(i, j);
-        if (cell != null) {
-          nColSpan = cell.getColumnSpannedNumber();
-          nRowSpan = cell.getRowSpannedNumber();
-          if ((nColSpan > 1) || (nRowSpan > 1)) {
-            coverList.add(new CellCoverInfo(i, j, nColSpan, nRowSpan));
+    for (int i = nStartRow; i < nEndRow + 1; ) {
+      OdfTableRow row = getRowByIndex(i);
+      if (row != null) {
+        for (int j = nStartCol; j < nEndCol + 1; ) {
+          OdfTableCell cell = getCellByPosition(j, i);
+          if (cell != null) {
+            nColSpan = cell.getColumnSpannedNumber();
+            nRowSpan = cell.getRowSpannedNumber();
+            if ((nColSpan > 1) || (nRowSpan > 1)) {
+              for (int k = 0; k < row.getRowsRepeatedNumber(); k++) {
+                coverList.add(new CellCoverInfo(j, i + k, nColSpan, nRowSpan));
+              }
+            }
+            j += cell.getColumnsRepeatedNumber();
+          } else {
+            j++;
           }
         }
+        i += row.getRowsRepeatedNumber();
+      } else {
+        i++;
       }
     }
     return coverList;


### PR DESCRIPTION
According to the ODF 1.3 spec, repeated columns cannot contain cells which span multiple rows or columns and repeated rows cannot contain vertical merges. Therefore, we can skip repeated rows and columns after the first one while searching for covering cells.

Note that while this code should properly handle horizontal merges in repeated rows, such merges are ignored after the first instance of the repeated row in current versions of LibreOffice, OpenOffice, and Excel, so this scenario is unlikely to come up.