### PR TITLE
refactor file contents tests; ignore macOS .DS_Store files in tests

### DIFF
--- a/generator/schema2template/src/test/java/schema2template/grammar/DirectoryCompare.java
+++ b/generator/schema2template/src/test/java/schema2template/grammar/DirectoryCompare.java
@@ -16,238 +16,159 @@
  */
 package schema2template.grammar;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.junit.Assert;
 
 /**
  * Compares a directory with all its subdirectories if its text files are equal by line. Comparing
  * our test results with our references, which were once test files of running tests!
  */
-class DirectoryCompare {
+final class DirectoryCompare {
 
   private static final Logger LOG = Logger.getLogger(DirectoryCompare.class.getName());
 
-  public static boolean compareDirectories(String newFileDir, String RefFileDir) {
-    boolean directoriesEqual = true;
-    try {
-      // ******** Reference Test *************
-      // generated sources must be equal to the previously generated reference sources
-      String targetPath = Paths.get(newFileDir).toAbsolutePath().toString();
-      String referencePath = Paths.get(RefFileDir).toAbsolutePath().toString();
+  private DirectoryCompare() {
+    // utility class
+  }
 
-      LOG.log(
-          Level.INFO,
-          "\n\nComparing new generated Files:\n\t{0}\nwith their reference:\n\t{1}\n",
-          new Object[] {targetPath, referencePath});
-      directoriesEqual =
-          DirectoryCompare.compareDirectories(Paths.get(newFileDir), Paths.get(RefFileDir));
-      Assert.assertTrue(
-          "The new generated sources\n\t"
-              + targetPath
-              + "\ndiffer from their reference:\n\t"
-              + referencePath,
-          directoriesEqual);
-    } catch (IOException ex) {
-      LOG.log(Level.SEVERE, null, ex);
-      Assert.fail(ex.toString());
-    }
-    return directoriesEqual;
+  public static void assertDirectoriesEqual(String RefFileDir, String newFileDir) throws Exception {
+    // ******** Reference Test *************
+    LOG.log(Level.INFO, "Comparing generated Files:\n\t{0}", RefFileDir);
+    assertDirectoriesEqual(Paths.get(RefFileDir).toAbsolutePath(), Paths.get(newFileDir).toAbsolutePath());
   }
 
   /**
    * Compare the contents of two directories to determine if they are equal or not. If one of the
    * paths don't exist, the contents aren't equal and this method returns false.
    */
-  private static boolean compareDirectories(Path dir1, Path dir2) throws IOException {
+  private static void assertDirectoriesEqual(Path dir1, Path dir2) throws IOException {
     boolean dir1Exists = Files.exists(dir1) && Files.isDirectory(dir1);
     boolean dir2Exists = Files.exists(dir2) && Files.isDirectory(dir2);
-    boolean areEqual = true;
 
-    if (dir1Exists && dir2Exists) {
-      HashMap<Path, Path> dir1Paths = new HashMap<>();
-      HashMap<Path, Path> dir2Paths = new HashMap<>();
+    Assert.assertTrue(String.format(
+      "The directory %s does not exist or is not a directory.", dir1),
+      dir1Exists
+    );
+    Assert.assertTrue(String.format(
+      "The directory %s does not exist or is not a directory.", dir2),
+      dir2Exists
+    );
 
-      // Map the path relative to the base directory to the complete path.
-      for (Path p : listPaths(dir1)) {
-        dir1Paths.put(dir1.relativize(p), p);
-      }
+    HashMap<Path, Path> dir1Paths = new HashMap<>();
+    HashMap<Path, Path> dir2Paths = new HashMap<>();
 
-      for (Path p : listPaths(dir2)) {
-        dir2Paths.put(dir2.relativize(p), p);
-      }
-
-      // The directories cannot be equal if the number of files aren't equal.
-      if (dir1Paths.size() != dir2Paths.size()) {
-        LOG.log(
-            Level.SEVERE,
-            "\nThe file size differ:\n{0} files exist in \n{1}\n{2} files exist in\n{3}\n\n",
-            new Object[] {dir1Paths.size(), dir1, dir2Paths.size(), dir2});
-        areEqual = false;
-      }
-
-      // For each file in dir1, check if also dir2 contains this file and if
-      // their contents are equal.
-      for (Entry<Path, Path> pathEntry : dir1Paths.entrySet()) {
-        Path relativePath = pathEntry.getKey();
-        Path absolutePath = pathEntry.getValue();
-        if (!dir2Paths.containsKey(relativePath)) {
-          areEqual = false;
-          LOG.log(
-              Level.SEVERE,
-              "\nThe file\n{0}\ndoes not exist in\n{1}\n\n",
-              new Object[] {relativePath, dir2});
-        } else {
-          if (!textFilesEquals(absolutePath, dir2Paths.get(relativePath))) {
-            // error msg within textFilesEquals with line difference
-            // LOG.log(Level.SEVERE, "There is a difference between:\n{0}\n and \n{1}\n\n", new
-            // Object[]{absolutePath.toString(), relativePath.toAbsolutePath().toString()});
-            areEqual = false;
-          }
-          // remove it to be able to show the superset of dir2Paths in the end
-          dir2Paths.remove(relativePath);
-        }
-      }
-      // if there is a superset of dir2Paths
-      if (!dir2Paths.isEmpty()) {
-        areEqual = false;
-        for (Entry<Path, Path> pathEntry2 : dir2Paths.entrySet()) {
-          Path relativePath2 = pathEntry2.getKey();
-          LOG.log(
-              Level.SEVERE,
-              "\nThe file\n{0}\ndoes not exist in\n{1}\n\n",
-              new Object[] {relativePath2, dir1});
-        }
-      }
-      return areEqual;
-    } else {
-      areEqual = false;
-      if (!dir1Exists) {
-        LOG.log(
-            Level.SEVERE,
-            "\nThe following input directory does not exist:\n{0}\n\n",
-            new Object[] {dir1});
-      }
-      if (!dir2Exists) {
-        LOG.log(
-            Level.SEVERE,
-            "\nThe following input directory does not exist:\n{0}",
-            new Object[] {dir2});
-      }
+    // Map the path relative to the base directory to the complete path.
+    for (Path p : listPaths(dir1)) {
+      dir1Paths.put(dir1.relativize(p), p);
     }
 
-    return areEqual;
-  }
-
-  /**
-   * Recursively finds all files with given extensions in the given directory and all of its
-   * sub-directories.
-   */
-  private static List<Path> listPaths(Path file, String... extensions) throws IOException {
-    if (file == null) {
-      return null;
+    for (Path p : listPaths(dir2)) {
+      dir2Paths.put(dir2.relativize(p), p);
     }
 
-    List<Path> paths = new ArrayList<>();
-    listPaths(file, paths, extensions);
+    // The directories cannot be equal if the numbers of files aren't equal.
+    if (dir1Paths.size() != dir2Paths.size()) {
+      LOG.log(
+          Level.SEVERE,
+          "\nThe file size differ:\n{0} files exist in \n{1}\n{2} files exist in\n{3}\n\n",
+          new Object[] {dir1Paths.size(), dir1, dir2Paths.size(), dir2});
+    }
 
-    return paths;
+    // For each file in dir1, check if also dir2 contains this file and if
+    // their contents are equal.
+    for (Entry<Path, Path> pathEntry : dir1Paths.entrySet()) {
+      Path relativePath = pathEntry.getKey();
+      Path absolutePath = pathEntry.getValue();
+
+      Assert.assertTrue(
+        String.format("The file%n%s%ndoes not exist in%n%s", relativePath, dir2),
+        dir2Paths.containsKey(relativePath)
+      );
+
+      assertFileContentsEqual(absolutePath, dir2Paths.get(relativePath));
+
+      // remove it to be able to show the superset of dir2Paths in the end
+      dir2Paths.remove(relativePath);
+    }
+
+    // if there is a superset of dir2Paths
+    if (!dir2Paths.isEmpty()) {
+      Assert.fail(
+        String.format("The following files exist in%n%s%n%nbut not in%n%s:%n%n%s", dir2, dir1,
+          dir2Paths.keySet().stream().map(Path::toString).collect(Collectors.joining("\n"))
+        )
+      );
+    }
   }
 
   /**
    * Recursively finds all paths with given extensions in the given directory and all of its
    * sub-directories.
    */
-  private static void listPaths(Path path, List<Path> result, String... extensions)
-      throws IOException {
+  private static List<Path> listPaths(Path path, String... extensions) throws IOException {
     if (path == null) {
-      return;
+      return new ArrayList<>();
     }
 
-    if (Files.isReadable(path)) {
-      // If the path is a directory try to read it.
-      if (Files.isDirectory(path)) {
-        if (extensions.length == 0) {
-          result.add(path);
-        }
-        try ( // The input is a directory. Read its files.
-        DirectoryStream<Path> directoryStream = Files.newDirectoryStream(path)) {
-          for (Path p : directoryStream) {
-            listPaths(p, result, extensions);
-          }
-        }
-      } else {
-        if (extensions.length == 0) {
-          result.add(path);
-        } else {
-          String filename = path.getFileName().toString();
-          for (String extension : extensions) {
-            if (filename.toLowerCase().endsWith(extension)) {
-              result.add(path);
-              break;
-            }
-          }
-        }
+    if (extensions.length == 0) {
+      try (Stream<Path> stream = Files.walk(path)) {
+        return stream
+          .filter(p -> !p.getFileName().toString().equals(".DS_Store")) // macOS system file
+          .collect(Collectors.toList());
       }
-    } else {
-      System.err.println("Not readable:" + path);
     }
+
+    try (Stream<Path> stream = Files.walk(path)) {
+      return stream
+        .filter(p -> !Files.isDirectory(p))
+        .filter(p -> !p.getFileName().toString().equals(".DS_Store")) // macOS system file
+        .filter(p -> {
+          String filename = p.getFileName().toString().toLowerCase(Locale.ROOT);
+          return Stream.of(extensions)
+            .anyMatch(filename::endsWith);
+        })
+        .collect(Collectors.toList());
+      }
   }
 
-  private static boolean textFilesEquals(Path p1, Path p2) throws IOException {
-    boolean areEqual = true;
-    if (Files.isDirectory(p1) || Files.isDirectory(p2)) {
-      if (!Files.isDirectory(p1)) {
-        LOG.log(
-            Level.SEVERE,
-            "\nOne file is a directory:\n{0}\nwhile the other is a file:\n{1}\n\n",
-            new Object[] {p2.toString(), p1.toString()});
-        areEqual = false;
-      }
-      if (!Files.isDirectory(p2)) {
-        LOG.log(
-            Level.SEVERE,
-            "\nOne file is a directory:\n{0}\nwhile the other is a file:\n{1}\n\n",
-            new Object[] {p1.toString(), p2.toString()});
-        areEqual = false;
-      }
-    } else {
-      try (BufferedReader reader1 = Files.newBufferedReader(p1)) {
-        try (BufferedReader reader2 = Files.newBufferedReader(p2)) {
-          String line1 = reader1.readLine();
-          String line2 = reader2.readLine();
-          int lineNum = 1;
-          while (line1 != null || line2 != null) {
-            if (line1 == null || line2 == null) {
-              areEqual = false;
-              break;
-            } else if (!line1.equals(line2)) {
-              areEqual = false;
-              break;
-            }
-            line1 = reader1.readLine();
-            line2 = reader2.readLine();
-            lineNum++;
-          }
-          if (!areEqual) {
-            LOG.log(
-                Level.SEVERE,
-                "\nTwo files have different content:\n{0}\nhas at line {1}:\n{2}\nand\n{3}\nhas at line {4}:\n{5}\n\n",
-                new Object[] {p1.toString(), lineNum, line1, p2.toString(), lineNum, line2});
-          }
+  private static void assertFileContentsEqual(Path p1, Path p2) throws IOException {
+    boolean isDirectory = Files.isDirectory(p1);
+    Assert.assertEquals(
+      String.format("Should be a %s: %s", isDirectory ? "directory" : "regular file", p2),
+      isDirectory,
+      Files.isDirectory(p2)
+    );
+
+    if (!isDirectory) {
+      try (Stream<String> stream1 = Files.lines(p1); Stream<String> stream2 = Files.lines(p2)) {
+        List<String> lines1 = stream1.collect(Collectors.toList());
+        List<String> lines2 = stream2.collect(Collectors.toList());
+        int n = Math.min(lines1.size(), lines2.size());
+        for (int i = 0; i < n; i++) {
+          Assert.assertEquals(
+            String.format("Files %s and %s differ in content at line %d", p1, p2, i + 1),
+            lines1.get(i).stripTrailing(),
+            lines2.get(i).stripTrailing()
+          );
         }
+        Assert.assertEquals(
+          String.format("The number of lines in the files %s and %s differ", p1, p2),
+          lines1.size(), lines2.size()
+        );
       }
     }
-    return areEqual;
   }
 }

--- a/generator/schema2template/src/test/java/schema2template/grammar/GenerationOdfdomJavaTest.java
+++ b/generator/schema2template/src/test/java/schema2template/grammar/GenerationOdfdomJavaTest.java
@@ -23,8 +23,9 @@ package schema2template.grammar;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
-import org.junit.Assert;
+
 import org.junit.Test;
 import schema2template.GenerationParameters;
 import schema2template.SchemaToTemplate;
@@ -101,8 +102,8 @@ public class GenerationOdfdomJavaTest {
 
   /** Test: It should be able to generate all examples without a failure. */
   @Test
-  public void testAllExampleGenerations() {
-    ArrayList<GenerationParameters> generations = new ArrayList<>();
+  public void testAllExampleGenerations() throws Exception {
+    List<GenerationParameters> generations = new ArrayList<>();
 
     String grammarAdditionsPath = null;
     String mainTemplatePath = null;
@@ -150,15 +151,11 @@ public class GenerationOdfdomJavaTest {
     }
     // }
 
-    try {
-      SchemaToTemplate.run(generations);
-    } catch (Exception e) {
-      Assert.fail("Exception during test run: " + e);
-      e.printStackTrace();
-      throw new RuntimeException(e);
-    }
-    DirectoryCompare.compareDirectories(
-        ConstantsBuildEnv.GENERATION_TARGET_BASE_DIR + ODFDOM_JAVA_DIRECTORY,
-        ConstantsBuildEnv.GENERATION_REFERENCE_BASE_DIR + ODFDOM_JAVA_DIRECTORY);
+    SchemaToTemplate.run(generations);
+
+    DirectoryCompare.assertDirectoriesEqual(
+        ConstantsBuildEnv.GENERATION_REFERENCE_BASE_DIR + ODFDOM_JAVA_DIRECTORY,
+        ConstantsBuildEnv.GENERATION_TARGET_BASE_DIR + ODFDOM_JAVA_DIRECTORY
+    );
   }
 }


### PR DESCRIPTION
I have changed the code that is used to compare directories:

- Instead of returning boolean values, it directly uses Assertion. methods to let JUnit do the formatting. I also renamed the methods from `compareDirectories()` to `assertDirectoriesEqual()` and made sure the order of parameters matches the standard order of the assert methods (expected result first, actual result second).
- When a difference in a text file is found, the original and changed lines are included in the assertion message.
- .DS_Store files are ignored - these files are created automatically by macOS when opening a directory in Finder; this means once you open a directory when looking for the cause of a failure, the tests will fail because now the number of files doesn't match and since these files are hidden by default, finding out what goes wrong may cause some headache.
