### PR TITLE
Adding ODF 1.4 GUI to the ODF Validator

### DIFF
--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
@@ -268,10 +268,10 @@ public class ODFValidator implements ODFValidatorProvider {
     Configuration aConfig = m_aConfigurationMap.get(aVersion);
     if (aConfig == null) {
       String aConfigName = null;
-      if (aVersion == null || aVersion == OdfVersion.V1_3) {
-        aConfigName = "/schema/odf1_3.properties";
-      } else if (aVersion == OdfVersion.V1_4) {
+      if (aVersion == null || aVersion == OdfVersion.V1_4) {
         aConfigName = "/schema/odf1_4.properties";
+      } else if (aVersion == OdfVersion.V1_3) {
+        aConfigName = "/schema/odf1_3.properties";
       } else if (aVersion == OdfVersion.V1_2) {
         aConfigName = "/schema/odf1_2.properties";
       } else if (aVersion == OdfVersion.V1_1) {

--- a/validator/src/main/webapp/WEB-INF/web.xml
+++ b/validator/src/main/webapp/WEB-INF/web.xml
@@ -28,7 +28,7 @@
     <context-param>
 		<!-- application title, shown in the header of the application -->
         <param-name>APPLICATION_TITLE</param-name>
-        <param-value>ODF Validator 1.3</param-value>
+        <param-value>ODF Validator 1.4</param-value>
     </context-param>
     <context-param>
 		<!-- name for setting-storing, used in the settings database -->

--- a/validator/src/main/webapp/jsp/info/info.jsp
+++ b/validator/src/main/webapp/jsp/info/info.jsp
@@ -22,25 +22,25 @@
 	<li><p><span style="font-weight:bold;">autodetect  </span>: Detects the ODF version of the root document from the given ODF package. ODF documents with version 1.2/1.3 will be validated against conformance, version 1.0/1.1 against none strict. 
 			In all other choices the document is validated with respect to the selected OpenDocument version regardless of the version information that is included in the file</p></li>
 	<li><p><span style="font-weight:bold;">conformant  </span>: Checks the basic requirements conforming OpenDocument documents must meet.
-			This modes considers the version of the checked documents. This means that for OpenDocument v1.2/1.3 documents (or if OpenDocument v1.2/1.3) has been selected) the
-			conformance definitions of the OpenDocument v1.2/1.3 specification are taken as basis, while those of the OpenDocument v1.1/v1.0 specification are taken as basis
-			for OpenDocument v1.1/v1.0 documents. Please note that not all provisions for conforming documents are checked.</p></li>
-	<li><p><span style="font-weight:bold;">extended conformance test</span>: For OpenDocument v1.2/1.3 documents (or if OpenDocument v1.2/1.3 has been selected), the basic requirements of extended conforming ODF documents are checked.
-			For OpenDocument v1.0/v1.1 documents (or if OpenDocument v1.0/v1.1 has been selected) this mode equals the <span style="font-weight:bold;">conformance test</span> mode.</p></li>
-	<li><p><span style="font-weight:bold;">validation</span>: For OpenDocument v1.1/v1.0 documents (or if OpenDocument v1.1/v1.0 has been selected) the selected document is validated in regard of the OpenDocument v1.1/v1.0 schema.
-			For OpenDocument v1.2/1.3 documents (or if OpenDocument v1.2/1.3 has been selected) this mode equals the <span style="font-weight:bold;">conformance test</span> mode.</p></li>
-	<li><p><span style="font-weight:bold;">strict validation</span>: For OpenDocument v1.1/v1.0 documents (or if OpenDocument v1.1/v1.0 has been selected) the selected document is validated in regard of the strict OpenDocument v1.1/v1.0 schema.
-			For OpenDocument v1.2/1.3 documents (or if OpenDocument v1.2/1.3 has been selected) this mode equals the <span style="font-weight:bold;">conformance test</span> mode.</p></li>
+			This modes considers the version of the checked documents. This means that for OpenDocument v1.2/1.3/1.4 documents (or if OpenDocument v1.2/1.3/1.4) has been selected) the
+			conformance definitions of the OpenDocument v1.2/1.3/1.4 specification are taken as basis, while those of the OpenDocument v1.0/1.1 specification are taken as basis
+			for OpenDocument v1.0/1.1 documents. Please note that not all provisions for conforming documents are checked.</p></li>
+	<li><p><span style="font-weight:bold;">extended conformance test</span>: For OpenDocument v1.2/1.3/1.4 documents (or if OpenDocument v1.2/1.3/1.4 has been selected), the basic requirements of extended conforming ODF documents are checked.
+			For OpenDocument v1.0/1.1 documents this mode equals the <span style="font-weight:bold;">conformance test</span> mode.</p></li>
+	<li><p><span style="font-weight:bold;">validation</span>: For OpenDocument v1.0/1.1 documents (or if OpenDocument v1.0/1.1 has been selected) the selected document is validated in regard of the OpenDocument v1.0/1.1 schema.
+			For OpenDocument v1.2/1.3/1.4 documents (or if OpenDocument v1.2/1.3/1.4 has been selected) this mode equals the <span style="font-weight:bold;">conformance test</span> mode.</p></li>
+	<li><p><span style="font-weight:bold;">strict validation</span>: For OpenDocument v1.0/1.1 documents (or if OpenDocument v1.0/1.1 has been selected) the selected document is validated in regard of the strict OpenDocument v1.0/1.1 schema.
+			For OpenDocument v1.2/1.3/1.4 documents (or if OpenDocument v1.2/1.3/1.4 has been selected) this mode equals the <span style="font-weight:bold;">conformance test</span> mode.</p></li>
 </ul>
-<p>For OpenDocument v1.1/v1.0 documents, the <span style="font-weight:bold;">validation</span> and <span style="font-weight:bold;">strict validation</span> tests are more restrictive than a conformance test. Please note that this means that errors may be reported for documents that are actually conforming to the ODF specification.</p>
-<p>The <span style="font-weight:bold;">strict validation test</span> is recommended for developers that want to make sure that an OpenDocument v1.0/v1.1 document does not only validate in regards to the ODF schema, but also does not use any extensions. The recommended mode
+<p>For OpenDocument v1.0/1.1 documents, the <span style="font-weight:bold;">validation</span> and <span style="font-weight:bold;">strict validation</span> tests are more restrictive than a conformance test. Please note that this means that errors may be reported for documents that are actually conforming to the ODF specification.</p>
+<p>The <span style="font-weight:bold;">strict validation test</span> is recommended for developers that want to make sure that an OpenDocument v1.0/1.1 document does not only validate in regards to the ODF schema, but also does not use any extensions. The recommended mode
 	for OpenDocument v1.2 documents is <span style="font-weight:bold;">conformance test</span>.</p>
 <p>The following items are checked by the validation service:</p>
 <ul>
-	<li><p>OpenDocument v1.2/1.3 documents</p>
+	<li><p>OpenDocument v1.2/1.3/1.4 documents</p>
 		<ul>
-			<li><p>If the test type is <span style="font-weight:bold;">conformance test</span>, and if the file is not a formula file, then the sub files <i>content.xml</i>, <i>styles.xml</i>, <i>meta.xml</i> and <i>settings.xml</i> are  validated with respect to the OpenDocument v1.2/1.3 schema.</p></li>
-			<li><p>If the test type is <span style="font-weight:bold;">extended conformance test</span>, and if the file is not a formula file, then the sub files <i>content.xml</i>, <i>styles.xml</i>, <i>meta.xml</i> and <i>settings.xml</i> are pre-processed as described in section 1.4.2.1 of the OpenDocument v1.2 specification (that is <i>foreign elements and attributes</i> are removed), and are then validated with respect to the OpenDocument v1.2/1.3 schema.</p></li>
+			<li><p>If the test type is <span style="font-weight:bold;">conformance test</span>, and if the file is not a formula file, then the sub files <i>content.xml</i>, <i>styles.xml</i>, <i>meta.xml</i> and <i>settings.xml</i> are  validated with respect to the OpenDocument v1.2/1.3/1.4 schema.</p></li>
+			<li><p>If the test type is <span style="font-weight:bold;">extended conformance test</span>, and if the file is not a formula file, then the sub files <i>content.xml</i>, <i>styles.xml</i>, <i>meta.xml</i> and <i>settings.xml</i> are pre-processed as described in section 1.4.2.1 of the OpenDocument v1.2 specification (that is <i>foreign elements and attributes</i> are removed), and are then validated with respect to the OpenDocument v1.2/1.3/1.4 schema.</p></li>
 		</ul>
 	</li>
 	<li><p>OpenDocument v1.1/1.0 documents</p>

--- a/validator/src/main/webapp/jsp/validate.jsp
+++ b/validator/src/main/webapp/jsp/validate.jsp
@@ -69,42 +69,50 @@ if(ServletFileUpload.isMultipartContent(request)) {
 				OdfVersion aOdfVersion = null;
 				OdfValidatorMode odfValidatorMode = null;
 				switch (modeSelection) {
-					case 6:
-						aOdfVersion = OdfVersion.V1_0;
-						odfValidatorMode = OdfValidatorMode.VALIDATE;
+					case 10:
+						aOdfVersion = OdfVersion.V1_4;
+						odfValidatorMode = OdfValidatorMode.CONFORMANCE;
 						break;
-					case 4:
-						aOdfVersion = OdfVersion.V1_1;
-						odfValidatorMode = OdfValidatorMode.VALIDATE;
-						break;
-					case 5:
-						aOdfVersion = OdfVersion.V1_0;
-						odfValidatorMode = OdfValidatorMode.VALIDATE_STRICT;
-						break;
-					case 3:
-						aOdfVersion = OdfVersion.V1_1;
-						odfValidatorMode = OdfValidatorMode.VALIDATE_STRICT;
-						break;
-					case 2:
+					case 9:
+						aOdfVersion = OdfVersion.V1_4;
 						odfValidatorMode = OdfValidatorMode.EXTENDED_CONFORMANCE;
-						aOdfVersion = OdfVersion.V1_2;
 						break;
-					case 1:
-						aOdfVersion = OdfVersion.V1_2;
+					case 8:
+						aOdfVersion = OdfVersion.V1_3;
 						odfValidatorMode = OdfValidatorMode.CONFORMANCE;
 						break;
 					case 7:
 						aOdfVersion = OdfVersion.V1_3;
+						odfValidatorMode = OdfValidatorMode.EXTENDED_CONFORMANCE;
+						break;
+					case 6:
+						aOdfVersion = OdfVersion.V1_2;
 						odfValidatorMode = OdfValidatorMode.CONFORMANCE;
 						break;
-					case 8:
+					case 5:
+						aOdfVersion = OdfVersion.V1_2;
 						odfValidatorMode = OdfValidatorMode.EXTENDED_CONFORMANCE;
-						aOdfVersion = OdfVersion.V1_3;
+						break;
+					case 4:
+						aOdfVersion = OdfVersion.V1_1;
+						odfValidatorMode = OdfValidatorMode.VALIDATE_STRICT;
+						break;
+					case 3:
+						aOdfVersion = OdfVersion.V1_1;
+						odfValidatorMode = OdfValidatorMode.VALIDATE;
+						break;
+					case 2:
+						aOdfVersion = OdfVersion.V1_0;
+						odfValidatorMode = OdfValidatorMode.VALIDATE_STRICT;
+						break;                
+					case 1:
+						aOdfVersion = OdfVersion.V1_0;
+						odfValidatorMode = OdfValidatorMode.VALIDATE;
 						break;
 					default:
 						odfValidatorMode = OdfValidatorMode.CONFORMANCE;
 						break;
-				}				
+				}
 				validator = new ODFValidator(null, aLogLevel, true, aOdfVersion);
 				ByteArrayOutputStream bout = null;
 				if(validator != null) {
@@ -156,14 +164,16 @@ if(ServletFileUpload.isMultipartContent(request)) {
 	<p class="selection"><a href="info.html">ODF Version</a>:<br/>
 		<select name="modeSelection" size="1" onChange="javascript: return setconfig();">
 			<option value="0" selected="">auto-detect</option>
-			<option value="7">OASIS ODF 1.3 (conforming)</option>
-			<option value="8">OASIS ODF 1.3 (extended conforming)</option>
-			<option value="1">OASIS ODF 1.2 (conforming)</option>
-			<option value="2">OASIS ODF 1.2 (extended conforming)</option>
-			<option value="3">OASIS ODF 1.1 (strict)</option>
-			<option value="4">OASIS ODF 1.1</option>
-			<option value="5">OASIS ODF 1.0 - ISO/IEC 26300 (strict)</option>
-			<option value="6">OASIS ODF 1.0 - ISO/IEC 26300</option>
+			<option value="10">OASIS ODF 1.4 (conforming)</option>
+			<option value="9">OASIS ODF 1.4 (extended conforming)</option>
+			<option value="8">OASIS ODF 1.3 (conforming)</option>
+			<option value="7">OASIS ODF 1.3 (extended conforming)</option>
+			<option value="6">OASIS ODF 1.2 (conforming)</option>
+			<option value="5">OASIS ODF 1.2 (extended conforming)</option>
+			<option value="4">OASIS ODF 1.1 (strict)</option>
+			<option value="3">OASIS ODF 1.1</option>
+			<option value="2">OASIS ODF 1.0 - ISO/IEC 26300 (strict)</option>
+			<option value="1">OASIS ODF 1.0 - ISO/IEC 26300</option>
 		</select>
 		<br/>
 	</p>


### PR DESCRIPTION
Adding ODF 1.4 GUI to the ODF Validator, making ODF 1.4 the new default, and 
doing some refactoring:

1. in info.jsp
   * v1.2/1.3 becomes v1.2/1.3/1.4 
   * v1.0/v1.1 becomes v1.0/1.1
   * v1.1/v1.0 becomes v1.0/1.1
2. in validate.jsp
   * order the versions consistently - became confusing...
