### PR TITLE
Support for AES256-CBC encryption

### DIFF
--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -100,6 +100,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.79</version>
+        </dependency>
     </dependencies>
 
     <!-- Build Settings -->


### PR DESCRIPTION
This pull request fixes the problem with password-protected LibreOffice files described in Issue #138.
It is now possible to open files with the old Blowfish encryption as well as with the AES256-CBC encryption.
Unfortunately, I had to add BouncyCastle because I couldn't solve the problem with the existing libraries.

resolves #138