### PR TITLE
Fix/360 re enable disabled unit tests

### DIFF
--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
@@ -55,19 +55,16 @@ public class TableCellTest {
   static final String SAMPLE_TEXT = "TestTextTable";
   OdfSpreadsheetDocument odsdoc, odsstyle;
   OdfTextDocument odtdoc;
-  OdfTable odsTable, odtTable;
 
   @Before
   public void setUp() {
     try {
       odsdoc =
-          (OdfSpreadsheetDocument)
-              OdfSpreadsheetDocument.loadDocument(
-                  ResourceUtilities.getAbsoluteInputPath(SAMPLE_SPREADSHEET + ".ods"));
+        OdfSpreadsheetDocument.loadDocument(
+            ResourceUtilities.getAbsoluteInputPath(SAMPLE_SPREADSHEET + ".ods"));
       odtdoc =
-          (OdfTextDocument)
-              OdfTextDocument.loadDocument(
-                  ResourceUtilities.getAbsoluteInputPath(SAMPLE_TEXT + ".odt"));
+        OdfTextDocument.loadDocument(
+            ResourceUtilities.getAbsoluteInputPath(SAMPLE_TEXT + ".odt"));
 
     } catch (Exception e) {
       LOG.log(Level.SEVERE, e.getMessage(), e);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
@@ -46,22 +46,18 @@ import org.odftoolkit.odfdom.incubator.doc.style.OdfStyle;
 import org.odftoolkit.odfdom.type.Color;
 import org.odftoolkit.odfdom.utils.ResourceUtilities;
 
-@Ignore
 public class TableCellTest {
 
   private static final Logger LOG = Logger.getLogger(TableCellTest.class.getName());
   static final String SAMPLE_SPREADSHEET = "TestSpreadsheetTable";
   static final String SAMPLE_STYLE_SPREADSHEET = "TestSpreadsheetStyleTable";
   static final String SAMPLE_TEXT = "TestTextTable";
-  OdfSpreadsheetDocument odsdoc, odsstyle;
+  OdfSpreadsheetDocument odsstyle;
   OdfTextDocument odtdoc;
 
   @Before
   public void setUp() {
     try {
-      odsdoc =
-        OdfSpreadsheetDocument.loadDocument(
-            ResourceUtilities.getAbsoluteInputPath(SAMPLE_SPREADSHEET + ".ods"));
       odtdoc =
         OdfTextDocument.loadDocument(
             ResourceUtilities.getAbsoluteInputPath(SAMPLE_TEXT + ".odt"));
@@ -71,13 +67,25 @@ public class TableCellTest {
     }
   }
 
-  private void saveods() {
+  private OdfSpreadsheetDocument loadInputOds() throws Exception {
+    return OdfSpreadsheetDocument.loadDocument(
+      ResourceUtilities.getAbsoluteInputPath(SAMPLE_SPREADSHEET + ".ods")
+    );
+  }
+
+  private void saveOutputOds(OdfSpreadsheetDocument odsdoc) {
     try {
       odsdoc.save(ResourceUtilities.getTestOutputFile(SAMPLE_SPREADSHEET + "Output.ods"));
 
     } catch (Exception e) {
       LOG.log(Level.SEVERE, e.getMessage(), e);
     }
+  }
+
+  private OdfSpreadsheetDocument loadOutputOds() throws Exception {
+    return OdfSpreadsheetDocument.loadDocument(
+      ResourceUtilities.getTestOutputFile(SAMPLE_SPREADSHEET + "Output.ods")
+    );
   }
 
   private void saveodt() {
@@ -89,7 +97,9 @@ public class TableCellTest {
   }
 
   @Test
-  public void testGetIndexInRowColumn() {
+  public void testGetIndexInRowColumn() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 2, columnindex = 1;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell cell = table.getCellByPosition(columnindex, rowindex);
@@ -104,7 +114,9 @@ public class TableCellTest {
   }
 
   @Test
-  public void testGetSetHoriAlignment() {
+  public void testGetSetHoriAlignment() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 3, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -127,7 +139,7 @@ public class TableCellTest {
     fcell.setHorizontalAlignment("right");
     align = fcell.getHorizontalAlignment();
     Assert.assertEquals("end", align);
-    saveods();
+    saveOutputOds(odsdoc);
 
     OdfSpreadsheetDocument ods;
     try {
@@ -143,7 +155,9 @@ public class TableCellTest {
   }
 
   @Test
-  public void testGetSetVertAlignment() {
+  public void testGetSetVertAlignment() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 3, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -158,7 +172,7 @@ public class TableCellTest {
     fcell.setVerticalAlignment("bottom");
     align = fcell.getVerticalAlignment();
     Assert.assertEquals("bottom", align);
-    saveods();
+    saveOutputOds(odsdoc);
     OdfSpreadsheetDocument ods;
     try {
       ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
@@ -173,7 +187,9 @@ public class TableCellTest {
   }
 
   @Test
-  public void testGetSetValueType() {
+  public void testGetSetValueType() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 3, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -190,7 +206,7 @@ public class TableCellTest {
     fcell.setValueType("date");
     String valueType = fcell.getValueType();
     Assert.assertEquals("date", valueType);
-    saveods();
+    saveOutputOds(odsdoc);
 
     OdfSpreadsheetDocument ods;
     try {
@@ -206,7 +222,9 @@ public class TableCellTest {
   }
 
   @Test
-  public void testGetSetWrapOption() {
+  public void testGetSetWrapOption() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 5, columnindex = 8;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -217,11 +235,13 @@ public class TableCellTest {
     fcell.setTextWrapped(false);
     wrap = fcell.isTextWrapped();
     Assert.assertEquals(false, wrap);
-    saveods();
+    saveOutputOds(odsdoc);
   }
 
   @Test
-  public void testGetSetTextValue() {
+  public void testGetSetTextValue() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 5, columnindex = 8;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -239,7 +259,7 @@ public class TableCellTest {
     fcell.setDisplayText(null, "automatic7777");
     text = fcell.getDisplayText();
     Assert.assertEquals("", text);
-    saveods();
+    saveOutputOds(odsdoc);
 
     OdfTable table1 = odtdoc.getTableByName("Table1");
     OdfTableCell fcell2 = table1.getCellByPosition(0, 1);
@@ -247,8 +267,10 @@ public class TableCellTest {
     Assert.assertEquals("Aabbccddee", text);
   }
 
-  @Test
-  public void testSetGetFormat() {
+  @Test @Ignore // FIXME test failure
+  public void testSetGetFormat() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 3, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -290,7 +312,7 @@ public class TableCellTest {
       LOG.log(Level.SEVERE, e.getMessage(), e);
       Assert.fail(e.getMessage());
     }
-    saveods();
+    saveOutputOds(odsdoc);
 
     // test value type adapt function.
     OdfSpreadsheetDocument ods;
@@ -376,26 +398,17 @@ public class TableCellTest {
     }
   }
 
-  private void loadOutputSpreadsheet() {
-    try {
-      odsdoc =
-          (OdfSpreadsheetDocument)
-              OdfSpreadsheetDocument.loadDocument(
-                  ResourceUtilities.getAbsoluteInputPath(SAMPLE_SPREADSHEET + "Output.ods"));
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-    }
-  }
-
   @Test
   public void testGetSetCellBackgroundColor() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 2, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     fcell.setCellBackgroundColor("#ffffff");
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     // set color as DEFAULT_BACKGROUND_COLOR #FFFFFF
@@ -403,9 +416,9 @@ public class TableCellTest {
 
     Color expectedColor = Color.valueOf("#000000");
     fcell.setCellBackgroundColor(expectedColor);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expectedColor.toString(), fcell.getCellBackgroundColor().toString());
@@ -425,31 +438,33 @@ public class TableCellTest {
 
   @Test
   public void testGetSetColumnSpannedNumber() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 2, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     fcell.setColumnSpannedNumber(-2);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     // set column spanned number as DEFAULT_COLUMN_SPANNED_NUMBER 1.
     Assert.assertEquals(1, fcell.getColumnSpannedNumber());
 
     fcell.setColumnSpannedNumber(0);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     // set column spanned number as DEFAULT_COLUMN_SPANNED_NUMBER 1.
     Assert.assertEquals(1, fcell.getColumnSpannedNumber());
 
     fcell.setColumnSpannedNumber(2);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(2, fcell.getColumnSpannedNumber());
@@ -457,31 +472,33 @@ public class TableCellTest {
 
   @Test
   public void testGetSetRowSpannedNumber() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 2, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     fcell.setRowSpannedNumber(-2);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     // set row spanned number as DEFAULT_ROW_SPANNED_NUMBER 1.
     Assert.assertEquals(1, fcell.getRowSpannedNumber());
 
     fcell.setRowSpannedNumber(0);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     // set row spanned number as DEFAULT_ROW_SPANNED_NUMBER 1.
     Assert.assertEquals(1, fcell.getRowSpannedNumber());
 
     fcell.setRowSpannedNumber(2);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(2, fcell.getRowSpannedNumber());
@@ -489,38 +506,42 @@ public class TableCellTest {
 
   @Test
   public void testGetSetColumnsRepeatedNumber() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 3, columnindex = 1;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     fcell.setColumnsRepeatedNumber(-2);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     // set columns repeated number as DEFAULT_COLUMNS_REPEATED_NUMBER 1.
     Assert.assertEquals(1, fcell.getColumnsRepeatedNumber());
 
     fcell.setColumnsRepeatedNumber(0);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     // set columns repeated number as DEFAULT_COLUMNS_REPEATED_NUMBER 1.
     Assert.assertEquals(1, fcell.getColumnsRepeatedNumber());
 
     fcell.setColumnsRepeatedNumber(2);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(2, fcell.getColumnsRepeatedNumber());
   }
 
   @Test
-  public void testGetSetDateValue() {
+  public void testGetSetDateValue() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 7, columnindex = 7;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -535,54 +556,60 @@ public class TableCellTest {
     Assert.assertTrue(illegalArgumentFlag);
     Calendar expectedCalendar = new GregorianCalendar(2010, 1, 30);
     fcell.setDateValue(expectedCalendar);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(0, fcell.getDateValue().compareTo(expectedCalendar));
   }
 
   @Test
-  public void testGetSetStringValue() {
+  public void testGetSetStringValue() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 6, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     fcell.setStringValue(null);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals("", fcell.getStringValue());
 
     String expectedString = "hello world";
     fcell.setStringValue(expectedString);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expectedString, fcell.getStringValue());
   }
 
   @Test
-  public void testGetSetBooleanValue() {
+  public void testGetSetBooleanValue() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 5, columnindex = 5;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     boolean expected = false;
     fcell.setBooleanValue(expected);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertFalse(fcell.getBooleanValue());
   }
 
   @Test
-  public void testGetSetCurrencyValue() {
+  public void testGetSetCurrencyValue() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 5, columnindex = 5;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -603,16 +630,18 @@ public class TableCellTest {
     Assert.assertTrue(illegalArgumentFlag);
 
     fcell.setCurrencyValue(expected, "USD");
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expected, fcell.getCurrencyValue(), 0);
   }
 
   @Test
-  public void testGetSetCurrencyDesc() {
+  public void testGetSetCurrencyDesc() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 1, columnindex = 2;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -629,31 +658,35 @@ public class TableCellTest {
     fcell = table.getCellByPosition(columnindex, rowindex);
     String expected = "USD";
     fcell.setCurrencyCode(expected);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expected, fcell.getCurrencyCode());
   }
 
   @Test
-  public void testGetSetPercentageValue() {
+  public void testGetSetPercentageValue() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 5, columnindex = 5;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     double expected = 56.98;
     fcell.setPercentageValue(expected);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expected, fcell.getPercentageValue(), 0);
   }
 
   @Test
-  public void testGetSetTimeValue() {
+  public void testGetSetTimeValue() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 0, columnindex = 4;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -668,9 +701,9 @@ public class TableCellTest {
     Assert.assertTrue(illegalArgumentFlag);
     Calendar expected = Calendar.getInstance();
     fcell.setTimeValue(expected);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
 
@@ -681,7 +714,9 @@ public class TableCellTest {
   }
 
   @Test
-  public void testGetSetFormula() {
+  public void testGetSetFormula() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 1, columnindex = 10;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -697,26 +732,29 @@ public class TableCellTest {
 
     String expected = "of:=[.I2]*4";
     fcell.setFormula(expected);
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expected, fcell.getFormula());
   }
 
   /**
-   * This test case is used to check whether the new created cell uses correct style settings.</br>
+   * This test case is used to check whether the new created cell uses correct style settings.
+   * <p>
    * ODFDOM allows users to set if cell styles are inherited or not whenever a new cell is added to
    * the table. The default setting is using inheritance. In this condition, the style of new column
    * is same with the last column before the inserted position, while the style of new row is same
-   * with the last row before the inserted position.<br>
+   * with the last row before the inserted position.
+   * <p>
    * This feature setting will influence <code>appendRow()</code>, <code>appendColumn()</code>,
    * <code>appendRows()</code>, <code>appendColumns()</code>, <code>insertRowsBefore()</code> and
    * <code>insertColumnsBefore()</code>. In default setting condition, the style name of new created
-   * cells after these methods called should be "ce1" which is inherited from preceding cell. <br>
+   * cells after these methods called should be "ce1" which is inherited from preceding cell.
    * But after setting cell style inheritance false, these new created cells' style name should be
-   * "Default", which is not inherited from preceding one.<br>
+   * "Default", which is not inherited from preceding one.
+   * <p>
    * For <code>getCellByPosition()</code>, <code>getCellRangeByPosition()</code>, <code>
    * getCellRangeByName()</code>, <code>getRowByIndex()</code> and <code>getColumnByIndex()</code>,
    * if need automatically expand cells, it will return empty cell(s) without any style settings.
@@ -818,7 +856,9 @@ public class TableCellTest {
   }
 
   @Test
-  public void testGetTableColumn() {
+  public void testGetTableColumn() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 2, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -828,7 +868,9 @@ public class TableCellTest {
   }
 
   @Test
-  public void testGetTableRow() {
+  public void testGetTableRow() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 2, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -838,16 +880,18 @@ public class TableCellTest {
   }
 
   @Test
-  public void testRemoveContent() {
+  public void testRemoveContent() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 5, columnindex = 8;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
 
     Assert.assertTrue(fcell.mCellElement.getChildNodes().getLength() > 0);
     fcell.removeContent();
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(0, fcell.mCellElement.getChildNodes().getLength());
@@ -855,6 +899,8 @@ public class TableCellTest {
 
   @Test
   public void testRemoveTextContent() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 5, columnindex = 8;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -871,34 +917,38 @@ public class TableCellTest {
     Assert.assertEquals(2, fcell.mCellElement.getChildNodes().getLength());
 
     fcell.removeTextContent();
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(1, fcell.mCellElement.getChildNodes().getLength());
   }
 
-  @Test
-  public void testGetSetDisplayText() {
+  @Test @Ignore // FIXME test failure
+  public void testGetSetDisplayText() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 5, columnindex = 5;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     String expected = "display text";
 
-    // Assert.assertEquals(expected, fcell.getDisplayText());
-
     fcell.setDisplayText(expected);
-    saveods();
+    Assert.assertEquals(expected, fcell.getDisplayText());
+
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expected, fcell.getDisplayText());
   }
 
-  @Test
-  public void testGetSetFormatString() {
+  @Test @Ignore // FIXME test failure
+  public void testGetSetFormatString() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     int rowindex = 3, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
@@ -918,16 +968,18 @@ public class TableCellTest {
     // String expected="MMM d, yy";
     // String expected="yyyy-MM-dd";
 
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expected, fcell.getFormatString());
   }
 
   @Test
-  public void testGetCurrencySymbol() {
+  public void testGetCurrencySymbol() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell cell1 = table.getCellByPosition("C2");
     Assert.assertEquals("$", cell1.getCurrencySymbol());
@@ -935,8 +987,10 @@ public class TableCellTest {
     Assert.assertEquals("CNY", cell2.getCurrencySymbol());
   }
 
-  @Test
-  public void testGetSetCurrencyFormat() {
+  @Test @Ignore // FIXME test failure
+  public void testGetSetCurrencyFormat() throws Exception {
+    OdfSpreadsheetDocument odsdoc = loadInputOds();
+
     OdfTable table = odsdoc.getTableByName("Sheet1");
     String[] formats = {"$#,##0.00", "#,##0.00 CNY", "$#,##0.0"};
 
@@ -971,9 +1025,9 @@ public class TableCellTest {
     cell.setCurrencyValue(-32.12, "USD");
     cell.setCurrencyFormat("$", formats[2]);
 
-    saveods();
+    saveOutputOds(odsdoc);
     // reload
-    loadOutputSpreadsheet();
+    odsdoc = loadOutputOds();
     table = odsdoc.getTableByName("Sheet1");
     for (int i = 1; i <= 3; i++) {
       OdfTableCell newcell = table.getCellByPosition("J" + i);
@@ -981,7 +1035,7 @@ public class TableCellTest {
     }
   }
 
-  @Test
+  @Test @Ignore // FIXME test failure
   public void testSetDefaultCellStyle() {
     OdfSpreadsheetDocument outputDocument;
     OdfContentDom contentDom; // the document object model for content.xml

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
@@ -23,10 +23,8 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.odftoolkit.odfdom.doc.OdfSpreadsheetDocument;
@@ -53,19 +51,6 @@ public class TableCellTest {
   static final String SAMPLE_STYLE_SPREADSHEET = "TestSpreadsheetStyleTable";
   static final String SAMPLE_TEXT = "TestTextTable";
   OdfSpreadsheetDocument odsstyle;
-  OdfTextDocument odtdoc;
-
-  @Before
-  public void setUp() {
-    try {
-      odtdoc =
-        OdfTextDocument.loadDocument(
-            ResourceUtilities.getAbsoluteInputPath(SAMPLE_TEXT + ".odt"));
-
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-    }
-  }
 
   private OdfSpreadsheetDocument loadInputOds() throws Exception {
     return OdfSpreadsheetDocument.loadDocument(
@@ -73,13 +58,8 @@ public class TableCellTest {
     );
   }
 
-  private void saveOutputOds(OdfSpreadsheetDocument odsdoc) {
-    try {
-      odsdoc.save(ResourceUtilities.getTestOutputFile(SAMPLE_SPREADSHEET + "Output.ods"));
-
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-    }
+  private void saveOutputOds(OdfSpreadsheetDocument odsdoc) throws Exception {
+    odsdoc.save(ResourceUtilities.getTestOutputFile(SAMPLE_SPREADSHEET + "Output.ods"));
   }
 
   private OdfSpreadsheetDocument loadOutputOds() throws Exception {
@@ -88,12 +68,20 @@ public class TableCellTest {
     );
   }
 
-  private void saveodt() {
-    try {
-      odtdoc.save(ResourceUtilities.getTestOutputFile(SAMPLE_TEXT + "Output.odt"));
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-    }
+  private OdfTextDocument loadInputOdt() throws Exception {
+    return OdfTextDocument.loadDocument(
+      ResourceUtilities.getAbsoluteInputPath(SAMPLE_TEXT + ".odt")
+    );
+  }
+
+  private void saveOutputOdt(OdfTextDocument odsdoc) throws Exception {
+    odsdoc.save(ResourceUtilities.getTestOutputFile(SAMPLE_TEXT + "Output.odt"));
+  }
+
+  private OdfTextDocument loadOutputOdt() throws Exception {
+    return OdfTextDocument.loadDocument(
+      ResourceUtilities.getTestOutputFile(SAMPLE_TEXT + "Output.odt")
+    );
   }
 
   @Test
@@ -107,7 +95,8 @@ public class TableCellTest {
     Assert.assertEquals(rowindex, cell.getRowIndex());
     Assert.assertEquals(columnindex, cell.getColumnIndex());
 
-    OdfTable table3 = odtdoc.getTableByName("Table3");
+    OdfTextDocument odtdoc = loadInputOdt();
+    table = odtdoc.getTableByName("Table3");
     OdfTableCell cell1 = table.getCellByPosition(0, 1);
     Assert.assertEquals(1, cell1.getRowIndex());
     Assert.assertEquals(0, cell1.getColumnIndex());
@@ -142,16 +131,11 @@ public class TableCellTest {
     saveOutputOds(odsdoc);
 
     OdfSpreadsheetDocument ods;
-    try {
-      ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      OdfTable tbl = ods.getTableByName("Sheet1");
-      OdfTableCell cell = tbl.getCellByPosition(0, 0);
-      String horizonAlignment = cell.getHorizontalAlignment();
-      Assert.assertEquals(null, horizonAlignment);
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
-    }
+    ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    OdfTable tbl = ods.getTableByName("Sheet1");
+    OdfTableCell cell = tbl.getCellByPosition(0, 0);
+    String horizonAlignment = cell.getHorizontalAlignment();
+    Assert.assertEquals(null, horizonAlignment);
   }
 
   @Test
@@ -173,17 +157,11 @@ public class TableCellTest {
     align = fcell.getVerticalAlignment();
     Assert.assertEquals("bottom", align);
     saveOutputOds(odsdoc);
-    OdfSpreadsheetDocument ods;
-    try {
-      ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      OdfTable tbl = ods.getTableByName("Sheet1");
-      OdfTableCell cell = tbl.getCellByPosition(0, 0);
-      String verticalAlignment = cell.getVerticalAlignment();
-      Assert.assertEquals(null, verticalAlignment);
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
-    }
+    OdfSpreadsheetDocument ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    OdfTable tbl = ods.getTableByName("Sheet1");
+    OdfTableCell cell = tbl.getCellByPosition(0, 0);
+    String verticalAlignment = cell.getVerticalAlignment();
+    Assert.assertEquals(null, verticalAlignment);
   }
 
   @Test
@@ -193,32 +171,18 @@ public class TableCellTest {
     int rowindex = 3, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
-    boolean illegalArgumentFlag = false;
-    try {
-      fcell.setValueType(null);
-    } catch (IllegalArgumentException ie) {
-      if ("type shouldn't be null.".equals(ie.getMessage())) {
-        illegalArgumentFlag = true;
-      }
-    }
-    Assert.assertTrue(illegalArgumentFlag);
+    Assert.assertThrows("type shouldn't be null.", IllegalArgumentException.class, () -> fcell.setValueType(null));
 
     fcell.setValueType("date");
     String valueType = fcell.getValueType();
     Assert.assertEquals("date", valueType);
     saveOutputOds(odsdoc);
 
-    OdfSpreadsheetDocument ods;
-    try {
-      ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      OdfTable tbl = ods.getTableByName("Sheet1");
-      OdfTableCell cell = tbl.getCellByPosition(0, 0);
-      valueType = cell.getValueType();
-      Assert.assertEquals(null, valueType);
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
-    }
+    OdfSpreadsheetDocument ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    OdfTable tbl = ods.getTableByName("Sheet1");
+    OdfTableCell cell = tbl.getCellByPosition(0, 0);
+    valueType = cell.getValueType();
+    Assert.assertEquals(null, valueType);
   }
 
   @Test
@@ -261,6 +225,7 @@ public class TableCellTest {
     Assert.assertEquals("", text);
     saveOutputOds(odsdoc);
 
+    OdfTextDocument odtdoc = loadInputOdt();
     OdfTable table1 = odtdoc.getTableByName("Table1");
     OdfTableCell fcell2 = table1.getCellByPosition(0, 1);
     text = fcell2.getDisplayText();
@@ -298,104 +263,79 @@ public class TableCellTest {
     displayvalue = pcell.getDisplayText();
     Assert.assertEquals(
         "200" + (new DecimalFormatSymbols()).getDecimalSeparator() + "00%", displayvalue);
-    try {
-      OdfTableRow tablerow = table.getRowByIndex(6);
-      OdfTableCell cell = tablerow.getCellByIndex(3);
-      Calendar currenttime = Calendar.getInstance();
-      cell.setDateValue(currenttime);
-      cell.setFormatString("yyyy-MM-dd");
-      tablerow = table.getRowByIndex(7);
-      cell = tablerow.getCellByIndex(3);
-      cell.setTimeValue(currenttime);
-      cell.setFormatString("HH:mm:ss");
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
-    }
+
+    OdfTableRow tablerow = table.getRowByIndex(6);
+    OdfTableCell cell = tablerow.getCellByIndex(3);
+    Calendar currenttime = Calendar.getInstance();
+    cell.setDateValue(currenttime);
+    cell.setFormatString("yyyy-MM-dd");
+    tablerow = table.getRowByIndex(7);
+    cell = tablerow.getCellByIndex(3);
+    cell.setTimeValue(currenttime);
+    cell.setFormatString("HH:mm:ss");
+
     saveOutputOds(odsdoc);
 
     // test value type adapt function.
-    OdfSpreadsheetDocument ods;
-    try {
-      ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      OdfTable tbl = ods.getTableByName("Sheet1");
-      OdfTableCell cell;
-      for (int i = 1; i <= 10; i++) {
-        cell = tbl.getCellByPosition("A" + i);
-        cell.setDoubleValue(new Double(i));
-      }
-      cell = tbl.getCellByPosition("A11");
-      cell.setFormula("=sum(A1:A10)");
-      // contains '#' should be adapted as float.
-      cell.setFormatString("#,###");
-      Assert.assertEquals("float", cell.getValueType());
-      cell = tbl.getCellByPosition("A12");
-      cell.setFormula("=sum(A1:A10)");
-      // contains '0' should be adapted as float.
-      cell.setFormatString("0.00");
-      Assert.assertEquals("float", cell.getValueType());
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
+    OdfSpreadsheetDocument ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    OdfTable tbl = ods.getTableByName("Sheet1");
+    for (int i = 1; i <= 10; i++) {
+      cell = tbl.getCellByPosition("A" + i);
+      cell.setDoubleValue(new Double(i));
     }
-    try {
-      ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      OdfTable tbl = ods.getTableByName("Sheet1");
-      OdfTableCell cell;
-      for (int i = 1; i <= 10; i++) {
-        cell = tbl.getCellByPosition("A" + i);
-        cell.setPercentageValue(0.1);
-      }
-      cell = tbl.getCellByPosition("A11");
-      cell.setFormula("=sum(A1:A10)");
-      // contains '%'should be adapted as percentage.
-      cell.setFormatString("###.0%");
-      Assert.assertEquals("percentage", cell.getValueType());
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
+    cell = tbl.getCellByPosition("A11");
+    cell.setFormula("=sum(A1:A10)");
+    // contains '#' should be adapted as float.
+    cell.setFormatString("#,###");
+    Assert.assertEquals("float", cell.getValueType());
+    cell = tbl.getCellByPosition("A12");
+    cell.setFormula("=sum(A1:A10)");
+    // contains '0' should be adapted as float.
+    cell.setFormatString("0.00");
+    Assert.assertEquals("float", cell.getValueType());
+
+    ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    tbl = ods.getTableByName("Sheet1");
+    for (int i = 1; i <= 10; i++) {
+      cell = tbl.getCellByPosition("A" + i);
+      cell.setPercentageValue(0.1);
     }
-    try {
-      ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      OdfTable tbl = ods.getTableByName("Sheet1");
-      OdfTableCell cell;
-      for (int i = 1; i <= 10; i++) {
-        cell = tbl.getCellByPosition("A" + i);
-        cell.setDateValue(Calendar.getInstance());
-        cell.setFormatString("yyyy.MM.dd");
-      }
-      cell = tbl.getCellByPosition("A11");
-      cell.setFormula("=max(A1:A10)");
-      // contains 'y' 'M' 'd' should be adapted as date.
+    cell = tbl.getCellByPosition("A11");
+    cell.setFormula("=sum(A1:A10)");
+    // contains '%'should be adapted as percentage.
+    cell.setFormatString("###.0%");
+    Assert.assertEquals("percentage", cell.getValueType());
+
+    ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    tbl = ods.getTableByName("Sheet1");
+    for (int i = 1; i <= 10; i++) {
+      cell = tbl.getCellByPosition("A" + i);
+      cell.setDateValue(Calendar.getInstance());
       cell.setFormatString("yyyy.MM.dd");
-      Assert.assertEquals("date", cell.getValueType());
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
     }
-    try {
-      ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      OdfTable tbl = ods.getTableByName("Sheet1");
-      OdfTableCell cell;
-      for (int i = 1; i <= 10; i++) {
-        cell = tbl.getCellByPosition("A" + i);
-        cell.setTimeValue(Calendar.getInstance());
-        cell.setFormatString("yyyy.MM.dd HH:mm:ss");
-      }
-      cell = tbl.getCellByPosition("A11");
-      cell.setFormula("=max(A1:A10)");
-      // contains 'H' 'm' 's' should be adapted as time.
+    cell = tbl.getCellByPosition("A11");
+    cell.setFormula("=max(A1:A10)");
+    // contains 'y' 'M' 'd' should be adapted as date.
+    cell.setFormatString("yyyy.MM.dd");
+    Assert.assertEquals("date", cell.getValueType());
+
+    ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    tbl = ods.getTableByName("Sheet1");
+    for (int i = 1; i <= 10; i++) {
+      cell = tbl.getCellByPosition("A" + i);
+      cell.setTimeValue(Calendar.getInstance());
       cell.setFormatString("yyyy.MM.dd HH:mm:ss");
-      Assert.assertEquals("time", cell.getValueType());
-      cell = tbl.getCellByPosition("A12");
-      cell.setFormula("=max(A1:A10)");
-      // contains 'H' 'm' 's' should be adapted as time.
-      cell.setFormatString("HH:mm:ss");
-      Assert.assertEquals("time", cell.getValueType());
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
     }
+    cell = tbl.getCellByPosition("A11");
+    cell.setFormula("=max(A1:A10)");
+    // contains 'H' 'm' 's' should be adapted as time.
+    cell.setFormatString("yyyy.MM.dd HH:mm:ss");
+    Assert.assertEquals("time", cell.getValueType());
+    cell = tbl.getCellByPosition("A12");
+    cell.setFormula("=max(A1:A10)");
+    // contains 'H' 'm' 's' should be adapted as time.
+    cell.setFormatString("HH:mm:ss");
+    Assert.assertEquals("time", cell.getValueType());
   }
 
   @Test
@@ -423,17 +363,11 @@ public class TableCellTest {
     fcell = table.getCellByPosition(columnindex, rowindex);
     Assert.assertEquals(expectedColor.toString(), fcell.getCellBackgroundColor().toString());
 
-    OdfSpreadsheetDocument ods;
-    try {
-      ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      OdfTable tbl = ods.getTableByName("Sheet1");
-      OdfTableCell cell = tbl.getCellByPosition(0, 0);
-      Color actualBackColor = cell.getCellBackgroundColor();
-      Assert.assertEquals("#ffffff", actualBackColor.toString());
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
-    }
+    OdfSpreadsheetDocument ods = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    OdfTable tbl = ods.getTableByName("Sheet1");
+    OdfTableCell cell = tbl.getCellByPosition(0, 0);
+    Color actualBackColor = cell.getCellBackgroundColor();
+    Assert.assertEquals("#ffffff", actualBackColor.toString());
   }
 
   @Test
@@ -619,15 +553,8 @@ public class TableCellTest {
     Assert.assertNull(actualValue);
 
     double expected = 100.00;
-    boolean illegalArgumentFlag = false;
-    try {
-      fcell.setCurrencyValue(expected, null);
-    } catch (IllegalArgumentException ie) {
-      if ("currency shouldn't be null.".equals(ie.getMessage())) {
-        illegalArgumentFlag = true;
-      }
-    }
-    Assert.assertTrue(illegalArgumentFlag);
+    OdfTableCell finalFcell = fcell;
+    Assert.assertThrows("currency shouldn't be null.", IllegalArgumentException.class, () -> finalFcell.setCurrencyValue(expected, null));
 
     fcell.setCurrencyValue(expected, "USD");
     saveOutputOds(odsdoc);
@@ -646,14 +573,8 @@ public class TableCellTest {
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     boolean illegalArgumentFlag = false;
-    try {
-      fcell.setCurrencyCode(null);
-    } catch (IllegalArgumentException ie) {
-      if ("Currency code of cell should not be null.".equals(ie.getMessage())) {
-        illegalArgumentFlag = true;
-      }
-    }
-    Assert.assertTrue(illegalArgumentFlag);
+    OdfTableCell finalFcell = fcell;
+    Assert.assertThrows("Currency code of cell should not be null.", IllegalArgumentException.class, () -> finalFcell.setCurrencyCode(null));
 
     fcell = table.getCellByPosition(columnindex, rowindex);
     String expected = "USD";
@@ -691,14 +612,9 @@ public class TableCellTest {
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
     boolean illegalArgumentFlag = false;
-    try {
-      fcell.setTimeValue(null);
-    } catch (IllegalArgumentException ie) {
-      if ("time shouldn't be null.".equals(ie.getMessage())) {
-        illegalArgumentFlag = true;
-      }
-    }
-    Assert.assertTrue(illegalArgumentFlag);
+    OdfTableCell finalFcell = fcell;
+    Assert.assertThrows("time shouldn't be null.", IllegalArgumentException.class, () -> finalFcell.setTimeValue(null));
+
     Calendar expected = Calendar.getInstance();
     fcell.setTimeValue(expected);
     saveOutputOds(odsdoc);
@@ -720,15 +636,8 @@ public class TableCellTest {
     int rowindex = 1, columnindex = 10;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
-    boolean illegalArgumentFlag = false;
-    try {
-      fcell.setFormula(null);
-    } catch (IllegalArgumentException ie) {
-      if ("formula shouldn't be null.".equals(ie.getMessage())) {
-        illegalArgumentFlag = true;
-      }
-    }
-    Assert.assertTrue(illegalArgumentFlag);
+    OdfTableCell finalFcell = fcell;
+    Assert.assertThrows("formula shouldn't be null.", IllegalArgumentException.class, () -> finalFcell.setFormula(null));
 
     String expected = "of:=[.I2]*4";
     fcell.setFormula(expected);
@@ -762,97 +671,93 @@ public class TableCellTest {
    * called, should have "Default" style name.
    */
   @Test
-  public void testGetStyleName() {
-    try {
-      odsstyle =
-          (OdfSpreadsheetDocument)
-              OdfSpreadsheetDocument.loadDocument(
-                  ResourceUtilities.getAbsoluteInputPath(SAMPLE_STYLE_SPREADSHEET + ".ods"));
-      int rowindex = 1, columnindex = 0;
-      OdfTable table = odsstyle.getTableByName("Sheet1");
-      OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
-      String expected = "ce1";
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // the default setting is inherited, so for new row,
-      // the cell style name should be "ce1".
-      // test appendColumn
-      table.appendColumn();
-      int columnCount = table.getColumnCount();
-      fcell = table.getCellByPosition(columnCount - 1, rowindex);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test appendRow
-      table.appendRow();
-      int rowCount = table.getRowCount();
-      fcell = table.getCellByPosition(columnindex, rowCount - 1);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test insertRowsBefore
-      table.insertRowsBefore(rowindex + 1, 1);
-      fcell = table.getCellByPosition(columnindex, rowindex + 1);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test insertColumnsBefore
-      table.insertColumnsBefore(columnindex + 1, 1);
-      fcell = table.getCellByPosition(columnindex + 1, rowindex);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test appendColumns
-      table.appendColumns(2);
-      columnCount = table.getColumnCount();
-      fcell = table.getCellByPosition(columnCount - 1, rowindex);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test appendRows
-      table.appendRows(2);
-      rowCount = table.getRowCount();
-      fcell = table.getCellByPosition(columnindex, rowCount - 1);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // for getCellByPosition the return cell style should be "Default".
-      fcell = table.getCellByPosition(table.getColumnCount() + 1, table.getRowCount() + 1);
-      Assert.assertEquals("Default", fcell.getStyleName());
-      odsstyle.close();
+  public void testGetStyleName() throws Exception {
+    odsstyle =
+        (OdfSpreadsheetDocument)
+            OdfSpreadsheetDocument.loadDocument(
+                ResourceUtilities.getAbsoluteInputPath(SAMPLE_STYLE_SPREADSHEET + ".ods"));
+    int rowindex = 1, columnindex = 0;
+    OdfTable table = odsstyle.getTableByName("Sheet1");
+    OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
+    String expected = "ce1";
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // the default setting is inherited, so for new row,
+    // the cell style name should be "ce1".
+    // test appendColumn
+    table.appendColumn();
+    int columnCount = table.getColumnCount();
+    fcell = table.getCellByPosition(columnCount - 1, rowindex);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test appendRow
+    table.appendRow();
+    int rowCount = table.getRowCount();
+    fcell = table.getCellByPosition(columnindex, rowCount - 1);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test insertRowsBefore
+    table.insertRowsBefore(rowindex + 1, 1);
+    fcell = table.getCellByPosition(columnindex, rowindex + 1);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test insertColumnsBefore
+    table.insertColumnsBefore(columnindex + 1, 1);
+    fcell = table.getCellByPosition(columnindex + 1, rowindex);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test appendColumns
+    table.appendColumns(2);
+    columnCount = table.getColumnCount();
+    fcell = table.getCellByPosition(columnCount - 1, rowindex);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test appendRows
+    table.appendRows(2);
+    rowCount = table.getRowCount();
+    fcell = table.getCellByPosition(columnindex, rowCount - 1);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // for getCellByPosition the return cell style should be "Default".
+    fcell = table.getCellByPosition(table.getColumnCount() + 1, table.getRowCount() + 1);
+    Assert.assertEquals("Default", fcell.getStyleName());
+    odsstyle.close();
 
-      // change setting is not inherited, so for new row,
-      // the cell style name should be "Default".
-      odsstyle =
-          (OdfSpreadsheetDocument)
-              OdfSpreadsheetDocument.loadDocument(
-                  ResourceUtilities.getAbsoluteInputPath(SAMPLE_STYLE_SPREADSHEET + ".ods"));
-      rowindex = 1;
-      columnindex = 0;
-      table = odsstyle.getTableByName("Sheet1");
-      table.setCellStyleInheritance(false);
-      expected = "Default";
-      table.appendColumn();
-      columnCount = table.getColumnCount();
-      fcell = table.getCellByPosition(columnCount - 1, rowindex);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test appendRow
-      table.appendRow();
-      rowCount = table.getRowCount();
-      fcell = table.getCellByPosition(columnindex, rowCount - 1);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test insertRowsBefore
-      table.insertRowsBefore(rowindex + 1, 1);
-      fcell = table.getCellByPosition(columnindex, rowindex + 1);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test insertColumnsBefore
-      table.insertColumnsBefore(columnindex + 1, 1);
-      fcell = table.getCellByPosition(columnindex + 1, rowindex);
-      // Assert.assertEquals(expected, fcell.getStyleName());
-      // test appendColumns
-      table.appendColumns(2);
-      columnCount = table.getColumnCount();
-      fcell = table.getCellByPosition(columnCount - 1, rowindex);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // test appendRows
-      table.appendRows(2);
-      rowCount = table.getRowCount();
-      fcell = table.getCellByPosition(columnindex, rowCount - 1);
-      Assert.assertEquals(expected, fcell.getStyleName());
-      // for getCellByPosition the return cell style should be "Default".
-      fcell = table.getCellByPosition(table.getColumnCount(), table.getRowCount());
-      Assert.assertEquals("Default", fcell.getStyleName());
-      odsstyle.close();
-    } catch (Exception e) {
-      Assert.fail(e.toString());
-    }
+    // change setting is not inherited, so for new row,
+    // the cell style name should be "Default".
+    odsstyle =
+        (OdfSpreadsheetDocument)
+            OdfSpreadsheetDocument.loadDocument(
+                ResourceUtilities.getAbsoluteInputPath(SAMPLE_STYLE_SPREADSHEET + ".ods"));
+    rowindex = 1;
+    columnindex = 0;
+    table = odsstyle.getTableByName("Sheet1");
+    table.setCellStyleInheritance(false);
+    expected = "Default";
+    table.appendColumn();
+    columnCount = table.getColumnCount();
+    fcell = table.getCellByPosition(columnCount - 1, rowindex);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test appendRow
+    table.appendRow();
+    rowCount = table.getRowCount();
+    fcell = table.getCellByPosition(columnindex, rowCount - 1);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test insertRowsBefore
+    table.insertRowsBefore(rowindex + 1, 1);
+    fcell = table.getCellByPosition(columnindex, rowindex + 1);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test insertColumnsBefore
+    table.insertColumnsBefore(columnindex + 1, 1);
+    fcell = table.getCellByPosition(columnindex + 1, rowindex);
+    // Assert.assertEquals(expected, fcell.getStyleName());
+    // test appendColumns
+    table.appendColumns(2);
+    columnCount = table.getColumnCount();
+    fcell = table.getCellByPosition(columnCount - 1, rowindex);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // test appendRows
+    table.appendRows(2);
+    rowCount = table.getRowCount();
+    fcell = table.getCellByPosition(columnindex, rowCount - 1);
+    Assert.assertEquals(expected, fcell.getStyleName());
+    // for getCellByPosition the return cell style should be "Default".
+    fcell = table.getCellByPosition(table.getColumnCount(), table.getRowCount());
+    Assert.assertEquals("Default", fcell.getStyleName());
+    odsstyle.close();
   }
 
   @Test
@@ -952,15 +857,9 @@ public class TableCellTest {
     int rowindex = 3, columnindex = 0;
     OdfTable table = odsdoc.getTableByName("Sheet1");
     OdfTableCell fcell = table.getCellByPosition(columnindex, rowindex);
-    boolean illegalArgumentFlag = false;
-    try {
-      fcell.setFormatString(null);
-    } catch (IllegalArgumentException ie) {
-      if ("formatStr shouldn't be null.".equals(ie.getMessage())) {
-        illegalArgumentFlag = true;
-      }
-    }
-    Assert.assertTrue(illegalArgumentFlag);
+    OdfTableCell finalFcell = fcell;
+    Assert.assertThrows("format string shouldn't be null.", IllegalArgumentException.class, () -> finalFcell.setFormatString(null));
+
     // float format string
     String expected = "#0.0";
     fcell.setFormatString(expected);
@@ -995,24 +894,9 @@ public class TableCellTest {
     String[] formats = {"$#,##0.00", "#,##0.00 CNY", "$#,##0.0"};
 
     OdfTableCell cell = table.getCellByPosition("J1");
-    boolean illegalArgumentFlag = false;
-    try {
-      cell.setCurrencyFormat(null, formats[0]);
-    } catch (IllegalArgumentException ie) {
-      if ("currencySymbol shouldn't be null.".equals(ie.getMessage())) {
-        illegalArgumentFlag = true;
-      }
-    }
-    Assert.assertTrue(illegalArgumentFlag);
-
-    try {
-      cell.setCurrencyFormat("$", null);
-    } catch (IllegalArgumentException ie) {
-      if ("format shouldn't be null.".equals(ie.getMessage())) {
-        illegalArgumentFlag = true;
-      }
-    }
-    Assert.assertTrue(illegalArgumentFlag);
+    OdfTableCell finalCell = cell;
+    Assert.assertThrows("currency format shouldn't be null.", IllegalArgumentException.class, () -> finalCell.setCurrencyFormat(null, formats[0]));
+    Assert.assertThrows("format shouldn't be null.", IllegalArgumentException.class, () -> finalCell.setCurrencyFormat("$", null));
 
     cell.setCurrencyValue(32.12, "USD");
     cell.setCurrencyFormat("$", formats[0]);
@@ -1036,7 +920,7 @@ public class TableCellTest {
   }
 
   @Test @Ignore // FIXME test failure
-  public void testSetDefaultCellStyle() {
+  public void testSetDefaultCellStyle() throws Exception {
     OdfSpreadsheetDocument outputDocument;
     OdfContentDom contentDom; // the document object model for content.xml
     OdfStylesDom stylesDom; // the document object model for styles.xml
@@ -1048,52 +932,47 @@ public class TableCellTest {
     String noaaDateStyleName;
     String noaaTempStyleName;
 
-    try {
-      outputDocument = OdfSpreadsheetDocument.newSpreadsheetDocument();
-      contentDom = outputDocument.getContentDom();
-      contentAutoStyles = contentDom.getOrCreateAutomaticStyles();
+    outputDocument = OdfSpreadsheetDocument.newSpreadsheetDocument();
+    contentDom = outputDocument.getContentDom();
+    contentAutoStyles = contentDom.getOrCreateAutomaticStyles();
 
-      OdfNumberDateStyle dateStyle =
-          new OdfNumberDateStyle(contentDom, "yyyy-MM-dd", "numberDateStyle", null);
-      OdfNumberStyle numberStyle =
-          new OdfNumberStyle(contentDom, "#0.00", "numberTemperatureStyle");
+    OdfNumberDateStyle dateStyle =
+        new OdfNumberDateStyle(contentDom, "yyyy-MM-dd", "numberDateStyle", null);
+    OdfNumberStyle numberStyle =
+        new OdfNumberStyle(contentDom, "#0.00", "numberTemperatureStyle");
 
-      contentAutoStyles.appendChild(dateStyle);
-      contentAutoStyles.appendChild(numberStyle);
+    contentAutoStyles.appendChild(dateStyle);
+    contentAutoStyles.appendChild(numberStyle);
 
-      style = contentAutoStyles.newStyle(OdfStyleFamily.TableCell);
-      noaaDateStyleName = style.getStyleNameAttribute();
-      style.setStyleDataStyleNameAttribute("numberDateStyle");
+    style = contentAutoStyles.newStyle(OdfStyleFamily.TableCell);
+    noaaDateStyleName = style.getStyleNameAttribute();
+    style.setStyleDataStyleNameAttribute("numberDateStyle");
 
-      // and for time cells
-      style = contentAutoStyles.newStyle(OdfStyleFamily.TableCell);
-      noaaTempStyleName = style.getStyleNameAttribute();
-      style.setStyleDataStyleNameAttribute("numberTemperatureStyle");
-      style.setProperty(StyleParagraphPropertiesElement.TextAlign, "end");
+    // and for time cells
+    style = contentAutoStyles.newStyle(OdfStyleFamily.TableCell);
+    noaaTempStyleName = style.getStyleNameAttribute();
+    style.setStyleDataStyleNameAttribute("numberTemperatureStyle");
+    style.setProperty(StyleParagraphPropertiesElement.TextAlign, "end");
 
-      OdfTable table = OdfTable.newTable(outputDocument);
-      List<OdfTableColumn> columns = table.insertColumnsBefore(0, 3);
-      OdfTableColumn column = columns.get(0);
-      column.setDefaultCellStyle(
-          contentAutoStyles.getStyle(noaaDateStyleName, OdfStyleFamily.TableCell));
-      OdfTableCell aCell = column.getCellByIndex(0);
-      aCell.setValueType("date");
-      String format = aCell.getFormatString();
-      Assert.assertEquals("yyyy-MM-dd", format);
+    OdfTable table = OdfTable.newTable(outputDocument);
+    List<OdfTableColumn> columns = table.insertColumnsBefore(0, 3);
+    OdfTableColumn column = columns.get(0);
+    column.setDefaultCellStyle(
+        contentAutoStyles.getStyle(noaaDateStyleName, OdfStyleFamily.TableCell));
+    OdfTableCell aCell = column.getCellByIndex(0);
+    aCell.setValueType("date");
+    String format = aCell.getFormatString();
+    Assert.assertEquals("yyyy-MM-dd", format);
 
-      List<OdfTableRow> rows = table.insertRowsBefore(0, 1);
-      OdfTableRow row = rows.get(0);
-      row.setDefaultCellStyle(
-          contentAutoStyles.getStyle(noaaTempStyleName, OdfStyleFamily.TableCell));
-      OdfTableCell bCell = row.getCellByIndex(0);
-      bCell.setValueType("float");
-      String bformat = bCell.getFormatString();
-      Assert.assertEquals("#0.00", bformat);
-      Assert.assertEquals("end", bCell.getHorizontalAlignment());
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail();
-    }
+    List<OdfTableRow> rows = table.insertRowsBefore(0, 1);
+    OdfTableRow row = rows.get(0);
+    row.setDefaultCellStyle(
+        contentAutoStyles.getStyle(noaaTempStyleName, OdfStyleFamily.TableCell));
+    OdfTableCell bCell = row.getCellByIndex(0);
+    bCell.setValueType("float");
+    String bformat = bCell.getFormatString();
+    Assert.assertEquals("#0.00", bformat);
+    Assert.assertEquals("end", bCell.getHorizontalAlignment());
   }
 
   @Test

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
@@ -232,7 +232,7 @@ public class TableCellTest {
     Assert.assertEquals("Aabbccddee", text);
   }
 
-  @Test @Ignore // FIXME test failure
+  @Test @Ignore // FIXME test failure: Expected: #0.0 Actual: 0.0
   public void testSetGetFormat() throws Exception {
     OdfSpreadsheetDocument odsdoc = loadInputOds();
 
@@ -830,7 +830,7 @@ public class TableCellTest {
     Assert.assertEquals(1, fcell.mCellElement.getChildNodes().getLength());
   }
 
-  @Test @Ignore // FIXME test failure
+  @Test
   public void testGetSetDisplayText() throws Exception {
     OdfSpreadsheetDocument odsdoc = loadInputOds();
 
@@ -850,7 +850,7 @@ public class TableCellTest {
     Assert.assertEquals(expected, fcell.getDisplayText());
   }
 
-  @Test @Ignore // FIXME test failure
+  @Test @Ignore // FIXME test failure: Expected: #0.0 Actual: 0.0
   public void testGetSetFormatString() throws Exception {
     OdfSpreadsheetDocument odsdoc = loadInputOds();
 
@@ -886,7 +886,7 @@ public class TableCellTest {
     Assert.assertEquals("CNY", cell2.getCurrencySymbol());
   }
 
-  @Test @Ignore // FIXME test failure
+  @Test  @Ignore // FIXME test failure: Expected: $#,##0.00 Actual: [$$]#,##0.00
   public void testGetSetCurrencyFormat() throws Exception {
     OdfSpreadsheetDocument odsdoc = loadInputOds();
 
@@ -919,7 +919,7 @@ public class TableCellTest {
     }
   }
 
-  @Test @Ignore // FIXME test failure
+  @Test @Ignore // FIXME test failure: Expected: yyyy-MM-dd Actual: YYYY-MM-DD
   public void testSetDefaultCellStyle() throws Exception {
     OdfSpreadsheetDocument outputDocument;
     OdfContentDom contentDom; // the document object model for content.xml
@@ -976,7 +976,6 @@ public class TableCellTest {
   }
 
   @Test
-  @Ignore
   public void testGetFromEmptyDateValue() throws Exception {
     OdfSpreadsheetDocument doc = OdfSpreadsheetDocument.newSpreadsheetDocument();
     OdfTable table = OdfTable.newTable(doc);
@@ -985,8 +984,7 @@ public class TableCellTest {
     Assert.assertNull(dateCell.getDateValue());
   }
 
-  @Test
-  @Ignore
+  @Test @Ignore // FIXME test failure: NPE
   public void testGetFromEmptyTimeValue() throws Exception {
     OdfSpreadsheetDocument doc = OdfSpreadsheetDocument.newSpreadsheetDocument();
     OdfTable table = OdfTable.newTable(doc);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableCellTest.java
@@ -23,7 +23,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.logging.Logger;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -46,7 +45,6 @@ import org.odftoolkit.odfdom.utils.ResourceUtilities;
 
 public class TableCellTest {
 
-  private static final Logger LOG = Logger.getLogger(TableCellTest.class.getName());
   static final String SAMPLE_SPREADSHEET = "TestSpreadsheetTable";
   static final String SAMPLE_STYLE_SPREADSHEET = "TestSpreadsheetStyleTable";
   static final String SAMPLE_TEXT = "TestTextTable";


### PR DESCRIPTION
This is the first part of fixes for #360. It is about TableCellTest. The whole test class was ignored. After enabling it again, many tests failed.

Many of the tests work by loading a workbook, making changes, saving the workbook again and then reloading it to assert that the correct results are read from the updated workbook. The paths were messed up and some tests read the original workbook instead of the updated one when reloading, others  used the wrong path and a FileNotFoundException occurred.

In the first step, I removed the @Ignore on the test class and made sure the correct files are read. Some tests still fail which indicates that there are bugs in ODF Toolkit. I added `@Ignore` annotations and a FIXME comment to these.

As I am still quite new to this project, someone with more knowledge about the internal workings might look at some of the failing tests, for example formats are written out but come back differently after reloading.

But I think this PR is already an improvement because now we have at least 24 working tests where before, there were 0.