### PR TITLE
Chore/refactorings

### DIFF
--- a/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionVisitorChildren.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionVisitorChildren.java
@@ -53,7 +53,7 @@ import java.util.List;
  */
 public class MSVExpressionVisitorChildren implements ExpressionVisitor {
 
-  private static final List<Expression> empty = Collections.EMPTY_LIST;
+  private static final List<Expression> empty = Collections.emptyList();
 
   public List<Expression> onAnyString() {
     return empty;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Component.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Component.java
@@ -859,29 +859,7 @@ public class Component {
 
   /** @return the position as a slash separated string */
   protected String getPosition(Component c) {
-    String s;
-    List<Integer> position;
-    int childPos;
-    if (c.mParent != null) {
-      position = new LinkedList();
-      Component parent;
-      while ((parent = c.getParent()) != null) {
-        childPos = parent.indexOf(c);
-        //				if (childPos < 0) {
-        //					childPos = indexOf(c);
-        //				}
-        position.add(childPos);
-        c = parent;
-      }
-      StringBuilder sb = new StringBuilder();
-      for (int i = position.size() - 1; i >= 0; i--) {
-        sb.append("/").append(position.get(i));
-      }
-      s = sb.toString();
-    } else {
-      s = "/";
-    }
-    return s;
+    return getPositionString(c);
   }
 
   /** @return the position as a slash separated string */
@@ -890,7 +868,7 @@ public class Component {
     List<Integer> position;
     int childPos;
     if (c.mParent != null) {
-      position = new LinkedList();
+      position = new LinkedList<>();
       Component parent;
       while ((parent = c.getParent()) != null) {
         childPos = parent.indexOf(c);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
@@ -92,7 +92,7 @@ public class Table<T> extends Component {
 
   @Override
   // TABLE ONLY -- Svante REMOVE THIS LATER AS THIS IT IS ONLY USED BY TABLES
-  public List getChildren() {
+  public List<Component> getChildren() {
     return list(this);
   }
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextContainingElement.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextContainingElement.java
@@ -83,8 +83,8 @@ public abstract class TextContainingElement extends OdfStylableElement {
    */
   public OdfElement appendTextSelection(TextSelection outerSelection) {
     if (this.mSelections == null) {
-      Comparator c = new SelectionComparator();
-      mSelections = new TreeSet<TextSelection>(c);
+      Comparator<TextSelection> c = new SelectionComparator();
+      mSelections = new TreeSet<>(c);
     }
     OdfElement parentElement = (OdfElement) outerSelection.mSelectionElement.getParentNode();
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextFieldSelection.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextFieldSelection.java
@@ -27,7 +27,7 @@ import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeAutomaticStyles;
 import org.odftoolkit.odfdom.pkg.OdfElement;
 
 /** @author svante.schubertATgmail.com */
-public class TextFieldSelection extends TextSelection implements Comparable {
+public class TextFieldSelection extends TextSelection {
 
   private String mReplacementText;
   private final Map<String, Object> mAttrs = new HashMap<String, Object>();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextHyperlinkSelection.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextHyperlinkSelection.java
@@ -21,7 +21,7 @@ import java.util.TreeSet;
 import org.odftoolkit.odfdom.dom.element.text.TextAElement;
 
 /** @author svante.schubertATgmail.com */
-public class TextHyperlinkSelection extends TextSelection implements Comparable {
+public class TextHyperlinkSelection extends TextSelection {
 
   /**
    * Constructor.

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextSelection.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextSelection.java
@@ -19,7 +19,7 @@ import java.util.List;
 import org.odftoolkit.odfdom.pkg.OdfElement;
 
 /** @author svante.schubertATgmail.com */
-public abstract class TextSelection {
+public abstract class TextSelection implements Comparable<TextSelection> {
 
   protected List<Integer> mStartPosition;
   protected List<Integer> mEndPosition;
@@ -144,9 +144,7 @@ public abstract class TextSelection {
    * ClassCastException - if the specified object's type prevents it from being compared to this
    * object.
    */
-  public int compareTo(Object o) {
-    TextSelection s2 = (TextSelection) o;
-
+  public int compareTo(TextSelection s2) {
     int result = 0;
     result = comparePosition(this.getStartPosition(), s2.getStartPosition());
     if (result == 0) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextSpanSelection.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextSpanSelection.java
@@ -19,7 +19,7 @@ import java.util.List;
 import org.odftoolkit.odfdom.dom.element.text.TextSpanElement;
 
 /** @author svante.schubertATgmail.com */
-public class TextSpanSelection extends TextSelection implements Comparable {
+public class TextSpanSelection extends TextSelection {
 
   /**
    * Constructor.

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/rdfa/BookmarkRDFMetadataExtractor.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/rdfa/BookmarkRDFMetadataExtractor.java
@@ -184,8 +184,8 @@ public class BookmarkRDFMetadataExtractor extends DefaultElementVisitor {
     return m;
   }
 
-  private Iterator fromAttributes(Attributes attributes) {
-    List toReturn = new LinkedList();
+  private Iterator<Attribute> fromAttributes(Attributes attributes) {
+    List<Attribute> toReturn = new LinkedList<>();
 
     for (int i = 0; i < attributes.getLength(); i++) {
       String qname = attributes.getQName(i);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
@@ -42,8 +42,8 @@ final class EvalContext implements NamespaceContext {
   String vocab;
   List<String> forwardProperties;
   List<String> backwardProperties;
-  Map<String, String> xmlnsMap = Collections.EMPTY_MAP;
-  Map<String, String> prefixMap = Collections.EMPTY_MAP;
+  Map<String, String> xmlnsMap = Collections.emptyMap();
+  Map<String, String> prefixMap = Collections.emptyMap();
 
   protected EvalContext(String base) {
     super();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/URIExtractorImpl.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/URIExtractorImpl.java
@@ -41,7 +41,7 @@ import org.apache.commons.validator.routines.UrlValidator;
 class URIExtractorImpl implements URIExtractor {
   private Set<Setting> settings;
   private final Resolver resolver;
-  private Map<String, String> xmlnsMap = Collections.EMPTY_MAP;
+  private Map<String, String> xmlnsMap = Collections.emptyMap();
   private boolean isForSAX;
   private UrlValidator urlValidator;
 

--- a/odfdom/src/test/java/org/odftoolkit/junit/AlphabeticalOrderedRunner.java
+++ b/odfdom/src/test/java/org/odftoolkit/junit/AlphabeticalOrderedRunner.java
@@ -44,25 +44,9 @@ public class AlphabeticalOrderedRunner extends BlockJUnit4ClassRunner {
    * part is in overriding the computeTestMethods method.
    */
   @Override
-  protected List computeTestMethods() {
-    List lst = super.computeTestMethods();
-    List methodList = new ArrayList(lst);
-
-    Collections.sort(methodList, new AlphabeticalOrder());
-
+  protected List<FrameworkMethod> computeTestMethods() {
+    List<FrameworkMethod> methodList = new ArrayList<>(super.computeTestMethods());
+    methodList.sort(Comparator.comparing(FrameworkMethod::getName));
     return methodList;
-  }
-
-  /*
-   * Class for alphabetical ordering of a list
-   */
-  public class AlphabeticalOrder implements Comparator {
-
-    public int compare(Object o1, Object o2) {
-      FrameworkMethod f1 = (FrameworkMethod) o1;
-      FrameworkMethod f2 = (FrameworkMethod) o2;
-
-      return f1.getName().compareTo(f2.getName());
-    }
   }
 }

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/Configuration.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/Configuration.java
@@ -69,13 +69,13 @@ public class Configuration extends Properties {
 
   public List<String> getListPropety(String aPropNamePrefix) {
     TreeSet<String> aSortedPropNames = new TreeSet<String>();
-    Enumeration aPropNames = propertyNames();
+    Enumeration<?> aPropNames = propertyNames();
     while (aPropNames.hasMoreElements()) {
       String aPropName = (String) aPropNames.nextElement();
       if (aPropName.startsWith(aPropNamePrefix)) aSortedPropNames.add(aPropName);
     }
 
-    List<String> aValues = new Vector<String>(aSortedPropNames.size());
+    List<String> aValues = new Vector<>(aSortedPropNames.size());
     Iterator<String> aIter = aSortedPropNames.iterator();
     while (aIter.hasNext()) aValues.add(getProperty(aIter.next()));
 


### PR DESCRIPTION
- fix many "raw use of generics" warnings
-   MSVExpressionVisitorChildren contained to methods with th exact same implementation, I kept both, but delegate from the non-static one to the static one
- removed the class AlphabeticalOrder in AlphabeticalOrderedRunner.java, using a Comparator.comparing(...) instead