### PR TITLE
Clarify the location hosting the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The ODF Toolkit
 
-Visit our latest documentation on [GitHub](https://tdf.github.io/odftoolkit/).
+Visit our latest documentation on [our GitHub Pages site](https://tdf.github.io/odftoolkit/).
 
 [The ODF Toolkit](http://odftoolkit.org) is a set of Java modules that allow programmatic
 creation, scanning and manipulation of Open Document Format (ISO/IEC 26300 == ODF)


### PR DESCRIPTION
This pull request addresses confusion about the README page on GitHub, claiming the documentation is also on GitHub while it is actually a GitHub Pages site URL.
