### PR TITLE
Line-ending normalizsation for ODF JSON regression tests

### DIFF
--- a/odfdom/src/test/java/org/odftoolkit/odfdom/changes/RoundtripTestHelper.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/changes/RoundtripTestHelper.java
@@ -364,7 +364,7 @@ class RoundtripTestHelper {
       if (initialRefOpsFile.exists()) {
         String initialRefOps = ResourceUtilities.loadFileAsString(initialRefOpsFile);
         LOG.log(Level.FINEST, "The original ops from testFile are:{0}", initialRefOps);
-        if (!initialTestOps.equals(initialRefOps)) {
+        if (!initialTestOps.equals(initialRefOps.replaceAll("\\r\\n?", "\n"))) {
           LOG.log(Level.SEVERE, "Ups! The original ops from testFile had been:{0}", initialRefOps);
           LOG.log(Level.SEVERE, "But The new ops from testFile are :{0}", initialTestOps);
           initialComparisonFailure = true;
@@ -615,7 +615,7 @@ class RoundtripTestHelper {
         // character for list bullets
         if (!JsonOperationNormalizer.asString(reloadedOps, Boolean.TRUE)
             .replace(",{\"name\"", ",\n{\"name\"")
-            .equals(referenceOpsFromFile)) {
+            .equals(referenceOpsFromFile.replaceAll("\\r\\n?", "\n"))) {
           LOG.log(Level.SEVERE, "The reference ops are:{0}", referenceOpsFromFile);
           reloadedComparisonFailure = true;
         }


### PR DESCRIPTION
JSON references - when cloned via Git on Windows receive sometimes a Windows line-ending (dependent on git configuration), which causes trouble (test errors - false positive) when comparing test results line-based.

The JSON created from the ODTs during regression tests is always created with Linux line endings.

Therefore, the line endings of reference test files are being changed from Windows to Linux to avoid this uncertainty.