### PR TITLE
Chore/use primitives use bulk operations fix raw generics

### DIFF
--- a/generator/schema2template/src/main/java/schema2template/grammar/OdfFamilyPropertiesPatternMatcher.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/OdfFamilyPropertiesPatternMatcher.java
@@ -214,11 +214,10 @@ class OdfFamilyPropertiesPatternMatcher {
   @Override
   public String toString() {
     Map<String, List<String>> results = getFamilyProperties();
-    Set<String> families = results.keySet();
     StringBuilder sb = new StringBuilder();
-    for (String family : families) {
-      sb.append("@style:family = '").append(family).append("' =");
-      List<String> propNames = results.get(family);
+    for (Map.Entry<String, List<String>> entry : results.entrySet()) {
+      sb.append("@style:family = '").append(entry.getKey()).append("' =");
+      List<String> propNames = entry.getValue();
       for (String propName : propNames) {
         sb.append(" style:").append(propName);
       }

--- a/generator/schema2template/src/main/java/schema2template/grammar/OdfModel.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/OdfModel.java
@@ -123,9 +123,7 @@ public class OdfModel {
   public List<String> getStyleFamilies(PuzzleComponent element) {
     List<String> retval = new ArrayList<String>();
     if (mNameToFamiliesMap.containsKey(element.getQName())) {
-      for (String family : mNameToFamiliesMap.get(element.getQName())) {
-        retval.add(family);
-      }
+      retval.addAll(mNameToFamiliesMap.get(element.getQName()));
     }
     return retval;
   }
@@ -139,9 +137,7 @@ public class OdfModel {
     Iterator<List<String>> iter = mNameToFamiliesMap.values().iterator();
     List<String> families = new ArrayList<String>();
     while (iter.hasNext()) {
-      for (String family : iter.next()) {
-        families.add(family);
-      }
+      families.addAll(iter.next());
     }
     return new TreeSet<String>(families);
   }

--- a/generator/schema2template/src/main/java/schema2template/grammar/PuzzlePiece.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/PuzzlePiece.java
@@ -693,17 +693,17 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
       puzzlePiece.mCanHaveText = elementInfo.canHaveText();
 
       Map<String, List<Expression>> atnameToDefs = buildNameExpressionsMap(puzzlePiece.mAttributes);
-      for (String name : atnameToDefs.keySet()) {
-        if (elementInfo.isMandatory(atnameToDefs.get(name))) {
-          puzzlePiece.mMandatoryChildAttributeNames.add(name);
+      for (Map.Entry<String, List<Expression>> entry : atnameToDefs.entrySet()) {
+        if (elementInfo.isMandatory(entry.getValue())) {
+          puzzlePiece.mMandatoryChildAttributeNames.add(entry.getKey());
         }
       }
 
       Map<String, List<Expression>> elnameToDefs =
           buildNameExpressionsMap(puzzlePiece.mChildElements);
-      for (String name : elnameToDefs.keySet()) {
-        if (elementInfo.isMandatory(elnameToDefs.get(name))) {
-          puzzlePiece.mMandatoryChildElementNames.add(name);
+      for (Map.Entry<String, List<Expression>> entry : elnameToDefs.entrySet()) {
+        if (elementInfo.isMandatory(entry.getValue())) {
+          puzzlePiece.mMandatoryChildElementNames.add(entry.getKey());
         }
       }
 

--- a/generator/schema2template/src/main/java/schema2template/grammar/TinkerPopGraph.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/TinkerPopGraph.java
@@ -113,7 +113,7 @@ class TinkerPopGraph {
     addGraphProperties(g, v, parentV, exp, parentExp);
     if (!(exp instanceof NameClassAndExpression) || parentExp == null) {
       List<Expression> children = (List<Expression>) exp.visit(CHILD_VISITOR);
-      Integer newChildNo = 0;
+      int newChildNo = 0;
       for (Expression newChildExp : children) {
         Vertex newChildV = createVertex(g, newChildExp);
         // only for sequences the order of children is important
@@ -123,7 +123,7 @@ class TinkerPopGraph {
               "has",
               newChildV,
               "order",
-              newChildNo.toString(),
+            Integer.toString(newChildNo),
               "color",
               "#00ee00"); // sequence edges using color green2 see
           // http://www.farb-tabelle.de/de/rgb2hex.htm?q=green2

--- a/generator/schema2template/src/main/java/schema2template/template/SourceCodeModel.java
+++ b/generator/schema2template/src/main/java/schema2template/template/SourceCodeModel.java
@@ -70,8 +70,9 @@ public class SourceCodeModel {
     // Intermediate Step -> get all childOfBaseElement Definitions for each baseName
     Map<String, SortedSet<PuzzlePiece>> baseNameElementsMap =
         new HashMap<String, SortedSet<PuzzlePiece>>(baseNames.size());
-    for (String elementName : elementNameBaseNameMap.keySet()) {
-      String baseName = elementNameBaseNameMap.get(elementName);
+    for (Map.Entry<String, String> entry : elementNameBaseNameMap.entrySet()) {
+      String elementName = entry.getKey();
+      String baseName = entry.getValue();
         SortedSet<PuzzlePiece> elements = baseNameElementsMap.computeIfAbsent(baseName, k -> new TreeSet<PuzzlePiece>());
         PuzzleComponent childElement = schemaModel.getElement(elementName);
       if (childElement != null) {
@@ -97,10 +98,10 @@ public class SourceCodeModel {
 
     // Generate a map from element tag name to base classes
     mElementBaseMap = new HashMap<String, SourceCodeBaseClass>(elementNameBaseNameMap.size());
-    for (String elementName : elementNameBaseNameMap.keySet()) {
-      String baseName = elementNameBaseNameMap.get(elementName);
+    for (Map.Entry<String, String> entry : elementNameBaseNameMap.entrySet()) {
+      String baseName = entry.getValue();
       SourceCodeBaseClass baseclass = mBaseNameToBaseClass.get(baseName);
-      mElementBaseMap.put(elementName, baseclass);
+      mElementBaseMap.put(entry.getKey(), baseclass);
     }
   }
   /**

--- a/generator/schema2template/src/main/java/schema2template/template/SourceCodeModel.java
+++ b/generator/schema2template/src/main/java/schema2template/template/SourceCodeModel.java
@@ -248,7 +248,7 @@ public class SourceCodeModel {
     String superClassName = null;
     if (mElementSuperClassNameMap != null && childName != null) {
       superClassName = mElementSuperClassNameMap.get(childName);
-      if (superClassName != null & superClassName.contains(".")) {
+      if (superClassName != null && superClassName.contains(".")) {
         superClassName =
             superClassName.substring(superClassName.lastIndexOf(".") + 1, superClassName.length());
       }
@@ -265,7 +265,7 @@ public class SourceCodeModel {
     String superClassName = null;
     if (mElementSuperClassNameMap != null && childName != null) {
       superClassName = mElementSuperClassNameMap.get(childName);
-      if (superClassName != null & superClassName.contains(".")) {
+      if (superClassName != null && superClassName.contains(".")) {
         superClassName = superClassName.substring(0, superClassName.lastIndexOf("."));
       }
     }

--- a/generator/schema2template/src/test/java/schema2template/grammar/DirectoryCompare.java
+++ b/generator/schema2template/src/test/java/schema2template/grammar/DirectoryCompare.java
@@ -72,7 +72,7 @@ class DirectoryCompare {
   private static boolean compareDirectories(Path dir1, Path dir2) throws IOException {
     boolean dir1Exists = Files.exists(dir1) && Files.isDirectory(dir1);
     boolean dir2Exists = Files.exists(dir2) && Files.isDirectory(dir2);
-    Boolean areEqual = Boolean.TRUE;
+    boolean areEqual = true;
 
     if (dir1Exists && dir2Exists) {
       HashMap<Path, Path> dir1Paths = new HashMap<>();
@@ -93,7 +93,7 @@ class DirectoryCompare {
             Level.SEVERE,
             "\nThe file size differ:\n{0} files exist in \n{1}\n{2} files exist in\n{3}\n\n",
             new Object[] {dir1Paths.size(), dir1, dir2Paths.size(), dir2});
-        areEqual = Boolean.FALSE;
+        areEqual = false;
       }
 
       // For each file in dir1, check if also dir2 contains this file and if
@@ -102,7 +102,7 @@ class DirectoryCompare {
         Path relativePath = pathEntry.getKey();
         Path absolutePath = pathEntry.getValue();
         if (!dir2Paths.containsKey(relativePath)) {
-          areEqual = Boolean.FALSE;
+          areEqual = false;
           LOG.log(
               Level.SEVERE,
               "\nThe file\n{0}\ndoes not exist in\n{1}\n\n",
@@ -112,7 +112,7 @@ class DirectoryCompare {
             // error msg within textFilesEquals with line difference
             // LOG.log(Level.SEVERE, "There is a difference between:\n{0}\n and \n{1}\n\n", new
             // Object[]{absolutePath.toString(), relativePath.toAbsolutePath().toString()});
-            areEqual = Boolean.FALSE;
+            areEqual = false;
           }
           // remove it to be able to show the superset of dir2Paths in the end
           dir2Paths.remove(relativePath);
@@ -120,7 +120,7 @@ class DirectoryCompare {
       }
       // if there is a superset of dir2Paths
       if (!dir2Paths.isEmpty()) {
-        areEqual = Boolean.FALSE;
+        areEqual = false;
         for (Entry<Path, Path> pathEntry2 : dir2Paths.entrySet()) {
           Path relativePath2 = pathEntry2.getKey();
           LOG.log(
@@ -131,7 +131,7 @@ class DirectoryCompare {
       }
       return areEqual;
     } else {
-      areEqual = Boolean.FALSE;
+      areEqual = false;
       if (!dir1Exists) {
         LOG.log(
             Level.SEVERE,
@@ -205,21 +205,21 @@ class DirectoryCompare {
   }
 
   private static boolean textFilesEquals(Path p1, Path p2) throws IOException {
-    boolean areEqual = Boolean.TRUE;
+    boolean areEqual = true;
     if (Files.isDirectory(p1) || Files.isDirectory(p2)) {
       if (!Files.isDirectory(p1)) {
         LOG.log(
             Level.SEVERE,
             "\nOne file is a directory:\n{0}\nwhile the other is a file:\n{1}\n\n",
             new Object[] {p2.toString(), p1.toString()});
-        areEqual = Boolean.FALSE;
+        areEqual = false;
       }
       if (!Files.isDirectory(p2)) {
         LOG.log(
             Level.SEVERE,
             "\nOne file is a directory:\n{0}\nwhile the other is a file:\n{1}\n\n",
             new Object[] {p1.toString(), p2.toString()});
-        areEqual = Boolean.FALSE;
+        areEqual = false;
       }
     } else {
       try (BufferedReader reader1 = Files.newBufferedReader(p1)) {
@@ -229,10 +229,10 @@ class DirectoryCompare {
           int lineNum = 1;
           while (line1 != null || line2 != null) {
             if (line1 == null || line2 == null) {
-              areEqual = Boolean.FALSE;
+              areEqual = false;
               break;
             } else if (!line1.equals(line2)) {
-              areEqual = Boolean.FALSE;
+              areEqual = false;
               break;
             }
             line1 = reader1.readLine();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CachedTable.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CachedTable.java
@@ -33,8 +33,8 @@ import org.json.JSONObject;
 @SuppressWarnings("serial")
 class CachedTable extends CachedComponent {
 
-  private ArrayList<CachedTable> mTableStack = new ArrayList<CachedTable>();
-  public HashMap<List<Integer>, CachedTable> mAllTables = new HashMap<List<Integer>, CachedTable>();
+  private ArrayList<CachedTable> mTableStack = new ArrayList<>();
+  private Map<List<Integer>, CachedTable> mAllTables = new HashMap<>();
   // START *** SPREADSHEET PROPERTIES
   // required to track repeatedColumns rows for spreadsheets..
   public int mPreviousRepeatedRows = 0;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CachedTable.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CachedTable.java
@@ -33,7 +33,7 @@ import org.json.JSONObject;
 @SuppressWarnings("serial")
 class CachedTable extends CachedComponent {
 
-  private ArrayList<CachedTable> mTableStack = new ArrayList<>();
+  private List<CachedTable> mTableStack = new ArrayList<>();
   private Map<List<Integer>, CachedTable> mAllTables = new HashMap<>();
   // START *** SPREADSHEET PROPERTIES
   // required to track repeatedColumns rows for spreadsheets..
@@ -59,7 +59,7 @@ class CachedTable extends CachedComponent {
   public Integer mSheetNo;
   public Integer mFirstRow = 0;
   public Integer mLastRow = 0;
-  public ArrayList<CachedInnerTableOperation> mCachedTableContentOps = null;
+  public List<CachedInnerTableOperation> mCachedTableContentOps = null;
   // 1) Mapping the column's default cell style to empty cells for none max size OR
   // adding column's default cell style to column style
   // 2) Mapping the largest range of rows/columns to the table in case of MAX sheet

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
@@ -37,7 +37,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -155,7 +155,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
   // the actual component. Linking each other building the tree view of the document
   private Component mCurrentComponent;
   // the position of the component, being updated for the operations being generated
-  private final LinkedList<Integer> mLastComponentPositions = new LinkedList<Integer>();
+  private final List<Integer> mLastComponentPositions = new ArrayList<Integer>();
   /** DOM is created by default, but is in general not needed */
   private final boolean domCreationEnabled = true;
   //    private final ArrayDeque<ShapeProperties> mShapePropertiesStack;
@@ -257,7 +257,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
           mListId = currentListId;
         }
       }
-      mSortedIds = new LinkedList<String>();
+      mSortedIds = new ArrayList<>();
     }
 
     public void add(String listId) {
@@ -1049,7 +1049,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
             mTableHardFormatting = new HashMap<>();
           }
           mTableName = mTableElement.getAttributeNS(OdfDocumentNamespace.TABLE.getUri(), "name");
-          mColumnRelWidths = new LinkedList<>();
+          mColumnRelWidths = new ArrayList<>();
           element.markAsComponentRoot(true);
         } else if (element instanceof TableTableRowElement) {
           mComponentDepth++;
@@ -1065,7 +1065,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
             }
 
             // The grid is known after columns had been parsed, updating later to row positino
-            List<Integer> tablePosition = new LinkedList<Integer>(mLastComponentPositions);
+            List<Integer> tablePosition = new ArrayList<Integer>(mLastComponentPositions);
             cacheTableOperation(
                 OperationConstants.TABLE,
                 tablePosition,
@@ -2418,14 +2418,14 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
       // added
     } else if (mComponentDepth < mLastComponentPositions.size() - 1) {
       // remove the last position and addChild a new one
-      mLastComponentPositions.removeLast();
+      mLastComponentPositions.remove(mLastComponentPositions.size() - 1);
       updatePosition(isComponent);
     } else {
       LOG.warning("Houston, we have a problem..");
     }
     // ToDo: Do I need a new LIST for every component? Or may I addChild a position to the
     // component?
-    return new LinkedList<Integer>(mLastComponentPositions);
+    return new ArrayList<>(mLastComponentPositions);
     // ToDo: Below a bad idea?
     // return Collections.unmodifiableList(mLastComponentPositions);
   }
@@ -2442,7 +2442,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
   // CachedTable mCachedTableOps = null;
   // based on document position the tables and subtables are being flushed after each end
   //    HashMap<List<Integer>, CachedTable> mAllTables = null;
-  //    private ArrayList<CachedTable> mTableStack;
+  //    private List<CachedTable> mTableStack;
   //    boolean mWithinTable = false; //TODO: Detect via type of top element of mComponentStack
   // private int mNumberOfNestedTables = 0;
   Stack<CachedComponent> mComponentStack = new Stack<CachedComponent>();
@@ -2542,9 +2542,9 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
         cacheTableOperation(componentType, start, hardFormattingProperties, componentProperties);
       } else {
         // collect the operations at the CachedComponent
-        LinkedList<Integer> position = null;
+        List<Integer> position = null;
         if (start != null) {
-          position = new LinkedList<>(start);
+          position = new ArrayList<>(start);
         }
 
         topComponent.add(
@@ -2565,7 +2565,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
       List<Integer> start,
       Map<String, Object> hardFormattingProperties,
       Object... componentProperties) {
-    LinkedList<Integer> position = null;
+    List<Integer> position = null;
     CachedTable currentTable =
         mComponentStack.empty()
             ? null
@@ -2573,7 +2573,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                 ? (CachedTable) mComponentStack.peek()
                 : null;
     if (start != null) {
-      position = new LinkedList<Integer>(start);
+      position = new ArrayList<>(start);
     }
     if (componentType.equals(OperationConstants.CELLS)) { // does not effect a spreadsheet
       currentTable.mCellCount++;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
@@ -73,7 +73,6 @@ import org.odftoolkit.odfdom.dom.element.style.StyleFooterStyleElement;
 import org.odftoolkit.odfdom.dom.element.style.StyleHeaderFooterPropertiesElement;
 import org.odftoolkit.odfdom.dom.element.style.StyleHeaderStyleElement;
 import org.odftoolkit.odfdom.dom.element.style.StyleMasterPageElement;
-import org.odftoolkit.odfdom.dom.element.style.StyleStyleElement;
 import org.odftoolkit.odfdom.dom.element.svg.SvgDescElement;
 import org.odftoolkit.odfdom.dom.element.table.TableCoveredTableCellElement;
 import org.odftoolkit.odfdom.dom.element.table.TableTableCellElement;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
@@ -33,7 +33,6 @@ import static org.odftoolkit.odfdom.changes.PageArea.HEADER_FIRST;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -42,6 +41,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 import java.util.logging.Level;
@@ -491,8 +491,8 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
           || ((isMasterPage
                   || Component.isHeaderRoot(uri, localName)
                   || Component.isFooterRoot(uri, localName))
-              && OdfDocument.OdfMediaType.TEXT.getMediaTypeString() != mMediaType
-              && OdfDocument.OdfMediaType.SPREADSHEET.getMediaTypeString() != mMediaType)) {
+              && !Objects.equals(OdfDocument.OdfMediaType.TEXT.getMediaTypeString(), mMediaType)
+              && !Objects.equals(OdfDocument.OdfMediaType.SPREADSHEET.getMediaTypeString(), mMediaType))) {
         isBlocked = true;
         mNoOperationsAllowed = true;
         mIsIgnoredElement = true;
@@ -509,8 +509,8 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
               || ((isMasterPage
                       || Component.isHeaderRoot(uri, localName)
                       || Component.isFooterRoot(uri, localName))
-                  && OdfDocument.OdfMediaType.TEXT.getMediaTypeString() != mMediaType
-                  && OdfDocument.OdfMediaType.SPREADSHEET.getMediaTypeString() != mMediaType)) {
+                  && !Objects.equals(OdfDocument.OdfMediaType.TEXT.getMediaTypeString(), mMediaType)
+                  && !Objects.equals(OdfDocument.OdfMediaType.SPREADSHEET.getMediaTypeString(), mMediaType))) {
             mIsIgnoredElement = false;
             mBlockingElementDepth = -1;
             mNoOperationsAllowed = false;
@@ -554,7 +554,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
         element = mFileDom.createElement(localName);
       } else {
         // == correct: if localName is the same object as qName, there is a default namespace set
-        if (localName == qName) {
+        if (Objects.equals(localName, qName)) {
           element =
               mFileDom.createElementNS(
                   OdfName.getOdfName(OdfNamespace.newNamespace(null, uri), localName));

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CommentComponent.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CommentComponent.java
@@ -24,7 +24,6 @@
 package org.odftoolkit.odfdom.changes;
 
 import java.util.ArrayList;
-import java.util.ArrayList;
 import java.util.List;
 
 /** The comment component. */

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CommentComponent.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CommentComponent.java
@@ -23,7 +23,8 @@
  */
 package org.odftoolkit.odfdom.changes;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.ArrayList;
 import java.util.List;
 
 /** The comment component. */
@@ -33,7 +34,7 @@ class CommentComponent extends CachedComponent {
   private String mCommentName;
   private String mAuthor;
   private String mDate;
-  private LinkedList<Integer> mCommentPosition;
+  private List<Integer> mCommentPosition;
   private boolean isInHeaderFooter = false;
 
   public boolean isInHeaderFooter() {
@@ -45,11 +46,11 @@ class CommentComponent extends CachedComponent {
   }
 
   public CommentComponent(List<Integer> start, String commentName) {
-    mCommentPosition = new LinkedList<Integer>(start);
+    mCommentPosition = new ArrayList<>(start);
     mCommentName = commentName;
   }
 
-  public LinkedList<Integer> getComponentPosition() {
+  public List<Integer> getComponentPosition() {
     return mCommentPosition;
   }
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Component.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Component.java
@@ -15,8 +15,9 @@
  */
 package org.odftoolkit.odfdom.changes;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -818,7 +819,7 @@ public class Component {
   public void addChild(int index, Component c) {
     if (mChildren == null) {
       if (mChildren == null) {
-        mChildren = new LinkedList<Component>();
+        mChildren = new ArrayList<Component>();
       }
     }
     if (index >= 0) {
@@ -868,7 +869,7 @@ public class Component {
     List<Integer> position;
     int childPos;
     if (c.mParent != null) {
-      position = new LinkedList<>();
+      position = new ArrayList<>();
       Component parent;
       while ((parent = c.getParent()) != null) {
         childPos = parent.indexOf(c);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Component.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Component.java
@@ -15,7 +15,6 @@
  */
 package org.odftoolkit.odfdom.changes;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.List;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
@@ -47,7 +47,6 @@ import org.odftoolkit.odfdom.doc.table.OdfTableRow;
 import org.odftoolkit.odfdom.dom.OdfContentDom;
 import org.odftoolkit.odfdom.dom.OdfDocumentNamespace;
 import org.odftoolkit.odfdom.dom.OdfSchemaConstraint;
-import org.odftoolkit.odfdom.dom.OdfSchemaDocument;
 import org.odftoolkit.odfdom.dom.OdfStylesDom;
 import org.odftoolkit.odfdom.dom.attribute.draw.DrawStyleNameAttribute;
 import org.odftoolkit.odfdom.dom.attribute.style.StyleRunThroughAttribute;
@@ -657,7 +656,7 @@ public class JsonOperationConsumer {
               if (attrs.has("cell") || attrs.has("paragraph") || attrs.has("text")) {
                 autoStyle =
                     newElement.getOrCreateUnqiueAutomaticStyle(
-                        Boolean.FALSE, OdfStyleFamily.TableCell);
+                        false, OdfStyleFamily.TableCell);
                 // APPLY HARD FORMATTING PROPERTIES OF ODF FAMILY
                 mapProperties(OdfStyleFamily.TableCell, attrs, autoStyle, doc);
                 // default-cell-style-name
@@ -926,7 +925,7 @@ public class JsonOperationConsumer {
               // Returns all TableTableColumn descendants that exist within the tableElement, even
               // within groups, columns and header elements
               OdfTable table = OdfTable.getInstance(tableElement);
-              table.removeColumnsByIndex(endPos, deletionCount - 1 + endPos, Boolean.TRUE);
+              table.removeColumnsByIndex(endPos, deletionCount - 1 + endPos, true);
               ((Table) tableElement.getComponent()).hasChangedWidth();
             }
           }
@@ -1262,7 +1261,7 @@ public class JsonOperationConsumer {
             tableElement.getComponent(),
             ((Table) tableElement.getComponent()).getPosition(),
             ((Table) tableElement.getComponent()).popTableGrid(),
-            Boolean.TRUE);
+            true);
       }
     }
   }
@@ -1407,7 +1406,7 @@ public class JsonOperationConsumer {
         // Heading Level
         if (props.has("outlineLevel")) {
           if (!props.get("outlineLevel").equals(JSONObject.NULL)) {
-            Integer outlineLevel = props.optInt("outlineLevel");
+            int outlineLevel = props.optInt("outlineLevel");
             if (outlineLevel >= 1) {
               style.setStyleDefaultOutlineLevelAttribute(outlineLevel);
             } else {
@@ -1455,7 +1454,7 @@ public class JsonOperationConsumer {
           }
           targetNode = parentComponent.getChildNode(startPos, targetPos);
         }
-        format(parentComponent.mRootElement, targetNode, start, end, attrs, Boolean.FALSE);
+        format(parentComponent.mRootElement, targetNode, start, end, attrs, false);
       } else {
         LOG.log(
             Level.SEVERE,
@@ -1650,8 +1649,8 @@ public class JsonOperationConsumer {
 
           JSONObject columnProps = attrs.optJSONObject("column");
           if (columnProps != null) {
-            Boolean changeToVisible = columnProps.optBoolean("visible", Boolean.TRUE);
-            boolean isVisible = Boolean.TRUE;
+            boolean changeToVisible = columnProps.optBoolean("visible", true);
+            boolean isVisible = true;
             if (columnElement.hasAttributeNS(OdfDocumentNamespace.TABLE.getUri(), "visibility")) {
               isVisible =
                   Constants.VISIBLE.equals(
@@ -1675,8 +1674,8 @@ public class JsonOperationConsumer {
           autoStyle = addStyle(attrs, (OdfStylableElement) targetNode, xmlDoc);
           JSONObject rowProps = attrs.optJSONObject("row");
           if (rowProps != null) {
-            Boolean changeToVisible = rowProps.optBoolean("visible", Boolean.TRUE);
-            boolean isVisible = Boolean.TRUE;
+            boolean changeToVisible = rowProps.optBoolean("visible", true);
+            boolean isVisible = true;
             if (rowElement.hasAttributeNS(OdfDocumentNamespace.TABLE.getUri(), "visibility")) {
               isVisible =
                   Constants.VISIBLE.equals(
@@ -1886,7 +1885,7 @@ public class JsonOperationConsumer {
               == null) { // if not within automatic style, its a template style
             autoStyle =
                 lineElement.getOrCreateUnqiueAutomaticStyle(
-                    Boolean.FALSE, OdfStyleFamily.TableCell);
+                    false, OdfStyleFamily.TableCell);
             defaultCellTemplateStyleName = defaultCellStyleName;
           } else {
             autoStyle = existingDefaultCellStyle;
@@ -1895,7 +1894,7 @@ public class JsonOperationConsumer {
           }
         } else {
           autoStyle =
-              lineElement.getOrCreateUnqiueAutomaticStyle(Boolean.FALSE, OdfStyleFamily.TableCell);
+              lineElement.getOrCreateUnqiueAutomaticStyle(false, OdfStyleFamily.TableCell);
         }
 
         if (defaultCellTemplateStyleName != null && !defaultCellTemplateStyleName.isEmpty()) {
@@ -2183,7 +2182,7 @@ public class JsonOperationConsumer {
         boolean listLabelHidden = false;
         // if there is no previous sibling and hidden, we need a list-header
         if (paraProps != null && paraProps.has("listLabelHidden")) {
-          listLabelHidden = paraProps.optBoolean("listLabelHidden", Boolean.FALSE);
+          listLabelHidden = paraProps.optBoolean("listLabelHidden", false);
         }
         if (listLabelHidden) {
           OdfElement elementForInsertion;
@@ -2583,7 +2582,7 @@ public class JsonOperationConsumer {
         if (paraProps != null && paraProps.has("listLabelHidden")
             || paragraphBaseElement.hasAttribute("hiddenParagraph")) {
           if (paraProps != null) {
-            listLabelHidden = paraProps.optBoolean("listLabelHidden", Boolean.FALSE);
+            listLabelHidden = paraProps.optBoolean("listLabelHidden", false);
           } else {
             listLabelHidden = true;
           }
@@ -2653,7 +2652,7 @@ public class JsonOperationConsumer {
         }
       }
       // Similar to MSO 15 ODF output & behavior, set by default the continue numbering to true
-      rootListElement.setTextContinueNumberingAttribute(Boolean.TRUE);
+      rootListElement.setTextContinueNumberingAttribute(true);
     }
   }
 
@@ -3960,7 +3959,7 @@ public class JsonOperationConsumer {
             -1,
             isTextTable,
             existingColumnList,
-            Boolean.TRUE);
+            true);
       }
     } else {
       LOG.log(
@@ -4053,7 +4052,7 @@ public class JsonOperationConsumer {
             -1,
             true,
             existingColumnList,
-            Boolean.FALSE);
+            false);
         // WORK AROUND for "UNDO COLUMN WIDTH" problem (see JsonOperationConsumer for further
         // changes)
         if (((Table) tableElement.getComponent()).isWidthChangeRequired()) {
@@ -4061,7 +4060,7 @@ public class JsonOperationConsumer {
               tableElement.getComponent(),
               ((Table) tableElement.getComponent()).getPosition(),
               ((Table) tableElement.getComponent()).popTableGrid(),
-              Boolean.TRUE);
+              true);
         }
       } else {
         LOG.log(
@@ -4655,7 +4654,7 @@ public class JsonOperationConsumer {
             -1,
             true,
             existingColumnList,
-            Boolean.TRUE);
+            true);
         ((Table) tableElement.getComponent()).hasChangedWidth();
       }
 
@@ -5563,7 +5562,7 @@ public class JsonOperationConsumer {
             if (value == null || value.equals(JSONObject.NULL)) {
               propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "text-indent");
             } else {
-              Integer indent = getSafelyInteger(value);
+              int indent = getSafelyInteger(value);
               propertiesElement.setAttributeNS(
                   OdfDocumentNamespace.FO.getUri(), "fo:text-indent", ((indent / 100.0) + "mm"));
             }
@@ -5804,7 +5803,7 @@ public class JsonOperationConsumer {
               propertiesElement.removeAttributeNS(
                   OdfDocumentNamespace.STYLE.getUri(), "min-row-height");
             } else {
-              Integer rowHeight = getSafelyInteger(value);
+              int rowHeight = getSafelyInteger(value);
               propertiesElement.setStyleRowHeightAttribute(((rowHeight / 100.0) + "mm"));
             }
           } catch (JSONException ex) {
@@ -6139,7 +6138,7 @@ public class JsonOperationConsumer {
               String textWrapMode = (String) value;
               if (textWrapMode.equals("topAndBottom")) {
                 propertiesElement.setStyleWrapAttribute("none");
-                propertiesElement.setStyleWrapContourAttribute(Boolean.FALSE);
+                propertiesElement.setStyleWrapContourAttribute(false);
               } else {
                 String textWrapSide = attrs.optString("textWrapSide");
                 if (textWrapSide != null) {
@@ -6153,10 +6152,10 @@ public class JsonOperationConsumer {
                     } else if (textWrapSide.equals("right")) {
                       propertiesElement.setStyleWrapAttribute("right");
                     }
-                    propertiesElement.setStyleWrapContourAttribute(Boolean.FALSE);
+                    propertiesElement.setStyleWrapContourAttribute(false);
                   } else if (textWrapMode.equals("through")) {
                     propertiesElement.setStyleWrapAttribute("run-through");
-                    propertiesElement.setStyleWrapContourAttribute(Boolean.FALSE);
+                    propertiesElement.setStyleWrapContourAttribute(false);
                   }
                 }
               }
@@ -6219,7 +6218,7 @@ public class JsonOperationConsumer {
             if (value == null || value.equals(JSONObject.NULL)) {
               propertiesElement.removeAttributeNS(OdfDocumentNamespace.SVG.getUri(), "x");
             } else {
-              Integer x = getSafelyInteger(value);
+              int x = getSafelyInteger(value);
 
               // This is the default in our constellation
               propertiesElement.setSvgXAttribute(x / 100.0 + "mm");
@@ -6260,7 +6259,7 @@ public class JsonOperationConsumer {
             if (value == null || value.equals(JSONObject.NULL)) {
               propertiesElement.removeAttributeNS(OdfDocumentNamespace.SVG.getUri(), "y");
             } else {
-              Integer y = getSafelyInteger(value);
+              int y = getSafelyInteger(value);
               // This is the default in our constellation
               propertiesElement.setSvgYAttribute(y / 100.0 + "mm");
             }
@@ -6745,7 +6744,7 @@ public class JsonOperationConsumer {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "margin-bottom");
           } else {
-            Integer width = getSafelyInteger(value);
+            int width = getSafelyInteger(value);
             propertiesElement.setAttributeNS(
                 OdfDocumentNamespace.FO.getUri(), "fo:margin-bottom", ((width / 100.0) + "mm"));
           }
@@ -6761,7 +6760,7 @@ public class JsonOperationConsumer {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "margin-left");
           } else {
-            Integer width = getSafelyInteger(value);
+            int width = getSafelyInteger(value);
             propertiesElement.setAttributeNS(
                 OdfDocumentNamespace.FO.getUri(), "fo:margin-left", ((width / 100.0) + "mm"));
           }
@@ -6776,7 +6775,7 @@ public class JsonOperationConsumer {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "margin-right");
           } else {
-            Integer width = getSafelyInteger(value);
+            int width = getSafelyInteger(value);
             propertiesElement.setAttributeNS(
                 OdfDocumentNamespace.FO.getUri(), "fo:margin-right", ((width / 100.0) + "mm"));
           }
@@ -6790,7 +6789,7 @@ public class JsonOperationConsumer {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "margin-top");
           } else {
-            Integer width = getSafelyInteger(value);
+            int width = getSafelyInteger(value);
             propertiesElement.setAttributeNS(
                 OdfDocumentNamespace.FO.getUri(), "fo:margin-top", ((width / 100.0) + "mm"));
           }
@@ -6841,7 +6840,7 @@ public class JsonOperationConsumer {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "padding-bottom");
           } else {
-            Integer width = getSafelyInteger(value);
+            int width = getSafelyInteger(value);
             propertiesElement.setAttributeNS(
                 OdfDocumentNamespace.FO.getUri(), "fo:padding-bottom", ((width / 100.0) + "mm"));
           }
@@ -6855,7 +6854,7 @@ public class JsonOperationConsumer {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "padding-left");
           } else {
-            Integer width = getSafelyInteger(value);
+            int width = getSafelyInteger(value);
             propertiesElement.setAttributeNS(
                 OdfDocumentNamespace.FO.getUri(), "fo:padding-left", ((width / 100.0) + "mm"));
           }
@@ -6868,7 +6867,7 @@ public class JsonOperationConsumer {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "padding-right");
           } else {
-            Integer width = getSafelyInteger(value);
+            int width = getSafelyInteger(value);
             propertiesElement.setAttributeNS(
                 OdfDocumentNamespace.FO.getUri(), "fo:padding-right", ((width / 100.0) + "mm"));
           }
@@ -6881,7 +6880,7 @@ public class JsonOperationConsumer {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "padding-top");
           } else {
-            Integer width = getSafelyInteger(value);
+            int width = getSafelyInteger(value);
             propertiesElement.setAttributeNS(
                 OdfDocumentNamespace.FO.getUri(), "fo:padding-top", ((width / 100.0) + "mm"));
           }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
@@ -31,7 +31,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -3940,7 +3940,7 @@ public class JsonOperationConsumer {
       TableTableElement tableElement = (TableTableElement) tableComponent.getRootElement();
       // WORK AROUND for "UNDO COLUMN WIDTH" problem (see TableTableElement for further changes)
       List<TableTableColumnElement> existingColumnList =
-          Table.getTableColumnElements(tableElement, new LinkedList<TableTableColumnElement>());
+          Table.getTableColumnElements(tableElement, new ArrayList<TableTableColumnElement>());
       int columnCount = 0;
       for (TableTableColumnElement column : existingColumnList) {
         columnCount += column.getRepetition();
@@ -4042,7 +4042,7 @@ public class JsonOperationConsumer {
         // groups, columns and header elements
         List<TableTableColumnElement> existingColumnList =
             Table.getTableColumnElements(
-                parentComponent.getRootElement(), new LinkedList<TableTableColumnElement>());
+                parentComponent.getRootElement(), new ArrayList<TableTableColumnElement>());
         addColumnAndCellElements(
             parentComponent,
             start,
@@ -4643,7 +4643,7 @@ public class JsonOperationConsumer {
         // Returns all TableTableColumn descendants that exist within the tableElement, even within
         // groups, columns and header elements
         List<TableTableColumnElement> existingColumnList =
-            Table.getTableColumnElements(tableElement, new LinkedList<TableTableColumnElement>());
+            Table.getTableColumnElements(tableElement, new ArrayList<TableTableColumnElement>());
         // Column creation only required
         addColumnAndCellElements(
             tableElement.getComponent(),

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
@@ -28,7 +28,6 @@ import static org.odftoolkit.odfdom.changes.PageArea.HEADER_FIRST;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ArrayList;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
@@ -21,7 +21,6 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ArrayList;
@@ -1102,7 +1101,7 @@ public class JsonOperationProducer {
    */
   public void addListStyle(
       OdfSchemaDocument doc, Map<String, TextListStyleElement> autoListStyles, String styleId) {
-    if (styleId != null & !styleId.isEmpty()) {
+    if (styleId != null && !styleId.isEmpty()) {
       if (!knownListStyles.containsKey(styleId)) {
         try {
           // Three locations to check for the list style

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
@@ -161,8 +161,8 @@ public class JsonOperationProducer {
       //			}
       if (formattingProperties != null && !formattingProperties.isEmpty()) {
         JSONObject attrs = new JSONObject();
-        for (String arg : formattingProperties.keySet()) {
-          attrs.put(arg, formattingProperties.get(arg));
+        for (Map.Entry<String, Object> entry : formattingProperties.entrySet()) {
+          attrs.put(entry.getKey(), entry.getValue());
         }
         addComponentObject.put(OPK_ATTRS, attrs);
       }
@@ -256,8 +256,8 @@ public class JsonOperationProducer {
         }
         if (formattingProperties != null && !formattingProperties.isEmpty()) {
           JSONObject attrs = new JSONObject();
-          for (String arg : formattingProperties.keySet()) {
-            attrs.put(arg, formattingProperties.get(arg));
+          for (Map.Entry<String, Object> entry : formattingProperties.entrySet()) {
+            attrs.put(entry.getKey(), entry.getValue());
           }
           newOperation.put(OPK_ATTRS, attrs);
         }
@@ -296,8 +296,8 @@ public class JsonOperationProducer {
           newOperation.put(OPK_END, lastRow + previousRowRepeated);
         }
         JSONObject attrs = new JSONObject();
-        for (String arg : formattingProperties.keySet()) {
-          attrs.put(arg, formattingProperties.get(arg));
+        for (Map.Entry<String, Object> entry : formattingProperties.entrySet()) {
+          attrs.put(entry.getKey(), entry.getValue());
         }
         newOperation.put(OPK_ATTRS, attrs);
 
@@ -1947,8 +1947,8 @@ public class JsonOperationProducer {
   // umsonst mappen..
   private Map<String, String> transformMap(Map<OdfStyleProperty, String> props) {
     Map<String, String> odfProps = new HashMap<String, String>();
-    for (OdfStyleProperty styleProp : props.keySet()) {
-      odfProps.put(styleProp.getName().getQName(), props.get(styleProp));
+    for (Map.Entry<OdfStyleProperty, String> entry : props.entrySet()) {
+      odfProps.put(entry.getKey().getName().getQName(), entry.getValue());
     }
     return odfProps;
   }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
@@ -24,7 +24,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -346,7 +346,7 @@ public class JsonOperationProducer {
 
     // the row start/end number 0 based, therefore - 1
     int rowStartNo = firstRow + repeatedRowOffset;
-    List rangeStart = new LinkedList<Integer>();
+    List rangeStart = new ArrayList<Integer>();
 
     // if there is a repeated row, there will be repeated cells (at least vertical)
     if (hasHorizontalRepetition || lastRow != null && !firstRow.equals(lastRow)) {
@@ -355,7 +355,7 @@ public class JsonOperationProducer {
       // second the start row position
       rangeStart.add(rowStartNo);
 
-      List rangeEnd = new LinkedList<Integer>();
+      List rangeEnd = new ArrayList<Integer>();
 
       // first the end column position: StartPos of content plus any repetiton (including itself,
       // therefore - 1)
@@ -406,10 +406,10 @@ public class JsonOperationProducer {
   /** */
   public void mergeCells(List<Integer> position, int columns, int rows) {
     final JSONObject newOperation = new JSONObject();
-    LinkedList<Integer> rangeStart = new LinkedList<Integer>();
+    List<Integer> rangeStart = new ArrayList<Integer>();
     rangeStart.add(position.get(2));
     rangeStart.add(position.get(1));
-    LinkedList<Integer> rangeEnd = new LinkedList<Integer>();
+    List<Integer> rangeEnd = new ArrayList<Integer>();
     rangeEnd.add(position.get(2) + columns - 1);
     rangeEnd.add(position.get(1) + rows - 1);
     try {
@@ -504,7 +504,7 @@ public class JsonOperationProducer {
     if (attrs != null && attrs.size() > 0) {
       // Not the next position, but the last character to be marked will be referenced
       final JSONObject newOp = new JSONObject();
-      List<Integer> lastCharacterPos = new LinkedList<Integer>();
+      List<Integer> lastCharacterPos = new ArrayList<Integer>();
       // text position is usually -1 as we take the first and the last character to be styled
       if (end != null) {
         for (int i = 0; i < end.size(); i++) {
@@ -880,7 +880,7 @@ public class JsonOperationProducer {
       } else {
         result = panose1.split("\\s");
       }
-      panose1_Integers = new LinkedList<Integer>();
+      panose1_Integers = new ArrayList<Integer>();
       for (String token : result) {
         try {
           panose1_Integers.add(Integer.parseInt(token));
@@ -1022,7 +1022,7 @@ public class JsonOperationProducer {
 
         // all ODF properties
         allOdfProps = new HashMap<String, Map<String, String>>();
-        List<OdfStyleBase> parents = new LinkedList<OdfStyleBase>();
+        List<OdfStyleBase> parents = new ArrayList<OdfStyleBase>();
         parents.add(style);
         OdfStyleBase parent = style.getParentStyle();
         // if automatic style inheritance is possible
@@ -1620,7 +1620,7 @@ public class JsonOperationProducer {
       if (!(style instanceof OdfDefaultStyle)) {
 
         if (!knownStyles.containsKey(((OdfStyle) style).getStyleNameAttribute())) {
-          List<OdfStyleBase> parents = new LinkedList<OdfStyleBase>();
+          List<OdfStyleBase> parents = new ArrayList<OdfStyleBase>();
           OdfStyleBase parent = style;
 
           // Collecting hierachy, to go back through the style hierarchy from the end, to be able to

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
@@ -1591,7 +1591,7 @@ public final class MapHelper {
     String tabLeaderText =
         tabStopElement.getAttributeNS(OdfDocumentNamespace.STYLE.getUri(), "leader-text");
 
-    if (tabLeaderText != null & !tabLeaderText.isEmpty()) {
+    if (tabLeaderText != null && !tabLeaderText.isEmpty()) {
       if (tabLeaderText.equals(Constants.DOT_CHAR)) {
         odfProps.put("tab_LeaderText" + tabNumber, Constants.DOT);
       } else if (tabLeaderText.equals(Constants.HYPHEN_CHAR)) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
@@ -2110,8 +2110,8 @@ public final class MapHelper {
       if (!code.isEmpty() && type != OfficeValueTypeAttribute.Value.VOID) {
         String foundStyleName = null;
         boolean foundInAutoStyles = false;
-        HashMap<String, DataStyleElement> officeDataStyles = officeStyles.getAllDataStyles();
-        HashMap<String, DataStyleElement> autoDataStyles = autoStyles.getAllDataStyles();
+        Map<String, DataStyleElement> officeDataStyles = officeStyles.getAllDataStyles();
+        Map<String, DataStyleElement> autoDataStyles = autoStyles.getAllDataStyles();
         for (Entry<String, DataStyleElement> autoNumberStyle : autoDataStyles.entrySet()) {
           if (autoNumberStyle.getValue().getFormat(true).equals(code)) {
             foundStyleName = autoNumberStyle.getKey();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
@@ -812,7 +812,8 @@ public final class MapHelper {
         imageProps = new JSONObject();
         lineProps = new JSONObject();
         fillProps = new JSONObject();
-        for (String propName : odfProps.keySet()) {
+        for (Entry<String, String> entry : odfProps.entrySet()) {
+          String propName = entry.getKey();
           try {
             if (propName.contains("margin")) {
               if (marginToBeDone) {
@@ -1082,7 +1083,7 @@ public final class MapHelper {
             } else if (propName.equals("svg:stroke-width")) {
               lineProps.put("width", MapHelper.normalizeLength(odfProps.get("svg:stroke-width")));
             } else if (propName.equals("style:run-through")) {
-              String runThrough = odfProps.get(propName);
+              String runThrough = entry.getValue();
               if ("background".equals(runThrough)) {
                 newProps.put("anchorBehindDoc", true);
               }
@@ -1504,10 +1505,10 @@ public final class MapHelper {
       Map<String, OdfStylePropertiesSet> familyPropertyGroups,
       Map<String, Map<String, String>> allOdfProps) {
     if (style != null) {
-      for (String styleFamilyKey : familyPropertyGroups.keySet()) {
+      for (Entry<String, OdfStylePropertiesSet> entry : familyPropertyGroups.entrySet()) {
         // the ODF properties of one family group
         Map<String, String> odfProps = new HashMap<String, String>();
-        OdfStylePropertiesSet key = familyPropertyGroups.get(styleFamilyKey);
+        OdfStylePropertiesSet key = entry.getValue();
         OdfStylePropertiesBase propsElement = style.getPropertiesElement(key);
         if (propsElement != null) {
           NamedNodeMap attrs = propsElement.getAttributes();
@@ -1557,7 +1558,7 @@ public final class MapHelper {
           }
         }
         if (!odfProps.isEmpty()) {
-          allOdfProps.put(styleFamilyKey, odfProps);
+          allOdfProps.put(entry.getKey(), odfProps);
         }
       }
     }
@@ -1649,7 +1650,7 @@ public final class MapHelper {
 
   // convert xmlschema-2 date to double
   public static Double dateToDouble(Object value) {
-    Double ret = 0.0;
+    double ret = 0.0;
     if (value instanceof String) {
       try {
         LocalDateTime dateTime = LocalDateTime.parse((String) value);
@@ -1665,7 +1666,7 @@ public final class MapHelper {
   // convert xmlschema-2 duration to double
 
   public static Double timeToDouble(Object value) {
-    Double ret = 0.;
+    double ret = 0.;
     if (value != null && value instanceof String) {
       // PThhHmmMss.sssS
       try {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ShapeProperties.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ShapeProperties.java
@@ -26,7 +26,7 @@ package org.odftoolkit.odfdom.changes;
 import static org.odftoolkit.odfdom.changes.OperationConstants.*;
 
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
@@ -66,7 +66,7 @@ public class ShapeProperties extends CachedComponent {
   //        }
   public ShapeProperties(List<Integer> start, Map<String, Object> hardFormatations) {
     // Maps are being reused, for upcoming components, therefore the collections have to be cloned
-    mShapePosition = new LinkedList<Integer>(start);
+    mShapePosition = new ArrayList<Integer>(start);
     if (hardFormatations != null) {
       mShapeHardFormatations = new HashMap<String, Object>();
       mShapeHardFormatations.putAll(hardFormatations);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ShapeProperties.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ShapeProperties.java
@@ -252,7 +252,7 @@ public class ShapeProperties extends CachedComponent {
       }
     }
     if (width != null) {
-      Integer maxHori = (Integer) width;
+      int maxHori = (Integer) width;
       if (horiOffset != null) {
         maxHori += (Integer) horiOffset;
       }
@@ -263,7 +263,7 @@ public class ShapeProperties extends CachedComponent {
       }
     }
     if (height != null) {
-      Integer maxVert = (Integer) height;
+      int maxVert = (Integer) height;
       if (vertOffset != null) {
         maxVert += (Integer) vertOffset;
       }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
@@ -17,7 +17,6 @@ package org.odftoolkit.odfdom.changes;
 
 import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import org.json.JSONArray;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
@@ -17,7 +17,7 @@ package org.odftoolkit.odfdom.changes;
 
 import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import org.json.JSONArray;
@@ -295,7 +295,7 @@ public class Table<T> extends Component {
 
   static void stashColumnWidths(TableTableElement tableElement) {
     List<TableTableColumnElement> existingColumnList =
-        Table.getTableColumnElements(tableElement, new LinkedList<TableTableColumnElement>());
+        Table.getTableColumnElements(tableElement, new ArrayList<TableTableColumnElement>());
     List<Integer> tableColumWidths = collectColumnWidths(tableElement, existingColumnList);
     ((Table) tableElement.getComponent()).pushTableGrid(tableColumWidths);
   }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
@@ -35,7 +35,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
+
 import org.odftoolkit.odfdom.doc.presentation.OdfSlide;
 import org.odftoolkit.odfdom.dom.OdfContentDom;
 import org.odftoolkit.odfdom.dom.OdfDocumentNamespace;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -228,12 +229,12 @@ public class OdfPresentationDocument extends OdfDocument {
   // while if the style elements really have the same style name but with different content
   // such as that these style elements are from different document
   // so the value for each key should be a list
-  private HashMap<String, List<String>> styleRenameMap = new HashMap<String, List<String>>();
+  private Map<String, List<String>> styleRenameMap = new HashMap<String, List<String>>();
   // the map is used to record if the renamed style name is appended to the current dom
-  private HashMap<String, Boolean> styleAppendMap = new HashMap<String, Boolean>();
+  private Map<String, Boolean> styleAppendMap = new HashMap<String, Boolean>();
   // the object rename map for image.
   // can not easily recognize if the embedded document are the same.
-  //	private HashMap<String, String> objectRenameMap = new HashMap<String, String>();
+  //	private Map<String, String> objectRenameMap = new HashMap<String, String>();
 
   /**
    * Return the slide at a specified position in this presentation. Return null if the index is out

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
@@ -66,7 +66,6 @@ import org.odftoolkit.odfdom.pkg.OdfPackageDocument;
 import org.odftoolkit.odfdom.pkg.OdfXMLFactory;
 import org.odftoolkit.odfdom.type.Length.Unit;
 import org.odftoolkit.odfdom.type.PositiveLength;
-import org.w3c.dom.DOMException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -1545,9 +1544,7 @@ public class OdfTable {
       reviseStyleFromTopRowToMediumRow(refRow);
       list.add(newFirstRow);
       List<OdfTableRow> rowList = insertMultipleRowBefore(refRow, refRow, rowCount - 1);
-      for (int i = 0; i < rowList.size(); i++) {
-        list.add(rowList.get(i));
-      }
+      list.addAll(rowList);
       return list;
     }
 
@@ -1574,9 +1571,7 @@ public class OdfTable {
         // correct styles
         reviseStyleFromTopRowToMediumRow(newRowList.get(0));
       }
-      for (int i = 0; i < newRowList.size(); i++) {
-        list.add(newRowList.get(i));
-      }
+      list.addAll(newRowList);
     }
 
     return list;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableCellRange.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableCellRange.java
@@ -324,7 +324,7 @@ public class OdfTableCellRange {
   // the returned value is all measured with "mm" unit
   private List<Long> getCellRangeWidthList() {
     List<Long> list = new ArrayList<Long>();
-    Long length = 0L;
+    long length = 0L;
     for (int i = 0; i < maOwnerTable.getColumnCount() - 1; i++) {
       OdfTableColumn col = maOwnerTable.getColumnByIndex(i);
       int repeateNum = col.getColumnsRepeatedNumber();
@@ -374,7 +374,7 @@ public class OdfTableCellRange {
     Long[] widthArray = (Long[]) tmpList.toArray();
     Arrays.sort(widthArray);
     List<Long> rtnValues = new ArrayList<Long>();
-    Long colWidth;
+    long colWidth;
     long unitWidth;
     rtnValues.add(widthArray[0]);
     for (int i = 1; i < widthArray.length; i++) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableColumn.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableColumn.java
@@ -227,7 +227,7 @@ public class OdfTableColumn {
     String sRelWidth = maColumnElement.getProperty(OdfTableColumnProperties.RelColumnWidth);
     if (sRelWidth != null) {
       if (sRelWidth.contains("*")) {
-        Long value = Long.valueOf(sRelWidth.substring(0, sRelWidth.indexOf("*")));
+        long value = Long.parseLong(sRelWidth.substring(0, sRelWidth.indexOf("*")));
         return value;
       }
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfContentDom.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfContentDom.java
@@ -38,7 +38,6 @@ import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeMasterStyles;
 import org.odftoolkit.odfdom.pkg.NamespaceName;
 import org.odftoolkit.odfdom.pkg.OdfElement;
 import org.odftoolkit.odfdom.pkg.OdfFileSaxHandler;
-import org.odftoolkit.odfdom.pkg.OdfPackageDocument;
 import org.odftoolkit.odfdom.pkg.OdfValidationException;
 import org.w3c.dom.Node;
 import org.xml.sax.ErrorHandler;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfStylesDom.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfStylesDom.java
@@ -40,7 +40,6 @@ import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeStyles;
 import org.odftoolkit.odfdom.pkg.NamespaceName;
 import org.odftoolkit.odfdom.pkg.OdfElement;
 import org.odftoolkit.odfdom.pkg.OdfFileSaxHandler;
-import org.odftoolkit.odfdom.pkg.OdfPackageDocument;
 import org.odftoolkit.odfdom.pkg.OdfValidationException;
 import org.w3c.dom.Node;
 import org.xml.sax.ErrorHandler;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -73,7 +74,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
   private static final long serialVersionUID = 8271282184913774000L;
 
   private Map<OdfStylePropertiesSet, OdfStylePropertiesBase> mPropertySetElementMap;
-  private ArrayList<OdfStylableElement> mStyleUser;
+  private List<OdfStylableElement> mStyleUser;
   static HashMap<OdfName, OdfStylePropertiesSet> mStylePropertiesElementToSetMap;
 
   static {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
@@ -306,7 +306,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
       OdfStylePropertiesSet set = mStylePropertiesElementToSetMap.get(node.getOdfName());
       if (set != null) {
         if (mPropertySetElementMap == null) {
-          mPropertySetElementMap = new HashMap<OdfStylePropertiesSet, OdfStylePropertiesBase>();
+          mPropertySetElementMap = new HashMap<>();
         }
         mPropertySetElementMap.put(set, (OdfStylePropertiesBase) node);
       }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
@@ -24,6 +24,7 @@
 package org.odftoolkit.odfdom.dom.element;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -71,7 +72,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
   /** */
   private static final long serialVersionUID = 8271282184913774000L;
 
-  private HashMap<OdfStylePropertiesSet, OdfStylePropertiesBase> mPropertySetElementMap;
+  private Map<OdfStylePropertiesSet, OdfStylePropertiesBase> mPropertySetElementMap;
   private ArrayList<OdfStylableElement> mStyleUser;
   static HashMap<OdfName, OdfStylePropertiesSet> mStylePropertiesElementToSetMap;
 
@@ -306,7 +307,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
       OdfStylePropertiesSet set = mStylePropertiesElementToSetMap.get(node.getOdfName());
       if (set != null) {
         if (mPropertySetElementMap == null) {
-          mPropertySetElementMap = new HashMap<>();
+          mPropertySetElementMap = new EnumMap<>(OdfStylePropertiesSet.class);
         }
         mPropertySetElementMap.put(set, (OdfStylePropertiesBase) node);
       }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/rdfa/BookmarkRDFMetadataExtractor.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/rdfa/BookmarkRDFMetadataExtractor.java
@@ -25,7 +25,7 @@ package org.odftoolkit.odfdom.dom.rdfa;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -185,7 +185,7 @@ public class BookmarkRDFMetadataExtractor extends DefaultElementVisitor {
   }
 
   private Iterator<Attribute> fromAttributes(Attributes attributes) {
-    List<Attribute> toReturn = new LinkedList<>();
+    List<Attribute> toReturn = new ArrayList<>();
 
     for (int i = 0; i < attributes.getLength(); i++) {
       String qname = attributes.getQName(i);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeAutomaticStyles.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeAutomaticStyles.java
@@ -26,6 +26,7 @@ package org.odftoolkit.odfdom.incubator.doc.office;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.odftoolkit.odfdom.changes.MapHelper;
@@ -66,7 +67,7 @@ public abstract class OdfOfficeAutomaticStyles extends OdfStylesBase {
 
   private static final long serialVersionUID = -2925910664631016175L;
   // styles that are only in OdfAutomaticStyles
-  private HashMap<String, OdfStylePageLayout> mPageLayouts;
+  private Map<String, OdfStylePageLayout> mPageLayouts;
   // styles that are common for OdfStyles and OdfAutomaticStyles
 
   public OdfOfficeAutomaticStyles(OdfFileDom ownerDoc) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeMasterStyles.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeMasterStyles.java
@@ -47,7 +47,7 @@ public abstract class OdfOfficeMasterStyles extends OdfStylesBase
   private static final long serialVersionUID = 6598785919980862801L;
   private DrawLayerSetElement mLayerSet;
   private StyleHandoutMasterElement mHandoutMaster;
-  private HashMap<String, StyleMasterPageElement> mMasterPages;
+  private Map<String, StyleMasterPageElement> mMasterPages;
 
   public OdfOfficeMasterStyles(OdfFileDom ownerDoc) {
     super(ownerDoc, ELEMENT_NAME);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeStyles.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeStyles.java
@@ -25,6 +25,8 @@ package org.odftoolkit.odfdom.incubator.doc.office;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
+
 import org.odftoolkit.odfdom.dom.DefaultElementVisitor;
 import org.odftoolkit.odfdom.dom.OdfDocumentNamespace;
 import org.odftoolkit.odfdom.dom.element.draw.DrawFillImageElement;
@@ -71,11 +73,11 @@ public abstract class OdfOfficeStyles extends OdfStylesBase {
   private static final long serialVersionUID = 700763983193326060L;
 
   // styles that are only in OdfOfficeStyles
-  private HashMap<OdfStyleFamily, OdfDefaultStyle> mDefaultStyles;
-  private HashMap<String, DrawMarkerElement> mMarker;
-  private HashMap<String, DrawGradientElement> mGradients;
-  private HashMap<String, DrawHatchElement> mHatches;
-  private HashMap<String, DrawFillImageElement> mFillImages;
+  private Map<OdfStyleFamily, OdfDefaultStyle> mDefaultStyles;
+  private Map<String, DrawMarkerElement> mMarker;
+  private Map<String, DrawGradientElement> mGradients;
+  private Map<String, DrawHatchElement> mHatches;
+  private Map<String, DrawFillImageElement> mFillImages;
   private OdfTextOutlineStyle mOutlineStyle;
 
   public OdfOfficeStyles(OdfFileDom ownerDoc) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfStylesBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfStylesBase.java
@@ -26,6 +26,7 @@ package org.odftoolkit.odfdom.incubator.doc.office;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.odftoolkit.odfdom.dom.OdfDocumentNamespace;
@@ -55,17 +56,17 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
 
   private static final long serialVersionUID = 1L;
 
-  private HashMap<OdfStyleFamily, HashMap<String, OdfStyle>> mStyles;
-  private HashMap<String, OdfTextListStyle> mListStyles;
-  private HashMap<String, OdfNumberStyle> mNumberStyles;
-  private HashMap<String, OdfNumberDateStyle> mDateStyles;
-  private HashMap<String, OdfNumberPercentageStyle> mPercentageStyles;
-  private HashMap<String, OdfNumberCurrencyStyle> mCurrencyStyles;
-  private HashMap<String, OdfNumberTimeStyle> mTimeStyles;
-  private HashMap<String, NumberBooleanStyleElement> mBooleanStyles;
-  private HashMap<String, NumberTextStyleElement> mTextStyles;
+  private Map<OdfStyleFamily, HashMap<String, OdfStyle>> mStyles;
+  private Map<String, OdfTextListStyle> mListStyles;
+  private Map<String, OdfNumberStyle> mNumberStyles;
+  private Map<String, OdfNumberDateStyle> mDateStyles;
+  private Map<String, OdfNumberPercentageStyle> mPercentageStyles;
+  private Map<String, OdfNumberCurrencyStyle> mCurrencyStyles;
+  private Map<String, OdfNumberTimeStyle> mTimeStyles;
+  private Map<String, NumberBooleanStyleElement> mBooleanStyles;
+  private Map<String, NumberTextStyleElement> mTextStyles;
 
-  private HashMap<String, DataStyleElement> mAllDataStyles =
+  private Map<String, DataStyleElement> mAllDataStyles =
       new HashMap<String, DataStyleElement>();
 
   public OdfStylesBase(OdfFileDom ownerDoc, OdfName odfName) {
@@ -73,7 +74,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
   }
 
   /** @return a set of all names of the contained 'number' styles (text, date, time, ...) */
-  public HashMap<String, DataStyleElement> getAllDataStyles() {
+  public Map<String, DataStyleElement> getAllDataStyles() {
     return mAllDataStyles;
   }
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfStylesBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfStylesBase.java
@@ -130,8 +130,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
   public Iterable<OdfStyle> getAllStyles() {
     ArrayList<OdfStyle> allStyles = new ArrayList<OdfStyle>();
     if (mStyles != null) {
-      for (OdfStyleFamily family : mStyles.keySet()) {
-        HashMap<String, OdfStyle> familySet = mStyles.get(family);
+      for (HashMap<String, OdfStyle> familySet : mStyles.values()) {
         Collection<OdfStyle> familyStyles = familySet.values();
         allStyles.addAll(familyStyles);
       }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/SelectionManager.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/SelectionManager.java
@@ -20,6 +20,8 @@ package org.odftoolkit.odfdom.incubator.search;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
+
 import org.odftoolkit.odfdom.pkg.OdfElement;
 
 /**
@@ -29,7 +31,7 @@ import org.odftoolkit.odfdom.pkg.OdfElement;
  */
 public class SelectionManager {
 
-  private HashMap<OdfElement, ArrayList<Selection>> repository = null;
+  private Map<OdfElement, ArrayList<Selection>> repository = null;
 
   public SelectionManager() {
     repository = new HashMap<OdfElement, ArrayList<Selection>>();
@@ -137,7 +139,7 @@ public class SelectionManager {
       selections.remove(item);
     }
   }
-  
+
   /**
    * Removes all selections from the SelectionManager.
    */

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/DefaultErrorHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/DefaultErrorHandler.java
@@ -55,9 +55,9 @@ public class DefaultErrorHandler implements ErrorHandler {
     return sw.getBuffer().toString();
   }
 
-  private ArrayList<SAXParseException> mWarnings = null;
-  private ArrayList<SAXParseException> mErrors = null;
-  private ArrayList<SAXParseException> mFatalErrors = null;
+  private List<SAXParseException> mWarnings = null;
+  private List<SAXParseException> mErrors = null;
+  private List<SAXParseException> mFatalErrors = null;
   private final StringBuilder mValidationMessages;
 
   public DefaultErrorHandler() {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfElement.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfElement.java
@@ -1862,7 +1862,7 @@ public abstract class OdfElement extends ElementNSImpl {
           JSONObject formatChanges,
           Map<OdfName, OdfElement> formatElementHolder) {
         if (currentNode != null) {
-          Integer nextSplitPos;
+          int nextSplitPos;
           // if the start is equal to the first position avoid the first split
           if (currentPos >= posStart) {
             // we are about to gather content in our span
@@ -1873,7 +1873,7 @@ public abstract class OdfElement extends ElementNSImpl {
           }
 
           // ** GET NODE SIZE
-          Integer contentLength = getNodeWidth(currentNode);
+          int contentLength = getNodeWidth(currentNode);
 
           // addChild the full currentNode ==> if the end of the span is equal to the end of the
           // currentNode
@@ -1943,7 +1943,7 @@ public abstract class OdfElement extends ElementNSImpl {
           // // ** GET NODE SIZE
           // Integer contentLength = getNodeWidth(currentNode);
           // ** GET NODE SIZE
-          Integer contentLength = 1; // component default is 1
+          int contentLength = 1; // component default is 1
           if (currentNode instanceof Text) {
             contentLength = ((Text) currentNode).getLength();
           } else {
@@ -2037,7 +2037,7 @@ public abstract class OdfElement extends ElementNSImpl {
       int delete(Node currentNode, int currentPos, int posStart, int posEnd, List deleteStatus) {
 
         if (currentNode != null) {
-          Integer nextSplitPos;
+          int nextSplitPos;
           // if the start is equal to the first position avoid the first split
           if (currentPos >= posStart) {
             // we are about to gather content in our span
@@ -2047,7 +2047,7 @@ public abstract class OdfElement extends ElementNSImpl {
             nextSplitPos = posStart;
           }
           // ** GET NODE SIZE
-          Integer contentLength = getNodeWidth(currentNode);
+          int contentLength = getNodeWidth(currentNode);
 
           // addChild the middle part of the currentNode ==> if the currentNode already starts
           // within the span, but the end is not within the span
@@ -2228,7 +2228,7 @@ public abstract class OdfElement extends ElementNSImpl {
         if (currentNode != null) {
 
           // ** GET NODE SIZE
-          Integer contentLength = 1; // component default is 1
+          int contentLength = 1; // component default is 1
           if (currentNode instanceof Text) {
             contentLength = ((Text) currentNode).getLength();
           } else {
@@ -2282,7 +2282,7 @@ public abstract class OdfElement extends ElementNSImpl {
         if (currentNode != null) {
 
           // ** GET NODE SIZE
-          Integer contentLength = 1; // component default is 1
+          int contentLength = 1; // component default is 1
           if (!(currentNode instanceof Text)) {
             // get size from component
             contentLength = ((OdfElement) currentNode).getRepetition();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfFileDom.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfFileDom.java
@@ -437,12 +437,11 @@ public class OdfFileDom extends DocumentImpl implements NamespaceContext {
     nsURI = mUriByPrefix.get(prefix);
     if (nsURI == null) {
       // look in Duplicate URI prefixes
-      Set<String> urisWithDuplicatePrefixes = this.mDuplicatePrefixesByUri.keySet();
-      for (String aURI : urisWithDuplicatePrefixes) {
-        Set<String> prefixes = this.mDuplicatePrefixesByUri.get(aURI);
+      for (Map.Entry<String, Set<String>> entry : this.mDuplicatePrefixesByUri.entrySet()) {
+        Set<String> prefixes = entry.getValue();
         // check if requested prefix exists in hashset
         if (prefixes.contains(prefix)) {
-          nsURI = aURI;
+          nsURI = entry.getKey();
           break;
         }
       }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfFileSaxHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfFileSaxHandler.java
@@ -24,6 +24,7 @@
 package org.odftoolkit.odfdom.pkg;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Stack;
 import org.odftoolkit.odfdom.pkg.rdfa.JenaSink;
 import org.w3c.dom.Element;
@@ -80,7 +81,7 @@ public class OdfFileSaxHandler extends DefaultHandler {
       element = mFileDom.createElement(localName);
     } else {
       // if localName is the same object as qName, there is a default namespace set
-      if (localName == qName) {
+      if (Objects.equals(localName, qName)) {
         element =
             mFileDom.createElementNS(
                 OdfName.getOdfName(OdfNamespace.newNamespace(null, uri), localName));

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfName.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfName.java
@@ -31,14 +31,16 @@ import java.util.HashMap;
  */
 public class OdfName implements Comparable<OdfName> {
 
-  private OdfNamespace mNS;
-  private String mLocalName;
-  private String mExpandedName; // i.e. {nsURI}localName
+  private final OdfNamespace mNS;
+  private final String mLocalName;
+  private final String mQName;
+  private final String mExpandedName; // i.e. {nsURI}localName
   private static HashMap<String, OdfName> mOdfNames = new HashMap<String, OdfName>();
 
   private OdfName(OdfNamespace ns, String localname, String expandedName) {
     mNS = ns;
     mLocalName = localname;
+    mQName = mNS != null ? ((mNS.getPrefix() + ":" + mLocalName).intern()) : mLocalName;
     mExpandedName = expandedName;
   }
 
@@ -153,11 +155,7 @@ public class OdfName implements Comparable<OdfName> {
 
   /** @return the XML QName, the qualified name e.g. for <text:p> it is text:p. */
   public String getQName() {
-    if (mNS != null) {
-      return ((mNS.getPrefix() + ":" + mLocalName).intern());
-    } else {
-      return mLocalName;
-    }
+    return mQName;
   }
 
   /**

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackage.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackage.java
@@ -141,7 +141,7 @@ public class OdfPackage implements Closeable {
   private ZipHelper mZipFile;
   private Resolver mResolver;
   private Map<String, ZipArchiveEntry> mZipEntries;
-  private HashMap<String, ZipArchiveEntry> mOriginalZipEntries;
+  private Map<String, ZipArchiveEntry> mOriginalZipEntries;
   private Map<String, OdfFileEntry> mManifestEntries;
   // All opened documents from the same package are cached (including the root document)
   private Map<String, OdfPackageDocument> mPkgDocuments;
@@ -150,8 +150,8 @@ public class OdfPackage implements Closeable {
   private int mTransientMarkupId = 0;
   // Three different incarnations of a package file/data
   // save() will check 1) mPkgDoms, 2) if not check mMemoryFileCache
-  private HashMap<String, Document> mPkgDoms;
-  private HashMap<String, byte[]> mMemoryFileCache;
+  private Map<String, Document> mPkgDoms;
+  private Map<String, byte[]> mMemoryFileCache;
   private Map<String, Object> mConfiguration = new HashMap<String, Object>();
 
   private ErrorHandler mErrorHandler;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
@@ -26,7 +26,7 @@ package org.odftoolkit.odfdom.pkg.rdfa;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.xml.namespace.NamespaceContext;
@@ -49,8 +49,8 @@ final class EvalContext implements NamespaceContext {
     super();
     this.base = base;
     this.parentSubject = base;
-    this.forwardProperties = new LinkedList<String>();
-    this.backwardProperties = new LinkedList<String>();
+    this.forwardProperties = new ArrayList<String>();
+    this.backwardProperties = new ArrayList<String>();
   }
 
   public EvalContext(EvalContext toCopy) {
@@ -59,8 +59,8 @@ final class EvalContext implements NamespaceContext {
     this.parentSubject = toCopy.parentSubject;
     this.parentObject = toCopy.parentObject;
     this.language = toCopy.language;
-    this.forwardProperties = new LinkedList<String>(toCopy.forwardProperties);
-    this.backwardProperties = new LinkedList<String>(toCopy.backwardProperties);
+    this.forwardProperties = new ArrayList<String>(toCopy.forwardProperties);
+    this.backwardProperties = new ArrayList<String>(toCopy.backwardProperties);
     this.parent = toCopy;
     this.vocab = toCopy.vocab;
   }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.xml.namespace.NamespaceContext;
 
 /** EvalContext modified from net.rootdev.javardfa.EvalContext */
@@ -70,8 +71,8 @@ final class EvalContext implements NamespaceContext {
     // from their typical values (base).
     // Base changing happens very late in the day when we're streaming, and
     // it is very fiddly to handle
-    boolean setPS = parentSubject == base;
-    boolean setPO = parentObject == base;
+    boolean setPS = Objects.equals(parentSubject, base);
+    boolean setPO = Objects.equals(parentObject, base);
 
     if (abase.contains("#")) {
       this.base = abase.substring(0, abase.indexOf("#"));

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/MultiContentHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/MultiContentHandler.java
@@ -24,6 +24,8 @@
 package org.odftoolkit.odfdom.pkg.rdfa;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.Locator;
@@ -34,10 +36,7 @@ public class MultiContentHandler implements ContentHandler {
   ArrayList<ContentHandler> subContentHandlers;
 
   public MultiContentHandler(ContentHandler... subs) {
-    subContentHandlers = new ArrayList<ContentHandler>();
-    for (ContentHandler sub : subs) {
-      subContentHandlers.add(sub);
-    }
+    subContentHandlers = new ArrayList<>(Arrays.asList(subs));
   }
 
   public void setDocumentLocator(Locator locator) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/RDFaParser.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/RDFaParser.java
@@ -25,7 +25,7 @@ package org.odftoolkit.odfdom.pkg.rdfa;
 
 import java.util.EnumSet;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import javax.xml.namespace.QName;
@@ -146,8 +146,8 @@ class RDFaParser extends net.rootdev.javardfa.Parser {
     boolean skipElement = false;
     String newSubject = null;
     String currentObject = null;
-    List<String> forwardProperties = new LinkedList();
-    List<String> backwardProperties = new LinkedList();
+    List<String> forwardProperties = new ArrayList();
+    List<String> backwardProperties = new ArrayList();
     String currentLanguage = context.language;
 
     if (settings.contains(Setting.OnePointOne)) {
@@ -340,7 +340,7 @@ class RDFaParser extends net.rootdev.javardfa.Parser {
   }
 
   private Iterator fromAttributes(Attributes attributes) {
-    List toReturn = new LinkedList();
+    List toReturn = new ArrayList();
 
     for (int i = 0; i < attributes.getLength(); i++) {
       String qname = attributes.getQName(i);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/URIExtractorImpl.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/URIExtractorImpl.java
@@ -25,7 +25,7 @@ package org.odftoolkit.odfdom.pkg.rdfa;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +78,7 @@ class URIExtractorImpl implements URIExtractor {
 
   public List<String> getURIs(StartElement element, Attribute attr, EvalContext context) {
 
-    List<String> uris = new LinkedList<String>();
+    List<String> uris = new ArrayList<String>();
 
     String[] curies = attr.getValue().split("\\s+");
     boolean permitReserved =

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/Length.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/Length.java
@@ -204,7 +204,7 @@ public class Length implements OdfDataType {
 
       for (Unit unit : Unit.values()) {
         if (length.contains(unit.abbr())) {
-          Double value = Double.valueOf(length.substring(0, length.indexOf(unit.abbr())));
+          double value = Double.parseDouble(length.substring(0, length.indexOf(unit.abbr())));
           // if no destination unit was given the unit remains the same
           if (destinationUnit != null) {
             // using roundfactor proved to be more precise when used with Java XSLT processor
@@ -298,7 +298,7 @@ public class Length implements OdfDataType {
 
       for (Unit unit : Unit.values()) {
         if (length.contains(unit.abbr())) {
-          Double value = Double.valueOf(length.substring(0, length.indexOf(unit.abbr())));
+          double value = Double.parseDouble(length.substring(0, length.indexOf(unit.abbr())));
           // if no destination unit was given the unit remains the same
           if (destinationUnit != null) {
             // using roundfactor proved to be more precise when used with Java XSLT processor

--- a/odfdom/src/test/java/org/odftoolkit/junit/AlphabeticalOrderedRunner.java
+++ b/odfdom/src/test/java/org/odftoolkit/junit/AlphabeticalOrderedRunner.java
@@ -16,7 +16,6 @@
 package org.odftoolkit.junit;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.runners.BlockJUnit4ClassRunner;

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/changes/RoundtripTestHelper.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/changes/RoundtripTestHelper.java
@@ -30,7 +30,6 @@ import java.util.logging.Logger;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.odftoolkit.odfdom.doc.LoadSaveTest;
 import org.odftoolkit.odfdom.pkg.DefaultErrorHandler;
 import org.odftoolkit.odfdom.utils.ResourceUtilities;
 

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentCreationTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentCreationTest.java
@@ -52,7 +52,6 @@ import org.odftoolkit.odfdom.incubator.doc.text.OdfTextSpan;
 import org.odftoolkit.odfdom.pkg.OdfElement;
 import org.odftoolkit.odfdom.pkg.OdfFileDom;
 import org.odftoolkit.odfdom.pkg.OdfPackage;
-import org.odftoolkit.odfdom.pkg.OdfPackageDocument;
 import org.odftoolkit.odfdom.pkg.OdfXMLFactory;
 import org.odftoolkit.odfdom.pkg.manifest.OdfFileEntry;
 import org.odftoolkit.odfdom.utils.ResourceUtilities;

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentCreationTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentCreationTest.java
@@ -251,8 +251,7 @@ public class DocumentCreationTest {
       OdfDocument docWithEmbeddedObjects = OdfDocument.loadDocument(TEST_FILE_EMBEDDED);
       Map<String, OdfDocument> embDocs = docWithEmbeddedObjects.loadSubDocuments();
       String pathToEmbeddedObject = "";
-      for (String embDocPath : embDocs.keySet()) {
-        OdfPackageDocument embDoc = embDocs.get(embDocPath);
+      for (OdfDocument embDoc : embDocs.values()) {
         LOG.log(
             Level.INFO,
             "Embedded file of {0} internal package path: {1} mediaType: {2}",
@@ -381,8 +380,7 @@ public class DocumentCreationTest {
     try {
       docWithEmbeddedObjects = OdfDocument.loadDocument(TEST_FILE_EMBEDDED);
       Map<String, OdfDocument> embDocs = docWithEmbeddedObjects.loadSubDocuments();
-      for (String embDocPath : embDocs.keySet()) {
-        OdfDocument doc1 = embDocs.get(embDocPath);
+      for (OdfDocument doc1 : embDocs.values()) {
         doc1.getDocumentPath();
         OdfContentDom contentDom1 = doc1.getContentDom();
         OdfDocument doc2 = doc1.loadSubDocument(".");
@@ -404,8 +402,7 @@ public class DocumentCreationTest {
       Map<String, OdfDocument> embDocs =
           docWithEmbeddedObjects.loadSubDocuments(OdfDocument.OdfMediaType.GRAPHICS);
       // Graphics Doc
-      for (String eDocPath : embDocs.keySet()) {
-        OdfDocument doc1 = embDocs.get(eDocPath);
+      for (OdfDocument doc1 : embDocs.values()) {
         Assert.assertNotNull(doc1);
         OdfContentDom contentDom = doc1.getContentDom();
         XPath xpath = contentDom.getXPath();
@@ -424,9 +421,8 @@ public class DocumentCreationTest {
         Assert.assertEquals(span.getTextContent(), TEST_SPAN_TEXT);
         Map<String, OdfDocument> embDocs3 =
             docWithEmbeddedObjects.loadSubDocuments(OdfDocument.OdfMediaType.TEXT);
-        for (String eDocPath3 : embDocs3.keySet()) {
+        for (OdfDocument doc3 : embDocs3.values()) {
           // Writer Doc
-          OdfDocument doc3 = embDocs3.get(eDocPath3);
           Assert.assertNotNull(doc3);
           OdfContentDom contentDom3 = doc3.getContentDom();
           TextPElement para2 =

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentTest.java
@@ -172,7 +172,7 @@ public class DocumentTest {
 
   @Test
   @Ignore
-  public void testDumpDom() {
+  public void testDumpDom() throws Exception {
     Assert.assertTrue(testXSLT("content"));
     Assert.assertTrue(testXSLT("styles"));
   }

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentTest.java
@@ -173,12 +173,8 @@ public class DocumentTest {
   @Test
   @Ignore
   public void testDumpDom() {
-    try {
-      Assert.assertTrue(testXSLT("content") & testXSLT("styles"));
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, e.getMessage(), e);
-      Assert.fail(e.getMessage());
-    }
+    Assert.assertTrue(testXSLT("content"));
+    Assert.assertTrue(testXSLT("styles"));
   }
 
   private static boolean testXSLT(String odfFileNamePrefix) throws Exception {

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableRowColumnTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableRowColumnTest.java
@@ -18,9 +18,6 @@
  */
 package org.odftoolkit.odfdom.doc.table;
 
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
@@ -1239,7 +1239,7 @@ public class TableTest {
   // ODFDOM ToDo: http://odftoolkit.org/bugzilla/show_bug.cgi?id=293
   // 293 - Adding optional Maps to generated ODF sources for indexed ODF elements
   // Method To be moved on StyleMasterPageElement
-  private HashMap<String, String> getPageStyleProps(
+  private Map<String, String> getPageStyleProps(
       OdfDocument odfDoc, StyleMasterPageElement masterPage) throws Exception {
     StylePageLayoutElement pageLayout = getMasterPageLayout(odfDoc, masterPage);
 
@@ -1262,7 +1262,7 @@ public class TableTest {
   // ODFDOM ToDo: http://odftoolkit.org/bugzilla/show_bug.cgi?id=293
   // 293 - Adding optional Maps to generated ODF sources for indexed ODF elements
   // Method To be moved on StyleMasterPageElement
-  private HashMap<String, String> getHeaderStyleProps(
+  private Map<String, String> getHeaderStyleProps(
       OdfDocument odfDoc, StyleMasterPageElement masterPage) throws Exception {
     StylePageLayoutElement pageLayout = getMasterPageLayout(odfDoc, masterPage);
     // ToDo: Combine a GETTER for header Properties in one method
@@ -1286,7 +1286,7 @@ public class TableTest {
   // ODFDOM ToDo: http://odftoolkit.org/bugzilla/show_bug.cgi?id=293
   // 293 - Adding optional Maps to generated ODF sources for indexed ODF elements
   // Method To be moved on StyleMasterPageElement
-  private HashMap<String, String> getFooterStyleProps(
+  private Map<String, String> getFooterStyleProps(
       OdfDocument odfDoc, StyleMasterPageElement masterPage) throws Exception {
     StylePageLayoutElement pageLayout = getMasterPageLayout(odfDoc, masterPage);
     // ODFDOM ToDo: Combine a GETTER for footer Properties in one method

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
@@ -18,7 +18,6 @@
  */
 package org.odftoolkit.odfdom.doc.table;
 
-import java.io.FileNotFoundException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.HashMap;

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/EmbeddedDocumentTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/EmbeddedDocumentTest.java
@@ -93,8 +93,7 @@ public class EmbeddedDocumentTest {
       OdfDocument saveDoc = OdfTextDocument.newTextDocument();
       Map<String, OdfDocument> subDocs = doc.loadSubDocuments();
       List<String> subDocNames = new ArrayList<String>();
-      for (String childDocPath : subDocs.keySet()) {
-        OdfDocument childDoc = subDocs.get(childDocPath);
+      for (OdfDocument childDoc : subDocs.values()) {
         String embeddedDocPath = childDoc.getDocumentPath();
         saveDoc.insertDocument(childDoc, embeddedDocPath);
         subDocNames.add(embeddedDocPath);
@@ -110,10 +109,10 @@ public class EmbeddedDocumentTest {
       saveDoc = OdfDocument.loadDocument(TEST_OUTPUT_FOLDER + TEST_FILE_EMBEDDED_SAVE_OUT);
       Map<String, OdfDocument> reloadedSubDocs = saveDoc.loadSubDocuments();
       Assert.assertTrue(subDocs.size() == reloadedSubDocs.size());
-      for (String childDocPath : subDocs.keySet()) {
+      for (Map.Entry<String, OdfDocument> entry : subDocs.entrySet()) {
         Assert.assertEquals(
-            subDocs.get(childDocPath).getMediaTypeString(),
-            reloadedSubDocs.get(childDocPath).getMediaTypeString());
+          entry.getValue().getMediaTypeString(),
+            reloadedSubDocs.get(entry.getKey()).getMediaTypeString());
       }
     } catch (Exception ex) {
       LOG.log(Level.SEVERE, null, ex);
@@ -159,8 +158,7 @@ public class EmbeddedDocumentTest {
       Assert.assertNotNull(imageEntry);
       Map<String, OdfDocument> embDocs =
           testLoad.loadSubDocuments(OdfDocument.OdfMediaType.SPREADSHEET);
-      for (String embedDocPath : embDocs.keySet()) {
-        OdfDocument doc1 = embDocs.get(embedDocPath);
+      for (OdfDocument doc1 : embDocs.values()) {
         imageEntry =
             doc1.getPackage()
                 .getFileEntry(
@@ -213,8 +211,7 @@ public class EmbeddedDocumentTest {
       Assert.assertNotNull(imageEntry);
       Map<String, OdfDocument> embDocs =
           testLoad.loadSubDocuments(OdfDocument.OdfMediaType.SPREADSHEET);
-      for (String childDocPath : embDocs.keySet()) {
-        OdfDocument doc1 = embDocs.get(childDocPath);
+      for (OdfDocument doc1 : embDocs.values()) {
         imageEntry =
             doc1.getPackage()
                 .getFileEntry(
@@ -240,8 +237,7 @@ public class EmbeddedDocumentTest {
       OdfDocument doc =
           OdfDocument.loadDocument(ResourceUtilities.getAbsoluteInputPath(TEST_FILE_EMBEDDED));
       Map<String, OdfDocument> embeddedDocs = doc.loadSubDocuments();
-      for (String childDocPath : embeddedDocs.keySet()) {
-        OdfDocument childDoc = embeddedDocs.get(childDocPath);
+      for (OdfDocument childDoc : embeddedDocs.values()) {
         String embedFileName = childDoc.getDocumentPath();
         OdfMediaType embedMediaType = OdfMediaType.getOdfMediaType(childDoc.getMediaTypeString());
         // use '_' replace '/', because '/' is not the valid char in file path
@@ -338,8 +334,7 @@ public class EmbeddedDocumentTest {
           OdfDocument.loadDocument(ResourceUtilities.getAbsoluteInputPath(TEST_FILE_EMBEDDED));
       Map<String, OdfDocument> embeddedDocs = doc.loadSubDocuments();
       List<String> subDocNames = new ArrayList<String>();
-      for (String childDocPath : embeddedDocs.keySet()) {
-        OdfDocument childDoc = embeddedDocs.get(childDocPath);
+      for (OdfDocument childDoc : embeddedDocs.values()) {
         Assert.assertNotNull(childDoc);
         String embedFileName = childDoc.getDocumentPath();
         subDocNames.add(embedFileName);

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFRootPackageValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFRootPackageValidator.java
@@ -28,6 +28,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.zip.ZipException;
 import javax.xml.validation.Validator;
 import org.odftoolkit.odfdom.doc.OdfDocument;
@@ -38,7 +39,7 @@ abstract class ODFRootPackageValidator extends ODFPackageValidator
     implements ManifestEntryListener {
 
   private OdfPackage m_aPkg = null;
-  private ArrayList<ManifestEntry> m_aSubDocs = null;
+  private List<ManifestEntry> m_aSubDocs = null;
   private ODFPackageErrorHandler m_ErrorHandler = null;
 
   protected ODFRootPackageValidator(

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidationResult.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidationResult.java
@@ -43,8 +43,8 @@ public class ODFValidationResult
   private String m_aGenerator = null;
   private String m_aMediaType = "";
 
-  private HashMap<String, Long> m_aForeignElementMap = null;
-  private HashMap<String, Long> m_aForeignAttributeMap = null;
+  private Map<String, Long> m_aForeignElementMap = null;
+  private Map<String, Long> m_aForeignAttributeMap = null;
 
   private Status m_aStrictValid = Status.UNKNOWN;
   private Status m_aValid = Status.UNKNOWN;

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
@@ -262,7 +262,7 @@ public class ODFValidator implements ODFValidatorProvider {
 
   private Configuration getConfiguration(OdfVersion aVersion) throws ODFValidatorException {
     if (m_aConfigurationMap == null) {
-      m_aConfigurationMap = new HashMap<OdfVersion, Configuration>();
+      m_aConfigurationMap = new HashMap<>();
     }
 
     Configuration aConfig = m_aConfigurationMap.get(aVersion);

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
@@ -28,9 +28,11 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
@@ -51,8 +53,8 @@ public class ODFValidator implements ODFValidatorProvider {
   protected OdfVersion m_aVersion = null;
   protected OdfVersion mOdfPackageVersion = null;
   // Validator and configuration cache
-  private HashMap<String, Schema> m_aSchemaMap = null;
-  private HashMap<OdfVersion, Configuration> m_aConfigurationMap = null;
+  private Map<String, Schema> m_aSchemaMap = null;
+  private Map<OdfVersion, Configuration> m_aConfigurationMap = null;
   // Generator from last validateFile or validateStream call
   private String m_aGenerator = "";
   private static final String MISSING_ODF_VERSION = " 'Missing ODF version'";
@@ -262,7 +264,7 @@ public class ODFValidator implements ODFValidatorProvider {
 
   private Configuration getConfiguration(OdfVersion aVersion) throws ODFValidatorException {
     if (m_aConfigurationMap == null) {
-      m_aConfigurationMap = new HashMap<>();
+      m_aConfigurationMap = new EnumMap<>(OdfVersion.class);
     }
 
     Configuration aConfig = m_aConfigurationMap.get(aVersion);

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ValidationOOoTaskIdErrorFilter.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ValidationOOoTaskIdErrorFilter.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -55,7 +56,7 @@ public class ValidationOOoTaskIdErrorFilter implements SAXParseExceptionFilter {
     }
   }
 
-  private HashMap<String, FilterEntry> m_aFilterEntries;
+  private Map<String, FilterEntry> m_aFilterEntries;
   private HashSet<String> m_aTaskIdsReported;
 
   class Handler extends DefaultHandler {
@@ -69,10 +70,10 @@ public class ValidationOOoTaskIdErrorFilter implements SAXParseExceptionFilter {
       }
     }
 
-    HashMap<String, FilterEntry> m_aFilterEntries;
+    Map<String, FilterEntry> m_aFilterEntries;
     Entry m_aEntry = null;
 
-    Handler(HashMap<String, FilterEntry> aFilterEntries) {
+    Handler(Map<String, FilterEntry> aFilterEntries) {
       m_aFilterEntries = aFilterEntries;
     }
 


### PR DESCRIPTION
Just some cleanup across the board. Let me know if the PRs get too big... maybe I should attack the module-info first, that one might take a while but should then be a rather small PR :)

Some notes:

# return of Collections

I changed the returns from the concrete implementation to the collection interface type. Returning the concrete type is an anti-pattern that exposes implementation details to the user that is none of their business and will prove problematic in the future.  This may break useer code if they use something like `LinkedList<...> = getSomeList();`, but it is easy to fix and every IDE I know of has a quick fix for that.

Declaring a return type Map instead of HashMap also has the advantage of being able to use a different implementation without the user even noticing. Examples are EnumMap (a map for EnumValues that offers much faster access or one of the ConcurrentMap implementations when thread safety is needed.

# LinkedLists

I changed all instantiations or LinkedList to ArrayList - while possible in theory, I have not seen a single case where LinkedList was really beneficial in the last 20 years. LinkedLists use more memory, and are slower to traverse. The only benefit would be frequent additions or removals at arbitrary positions inside the list. I profiled the tests and saw that LinkedList.indexOf() was one of the methods the most time was spent in. Even if both List implementations are O(n) here, the constant factor for ArrayList is much lower.

# String.intern()

Using String.intern() generally is a bad idea: the string will be copied into the constant pool and persist even after garbage collections. It was used for QNames and might lead to memory leaks, for example when running in a server context. Should there be any negative side effects, I can create a PR that fixes that without using intern(), but I think it should not be necessary.

# String comparisons using != and ==

These are simply bugs. It only works (more or less) reliably when __both__ strings are literals or have been obtained using intern(). It may or may not work if one of the strings is the result of a concatenation or was created using a StringBuilder/StringBuffer. IT may even work in all your tests and then fail after hours in your production system.

# redundant Map lookups

I have changed some places to reduce unnecessary map lookups, for example by iterating directly over values() instead of keys() and just doing a get(key) afterwards, or over the entySet() if both key and value are needed. I'll look for more places later.
