### PR TITLE
Chore/code cleanup

### DIFF
--- a/docs/api/odfdom/org/odftoolkit/odfdom/dom/OdfSchemaConstraint.html
+++ b/docs/api/odfdom/org/odftoolkit/odfdom/dom/OdfSchemaConstraint.html
@@ -299,8 +299,8 @@ not permitted.)</div>
 <dt>Specified by:</dt>
 <dd><code><a href="../pkg/ValidationConstraint.html#getMessage()">getMessage</a></code>&nbsp;in interface&nbsp;<code><a href="../pkg/ValidationConstraint.html" title="interface in org.odftoolkit.odfdom.pkg">ValidationConstraint</a></code></dd>
 <dt>Returns:</dt>
-<dd>the detail message string of this <tt>Constraint</tt> instance (which may be
-     <tt>null</tt>).</dd>
+<dd>the detail message string of this <code>Constraint</code> instance (which may be
+     <code>null</code>).</dd>
 </dl>
 </section>
 </li>

--- a/docs/api/odfdom/org/odftoolkit/odfdom/pkg/OdfPackageConstraint.html
+++ b/docs/api/odfdom/org/odftoolkit/odfdom/pkg/OdfPackageConstraint.html
@@ -427,8 +427,8 @@ not permitted.)</div>
 <dt>Specified by:</dt>
 <dd><code><a href="ValidationConstraint.html#getMessage()">getMessage</a></code>&nbsp;in interface&nbsp;<code><a href="ValidationConstraint.html" title="interface in org.odftoolkit.odfdom.pkg">ValidationConstraint</a></code></dd>
 <dt>Returns:</dt>
-<dd>the detail message string of this <tt>Constraint</tt> instance (which may be
-     <tt>null</tt>).</dd>
+<dd>the detail message string of this <code>Constraint</code> instance (which may be
+     <code>null</code>).</dd>
 </dl>
 </section>
 </li>

--- a/docs/api/odfdom/org/odftoolkit/odfdom/pkg/ValidationConstraint.html
+++ b/docs/api/odfdom/org/odftoolkit/odfdom/pkg/ValidationConstraint.html
@@ -153,8 +153,8 @@ loadScripts(document, 'script');</script>
 <div class="block">Returns the detail message string of this Constraint.</div>
 <dl class="notes">
 <dt>Returns:</dt>
-<dd>the detail message string of this <tt>Constraint</tt> instance (which may be
-     <tt>null</tt>).</dd>
+<dd>the detail message string of this <code>Constraint</code> instance (which may be
+     <code>null</code>).</dd>
 </dl>
 </section>
 </li>

--- a/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionInformation.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionInformation.java
@@ -69,15 +69,15 @@ public class MSVExpressionInformation {
   private Map<Expression, List<List<Expression>>> mContainedInPaths;
   private boolean mCanHaveText = false;
   // map child to its isSingleton property
-  private Set<Expression> mSingletonChildren = new HashSet<Expression>();
-  private Set<Expression> mMultipleChildren = new HashSet<Expression>();
+  private Set<Expression> mSingletonChildren = new HashSet<>();
+  private Set<Expression> mMultipleChildren = new HashSet<>();
 
   public MSVExpressionInformation(Expression exp, String schemaFileName) {
-    mContainedInPaths = new HashMap<Expression, List<List<Expression>>>();
+    mContainedInPaths = new HashMap<>();
 
     // Builds paths to child elements and child attributes
-    List<List<Expression>> paths = new ArrayList<List<Expression>>();
-    List<Expression> start = new ArrayList<Expression>(1);
+    List<List<Expression>> paths = new ArrayList<>();
+    List<Expression> start = new ArrayList<>(1);
     start.add(exp);
     paths.add(start);
     buildPaths(paths);
@@ -111,7 +111,7 @@ public class MSVExpressionInformation {
       for (Expression step : path) {
         List<List<Expression>> pathsToStep = mContainedInPaths.get(step);
         if (pathsToStep == null) {
-          pathsToStep = new ArrayList<List<Expression>>(1);
+          pathsToStep = new ArrayList<>(1);
           pathsToStep.add(path);
           mContainedInPaths.put(step, pathsToStep);
         } else {
@@ -132,9 +132,8 @@ public class MSVExpressionInformation {
    */
   private void registerChildrenMaxCardinalities(List<List<Expression>> waysToChildren) {
     Map<Expression, Boolean> multiples =
-        new HashMap<
-            Expression, Boolean>(); // Cardinality (the opposite of isSingleton): true=N, false=1
-    Map<Expression, List<Expression>> paths = new HashMap<Expression, List<Expression>>();
+      new HashMap<>(); // Cardinality (the opposite of isSingleton): true=N, false=1
+    Map<Expression, List<Expression>> paths = new HashMap<>();
 
     for (List<Expression> way : waysToChildren) {
       Expression childexp = way.get(way.size() - 1);
@@ -169,7 +168,7 @@ public class MSVExpressionInformation {
         // MSV detects that this is two times the same choice and creates just one ChoiceExpression.
         // But this is not what we understand as a common CHOICE -> It's a common element definition
         // <OPTIONAL>X</OPTIONAL> == <CHOICE>empty, X</CHOICE>
-        Set<ChoiceExp> choices = new HashSet<ChoiceExp>();
+        Set<ChoiceExp> choices = new HashSet<>();
         for (Expression oldStep : paths.get(childexp)) {
           if (oldStep instanceof ChoiceExp) {
             choices.add((ChoiceExp) oldStep);
@@ -290,7 +289,7 @@ public class MSVExpressionInformation {
     } else if (children.size() > 1) {
       paths.remove(paths.size() - 1);
       for (Expression child : children) {
-        List<Expression> newway = new ArrayList<Expression>();
+        List<Expression> newway = new ArrayList<>();
         newway.addAll(waytoresearch);
         newway.add(child);
         paths.add(newway);
@@ -302,7 +301,7 @@ public class MSVExpressionInformation {
   }
 
   private static List<List<Expression>> getPathsToClass(List<List<Expression>> paths, Class clazz) {
-    List<List<Expression>> remainingPaths = new ArrayList<List<Expression>>();
+    List<List<Expression>> remainingPaths = new ArrayList<>();
     for (List<Expression> path : paths) {
       if (clazz.isInstance(path.get(path.size() - 1))) {
         remainingPaths.add(path);
@@ -350,7 +349,7 @@ public class MSVExpressionInformation {
           "ExpressionInformation: Cannot determine isMandatory for a null or empty children list.");
     }
 
-    Set<List<Expression>> twins = new HashSet<List<Expression>>();
+    Set<List<Expression>> twins = new HashSet<>();
 
     for (Expression exp : equallyNamedChildren) {
       if (!(exp instanceof NameClassAndExpression)) {
@@ -378,7 +377,7 @@ public class MSVExpressionInformation {
      * So both twins do not really share such a CHOICE. You have to look for another path which _really_ shares this choice or - if you find none -
      * set CHILD to optional.
      */
-    HashSet<Expression> visitedChoices = new HashSet<Expression>();
+    HashSet<Expression> visitedChoices = new HashSet<>();
 
     for (List<Expression> path : twins) {
       for (int s = 0; s < path.size(); s++) {
@@ -388,7 +387,7 @@ public class MSVExpressionInformation {
 
           // If other twin paths share the same choice...
           List<List<Expression>> choiceInPaths =
-              new ArrayList<List<Expression>>(mContainedInPaths.get(step));
+            new ArrayList<>(mContainedInPaths.get(step));
           choiceInPaths.retainAll(twins);
 
           // small Performance gain: A CHOICE contained only in one path makes CHILD always optional

--- a/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionInformation.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionInformation.java
@@ -300,7 +300,7 @@ public class MSVExpressionInformation {
     }
   }
 
-  private static List<List<Expression>> getPathsToClass(List<List<Expression>> paths, Class clazz) {
+  private static List<List<Expression>> getPathsToClass(List<List<Expression>> paths, Class<?> clazz) {
     List<List<Expression>> remainingPaths = new ArrayList<>();
     for (List<Expression> path : paths) {
       if (clazz.isInstance(path.get(path.size() - 1))) {

--- a/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionIterator.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionIterator.java
@@ -75,7 +75,7 @@ public final class MSVExpressionIterator implements Iterator<Expression> {
     private int mSiblingIndex;
   }
   // limit browsing to subclasses of Expression
-  private Class mDesiredExpression;
+  private Class<?> mDesiredExpression;
   // if false, only return direct children of root. Don't return root as first element or grand
   // children
   private boolean mOnlyChildren;
@@ -102,7 +102,7 @@ public final class MSVExpressionIterator implements Iterator<Expression> {
    * @param root Expression root
    * @param desiredExpression Limit returned expressions to subclasses of desiredExpression
    */
-  public MSVExpressionIterator(Expression root, Class desiredExpression) {
+  public MSVExpressionIterator(Expression root, Class<?> desiredExpression) {
     this(root, desiredExpression, false);
   }
 
@@ -118,7 +118,7 @@ public final class MSVExpressionIterator implements Iterator<Expression> {
    * @param desiredExpression Limit returned expressions to subclasses of desiredExpression
    * @param onlyChildren if only children should be returned
    */
-  public MSVExpressionIterator(Expression root, Class desiredExpression, boolean onlyChildren) {
+  public MSVExpressionIterator(Expression root, Class<?> desiredExpression, boolean onlyChildren) {
     // initialize members
     mCurrentExpression = root;
     mDesiredExpression = desiredExpression;

--- a/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionIterator.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionIterator.java
@@ -126,10 +126,10 @@ public final class MSVExpressionIterator implements Iterator<Expression> {
 
     // create helpers
     mVisitor = new MSVExpressionVisitorChildren();
-    mKnownElementExpressions = new HashSet<Expression>();
+    mKnownElementExpressions = new HashSet<>();
 
     // Initialize status
-    mAncestorsAndCurrent = new Stack<UniqueAncestor>();
+    mAncestorsAndCurrent = new Stack<>();
     mAncestorsAndCurrent.push(new UniqueAncestor(root, 0));
 
     // make sure that there is at least one desired expression - for hasNext()

--- a/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionVisitorChildren.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/MSVExpressionVisitorChildren.java
@@ -123,7 +123,7 @@ public class MSVExpressionVisitorChildren implements ExpressionVisitor {
   }
 
   private List<Expression> children(Iterator<Expression> i) {
-    ArrayList<Expression> list = new ArrayList<Expression>();
+    ArrayList<Expression> list = new ArrayList<>();
     while (i.hasNext()) {
       list.add(i.next());
     }

--- a/generator/schema2template/src/main/java/schema2template/grammar/MSVNameClassVisitorList.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/MSVNameClassVisitorList.java
@@ -61,7 +61,7 @@ public class MSVNameClassVisitorList implements NameClassVisitor {
   }
 
   public List<String> onChoice(ChoiceNameClass arg0) {
-    List<String> retval = new ArrayList<String>();
+    List<String> retval = new ArrayList<>();
     retval.addAll((List<String>) arg0.nc1.visit(this));
     retval.addAll((List<String>) arg0.nc2.visit(this));
     return retval;
@@ -71,7 +71,7 @@ public class MSVNameClassVisitorList implements NameClassVisitor {
   // W3C Schema restriction on name have to be given out as more adequate for us!
   public List<String> onDifference(DifferenceNameClass arg0) {
     if (arg0 != null) {
-      List<String> l = new ArrayList<String>(2);
+      List<String> l = new ArrayList<>(2);
       l.add(arg0.nc1.toString());
       l.add(arg0.nc2.toString());
       return l;

--- a/generator/schema2template/src/main/java/schema2template/grammar/NamespaceDictionary.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/NamespaceDictionary.java
@@ -34,8 +34,8 @@ public class NamespaceDictionary {
 
   /** Construct a new empty dictionary */
   public NamespaceDictionary() {
-    uri2local = new HashMap<String, String>();
-    local2uri = new HashMap<String, String>();
+    uri2local = new HashMap<>();
+    local2uri = new HashMap<>();
   }
 
   /**

--- a/generator/schema2template/src/main/java/schema2template/grammar/OdfFamilyPropertiesPatternMatcher.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/OdfFamilyPropertiesPatternMatcher.java
@@ -91,7 +91,7 @@ class OdfFamilyPropertiesPatternMatcher {
               // Whenever visiting elements and RefExps, they are memorized
               // to identify head of islands.
               int depth = 1;
-              List resultList = null;
+              List<String> resultList = null;
 
               @Override
               public void onElement(ElementExp exp) {
@@ -116,7 +116,7 @@ class OdfFamilyPropertiesPatternMatcher {
                   // System.out.println("NEW FAMILY" + asString(propertiesByFamily));
                   collectingState = Boolean.TRUE;
                   depthCollecting = depth;
-                  resultList = new ArrayList();
+                  resultList = new ArrayList<>();
                   if (exp.exp instanceof ValueExp) {
                     // System.out.println("style:family-1" + ((ValueExp) exp.exp).value.toString());
                     propertiesByFamily.put(((ValueExp) exp.exp).value.toString(), resultList);

--- a/generator/schema2template/src/main/java/schema2template/grammar/OdfModel.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/OdfModel.java
@@ -121,7 +121,7 @@ public class OdfModel {
    * @return list of style family names
    */
   public List<String> getStyleFamilies(PuzzleComponent element) {
-    List<String> retval = new ArrayList<String>();
+    List<String> retval = new ArrayList<>();
     if (mNameToFamiliesMap.containsKey(element.getQName())) {
       retval.addAll(mNameToFamiliesMap.get(element.getQName()));
     }
@@ -135,11 +135,11 @@ public class OdfModel {
    */
   public SortedSet<String> getStyleFamilies() {
     Iterator<List<String>> iter = mNameToFamiliesMap.values().iterator();
-    List<String> families = new ArrayList<String>();
+    List<String> families = new ArrayList<>();
     while (iter.hasNext()) {
       families.addAll(iter.next());
     }
-    return new TreeSet<String>(families);
+    return new TreeSet<>(families);
   }
 
   /**

--- a/generator/schema2template/src/main/java/schema2template/grammar/PuzzlePiece.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/PuzzlePiece.java
@@ -77,9 +77,9 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
 
   /* Properties for PuzzlePiece of Type.ELEMENT */
   private PuzzlePieceSet mChildElements = new PuzzlePieceSet();
-  private HashSet<String> mMandatoryChildElementNames = new HashSet<String>();
+  private HashSet<String> mMandatoryChildElementNames = new HashSet<>();
   private PuzzlePieceSet mAttributes = new PuzzlePieceSet();
-  private HashSet<String> mMandatoryChildAttributeNames = new HashSet<String>();
+  private HashSet<String> mMandatoryChildAttributeNames = new HashSet<>();
   private boolean mCanHaveText = false;
   private Set<Expression> mSingletonChildExpressions;
   private Set<Expression> mMultipleChildExpressions;
@@ -522,7 +522,7 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
       Grammar grammar, PuzzlePieceSet setToBeFilled, Class<T> superclass) {
     Expression root = grammar.getTopLevel();
     MSVExpressionIterator iter = new MSVExpressionIterator(root, superclass);
-    HashMap<String, List<PuzzlePiece>> multipleMap = new HashMap<String, List<PuzzlePiece>>();
+    HashMap<String, List<PuzzlePiece>> multipleMap = new HashMap<>();
 
     while (iter.hasNext()) {
       Expression exp = iter.next();
@@ -544,7 +544,7 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
         if (multiples != null) {
           multiples.add(newDefinition);
         } else {
-          multiples = new ArrayList<PuzzlePiece>(1);
+          multiples = new ArrayList<>(1);
           multiples.add(newDefinition);
           multipleMap.put(name, multiples);
         }
@@ -561,11 +561,11 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
 
   // Builds Map Expression->List<PuzzlePiece>
   private static Map<Expression, List<PuzzlePiece>> buildReverseMap(PuzzlePieceSet defs) {
-    Map<Expression, List<PuzzlePiece>> retval = new HashMap<Expression, List<PuzzlePiece>>();
+    Map<Expression, List<PuzzlePiece>> retval = new HashMap<>();
     Iterator<PuzzlePiece> iter = defs.iterator();
     while (iter.hasNext()) {
       PuzzlePiece def = iter.next();
-      List<PuzzlePiece> list = retval.computeIfAbsent(def.getExpression(), k -> new ArrayList<PuzzlePiece>());
+      List<PuzzlePiece> list = retval.computeIfAbsent(def.getExpression(), k -> new ArrayList<>());
       list.add(def);
     }
     return retval;
@@ -573,11 +573,11 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
 
   // Builds Map Name->List<Expression>
   private static Map<String, List<Expression>> buildNameExpressionsMap(PuzzlePieceSet defs) {
-    Map<String, List<Expression>> retval = new HashMap<String, List<Expression>>();
+    Map<String, List<Expression>> retval = new HashMap<>();
     Iterator<PuzzlePiece> iter = defs.iterator();
     while (iter.hasNext()) {
       PuzzlePiece def = iter.next();
-        List<Expression> list = retval.computeIfAbsent(def.getQName(), k -> new ArrayList<Expression>());
+        List<Expression> list = retval.computeIfAbsent(def.getQName(), k -> new ArrayList<>());
         list.add(def.getExpression());
     }
     return retval;

--- a/generator/schema2template/src/main/java/schema2template/grammar/PuzzlePiece.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/PuzzlePiece.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -335,9 +334,8 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
    */
   public int getMultipleNumber() {
     int retval = 0;
-    Iterator<PuzzlePiece> iter = mMultiples.iterator();
-    while (iter.hasNext()) {
-      if (iter.next().equals(this)) {
+    for (PuzzlePiece mMultiple : mMultiples) {
+      if (mMultiple.equals(this)) {
         return retval;
       }
       retval++;
@@ -552,9 +550,7 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
     }
 
     // Fills multiple information
-    Iterator<PuzzlePiece> defIter = setToBeFilled.iterator();
-    while (defIter.hasNext()) {
-      PuzzlePiece def = defIter.next();
+    for (PuzzlePiece def : setToBeFilled) {
       def.mMultiples = new PuzzlePieceSet(multipleMap.get(def.getQName()));
     }
   }
@@ -562,9 +558,7 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
   // Builds Map Expression->List<PuzzlePiece>
   private static Map<Expression, List<PuzzlePiece>> buildReverseMap(PuzzlePieceSet defs) {
     Map<Expression, List<PuzzlePiece>> retval = new HashMap<>();
-    Iterator<PuzzlePiece> iter = defs.iterator();
-    while (iter.hasNext()) {
-      PuzzlePiece def = iter.next();
+    for (PuzzlePiece def : defs) {
       List<PuzzlePiece> list = retval.computeIfAbsent(def.getExpression(), k -> new ArrayList<>());
       list.add(def);
     }
@@ -574,11 +568,9 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
   // Builds Map Name->List<Expression>
   private static Map<String, List<Expression>> buildNameExpressionsMap(PuzzlePieceSet defs) {
     Map<String, List<Expression>> retval = new HashMap<>();
-    Iterator<PuzzlePiece> iter = defs.iterator();
-    while (iter.hasNext()) {
-      PuzzlePiece def = iter.next();
-        List<Expression> list = retval.computeIfAbsent(def.getQName(), k -> new ArrayList<>());
-        list.add(def.getExpression());
+    for (PuzzlePiece def : defs) {
+      List<Expression> list = retval.computeIfAbsent(def.getQName(), k -> new ArrayList<>());
+      list.add(def.getExpression());
     }
     return retval;
   }
@@ -654,14 +646,12 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
     Map<Expression, List<PuzzlePiece>> reverseAttributeMap = buildReverseMap(attributes);
 
     // Handle Element Definitions
-    Iterator<PuzzlePiece> iter = elements.iterator();
-    while (iter.hasNext()) {
-      PuzzlePiece puzzlePiece = iter.next();
+    for (PuzzlePiece puzzlePiece : elements) {
       MSVExpressionIterator childFinder =
-          new MSVExpressionIterator(
-              puzzlePiece.getExpression(),
-              NameClassAndExpression.class,
-              MSVExpressionIterator.DIRECT_CHILDREN_ONLY);
+        new MSVExpressionIterator(
+          puzzlePiece.getExpression(),
+          NameClassAndExpression.class,
+          MSVExpressionIterator.DIRECT_CHILDREN_ONLY);
       while (childFinder.hasNext()) {
         Expression child_exp = childFinder.next();
         List<PuzzlePiece> child_defs = null;
@@ -683,13 +673,13 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
 
       if (graphMLTargetDir != null) {
         TinkerPopGraph tinkerPopGraph =
-            new TinkerPopGraph(puzzlePiece.getExpression(), schemaFileName);
+          new TinkerPopGraph(puzzlePiece.getExpression(), schemaFileName);
         File f = new File(graphMLTargetDir);
         f.mkdirs();
         tinkerPopGraph.exportAsGraphML(f.getAbsolutePath());
       }
       MSVExpressionInformation elementInfo =
-          new MSVExpressionInformation(puzzlePiece.getExpression(), schemaFileName);
+        new MSVExpressionInformation(puzzlePiece.getExpression(), schemaFileName);
       puzzlePiece.mCanHaveText = elementInfo.canHaveText();
 
       Map<String, List<Expression>> atnameToDefs = buildNameExpressionsMap(puzzlePiece.mAttributes);
@@ -700,7 +690,7 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
       }
 
       Map<String, List<Expression>> elnameToDefs =
-          buildNameExpressionsMap(puzzlePiece.mChildElements);
+        buildNameExpressionsMap(puzzlePiece.mChildElements);
       for (Map.Entry<String, List<Expression>> entry : elnameToDefs.entrySet()) {
         if (elementInfo.isMandatory(entry.getValue())) {
           puzzlePiece.mMandatoryChildElementNames.add(entry.getKey());
@@ -712,21 +702,18 @@ public class PuzzlePiece implements Comparable<PuzzlePiece>, PuzzleComponent {
     }
 
     // Handle Attribute Definitions
-    Iterator<PuzzlePiece> aiter = attributes.iterator();
-    while (aiter.hasNext()) {
-      PuzzlePiece def = aiter.next();
-
+    for (PuzzlePiece def : attributes) {
       MSVExpressionIterator datatypeFinder =
-          new MSVExpressionIterator(
-              def.getExpression(), DataExp.class, MSVExpressionIterator.DIRECT_CHILDREN_ONLY);
+        new MSVExpressionIterator(
+          def.getExpression(), DataExp.class, MSVExpressionIterator.DIRECT_CHILDREN_ONLY);
       while (datatypeFinder.hasNext()) {
         DataExp data_exp = (DataExp) datatypeFinder.next();
         def.mDatatypes.add(new PuzzlePiece(data_exp));
       }
 
       MSVExpressionIterator valueFinder =
-          new MSVExpressionIterator(
-              def.getExpression(), ValueExp.class, MSVExpressionIterator.DIRECT_CHILDREN_ONLY);
+        new MSVExpressionIterator(
+          def.getExpression(), ValueExp.class, MSVExpressionIterator.DIRECT_CHILDREN_ONLY);
       while (valueFinder.hasNext()) {
         ValueExp value_exp = (ValueExp) valueFinder.next();
         if (value_exp.getName().localName.equals("token")) {

--- a/generator/schema2template/src/main/java/schema2template/grammar/PuzzlePieceSet.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/PuzzlePieceSet.java
@@ -50,11 +50,11 @@ public class PuzzlePieceSet implements PuzzleComponent, Collection<PuzzlePiece> 
   private SortedSet<PuzzlePiece> mDefinitions;
 
   public PuzzlePieceSet() {
-    mDefinitions = new TreeSet<PuzzlePiece>();
+    mDefinitions = new TreeSet<>();
   }
 
   public PuzzlePieceSet(Collection<PuzzlePiece> c) {
-    mDefinitions = new TreeSet<PuzzlePiece>(c);
+    mDefinitions = new TreeSet<>(c);
   }
 
   private void assertNotImmutable() {
@@ -109,8 +109,8 @@ public class PuzzlePieceSet implements PuzzleComponent, Collection<PuzzlePiece> 
    */
   Map<PuzzlePiece, PuzzlePiece> uniteDefinitionsWithEqualContent() {
     //    System.out.println("this.mDefinitions: " + this.mDefinitions.size());
-    Map<PuzzlePiece, PuzzlePiece> retval = new HashMap<PuzzlePiece, PuzzlePiece>();
-    SortedSet<PuzzlePiece> immutableSet = new TreeSet<PuzzlePiece>(this.mDefinitions);
+    Map<PuzzlePiece, PuzzlePiece> retval = new HashMap<>();
+    SortedSet<PuzzlePiece> immutableSet = new TreeSet<>(this.mDefinitions);
     for (PuzzlePiece def1 : immutableSet) {
       if (!this.mDefinitions.contains(def1)) {
         // if def1 is already removed, we shouldn't process it
@@ -174,7 +174,7 @@ public class PuzzlePieceSet implements PuzzleComponent, Collection<PuzzlePiece> 
    * @return new PuzzlePieceSet
    */
   public PuzzlePieceSet withoutMultiples() {
-    Map<String, PuzzlePiece> uniqueMap = new HashMap<String, PuzzlePiece>();
+    Map<String, PuzzlePiece> uniqueMap = new HashMap<>();
     for (PuzzlePiece def : this) {
       uniqueMap.put(def.getQName(), def);
     }

--- a/generator/schema2template/src/main/java/schema2template/grammar/XMLModel.java
+++ b/generator/schema2template/src/main/java/schema2template/grammar/XMLModel.java
@@ -108,7 +108,7 @@ public class XMLModel {
       // create a map from the qName to the PuzzlePiece(s) - multiple if there are multiple
       // definitions for the qName in the grammar
       this.elementNameToPuzzlePieces =
-          createMapQNameToPuzzlePiece(new TreeSet<PuzzlePiece>(this.getElements()));
+          createMapQNameToPuzzlePiece(new TreeSet<>(this.getElements()));
     }
     return this.elementNameToPuzzlePieces.get(qName);
   }
@@ -119,7 +119,7 @@ public class XMLModel {
       // create a map from the qName to the PuzzlePiece(s) - multiple if there are multiple
       // definitions for the qName in the grammar
       this.attributeNameToPuzzlePieces =
-          createMapQNameToPuzzlePiece(new TreeSet<PuzzlePiece>(this.getElements()));
+          createMapQNameToPuzzlePiece(new TreeSet<>(this.getElements()));
     }
     return this.attributeNameToPuzzlePieces.get(qName);
   }
@@ -133,9 +133,9 @@ public class XMLModel {
    */
   private static Map<String, SortedSet<PuzzlePiece>> createMapQNameToPuzzlePiece(
       Set<PuzzlePiece> definitions) {
-    Map<String, SortedSet<PuzzlePiece>> retval = new HashMap<String, SortedSet<PuzzlePiece>>();
+    Map<String, SortedSet<PuzzlePiece>> retval = new HashMap<>();
     for (PuzzlePiece def : definitions) {
-      SortedSet<PuzzlePiece> multiples = retval.computeIfAbsent(def.getQName(), k -> new TreeSet<PuzzlePiece>());
+      SortedSet<PuzzlePiece> multiples = retval.computeIfAbsent(def.getQName(), k -> new TreeSet<>());
       multiples.add(def);
     }
     return retval;

--- a/generator/schema2template/src/main/java/schema2template/template/FileCreationListEntry.java
+++ b/generator/schema2template/src/main/java/schema2template/template/FileCreationListEntry.java
@@ -55,7 +55,7 @@ public class FileCreationListEntry {
    */
   public FileCreationListEntry(EntryType type, int lineNumber) {
     mType = type;
-    mAttributes = new HashMap<String, String>();
+    mAttributes = new HashMap<>();
     mLineNumber = lineNumber;
   }
 

--- a/generator/schema2template/src/main/java/schema2template/template/GrammarAdditionsFileHandler.java
+++ b/generator/schema2template/src/main/java/schema2template/template/GrammarAdditionsFileHandler.java
@@ -92,8 +92,8 @@ public class GrammarAdditionsFileHandler extends DefaultHandler {
     mAttributeDefaults = attributeDefaultMap;
     mDatatypeValueConversion = datatypeValueConversion;
     mElementStyleFamilies = elementNameToFamilyMap;
-    mProcessedElements = new HashSet<String>();
-    mProcessedDatatypes = new HashSet<String>();
+    mProcessedElements = new HashSet<>();
+    mProcessedDatatypes = new HashSet<>();
   }
 
   private void readElementSettings(Attributes attrs) throws SAXException {
@@ -116,7 +116,7 @@ public class GrammarAdditionsFileHandler extends DefaultHandler {
     String commaSeparatedStyleFamilies = attrs.getValue("family");
     if (commaSeparatedStyleFamilies != null) {
       StringTokenizer tok = new StringTokenizer(commaSeparatedStyleFamilies, ",");
-      List<String> families = new ArrayList<String>();
+      List<String> families = new ArrayList<>();
       while (tok.hasMoreElements()) {
         String family = tok.nextToken();
         if (family.length() > 0) {
@@ -156,7 +156,7 @@ public class GrammarAdditionsFileHandler extends DefaultHandler {
 
     String elementName = attrs.getValue("element");
     String defaultValue = attrs.getValue("defaultValue");
-    Map<String, String> defaultValueByParentElement = mAttributeDefaults.computeIfAbsent(attrName, k -> new HashMap<String, String>());
+    Map<String, String> defaultValueByParentElement = mAttributeDefaults.computeIfAbsent(attrName, k -> new HashMap<>());
     if (elementName == null) {
       elementName = ALL_ELEMENTS;
     }

--- a/generator/schema2template/src/main/java/schema2template/template/SourceCodeBaseClass.java
+++ b/generator/schema2template/src/main/java/schema2template/template/SourceCodeBaseClass.java
@@ -101,7 +101,7 @@ public class SourceCodeBaseClass implements Comparable<SourceCodeBaseClass> {
    */
   public PuzzlePieceSet getBaseAttributes() {
     SortedSet<PuzzlePiece> attributes =
-        new TreeSet<PuzzlePiece>(mChildElementsOfBaseClass.last().getAttributes());
+      new TreeSet<>(mChildElementsOfBaseClass.last().getAttributes());
     for (PuzzlePiece childElement :
         mChildElementsOfBaseClass.headSet(mChildElementsOfBaseClass.last())) {
       attributes.retainAll(childElement.getAttributes());
@@ -116,7 +116,7 @@ public class SourceCodeBaseClass implements Comparable<SourceCodeBaseClass> {
    */
   public PuzzlePieceSet getBaseElements() {
     SortedSet<PuzzlePiece> elements =
-        new TreeSet<PuzzlePiece>(mChildElementsOfBaseClass.last().getChildElements());
+            new TreeSet<>(mChildElementsOfBaseClass.last().getChildElements());
     for (PuzzlePiece childElement :
         mChildElementsOfBaseClass.headSet(mChildElementsOfBaseClass.last())) {
       elements.retainAll(childElement.getChildElements());

--- a/generator/schema2template/src/main/java/schema2template/template/SourceCodeModel.java
+++ b/generator/schema2template/src/main/java/schema2template/template/SourceCodeModel.java
@@ -65,15 +65,15 @@ public class SourceCodeModel {
     mElementNameBaseNameMap = elementNameBaseNameMap;
     mBaseNameElementNameMap = invertMap(elementNameBaseNameMap);
     // Intermediate Step -> get all baseNames
-    SortedSet<String> baseNames = new TreeSet<String>(elementNameBaseNameMap.values());
+    SortedSet<String> baseNames = new TreeSet<>(elementNameBaseNameMap.values());
 
     // Intermediate Step -> get all childOfBaseElement Definitions for each baseName
     Map<String, SortedSet<PuzzlePiece>> baseNameElementsMap =
-        new HashMap<String, SortedSet<PuzzlePiece>>(baseNames.size());
+      new HashMap<>(baseNames.size());
     for (Map.Entry<String, String> entry : elementNameBaseNameMap.entrySet()) {
       String elementName = entry.getKey();
       String baseName = entry.getValue();
-        SortedSet<PuzzlePiece> elements = baseNameElementsMap.computeIfAbsent(baseName, k -> new TreeSet<PuzzlePiece>());
+        SortedSet<PuzzlePiece> elements = baseNameElementsMap.computeIfAbsent(baseName, k -> new TreeSet<>());
         PuzzleComponent childElement = schemaModel.getElement(elementName);
       if (childElement != null) {
         if (childElement instanceof Collection) {
@@ -87,8 +87,8 @@ public class SourceCodeModel {
     }
 
     // Generate all base classes (additional intermediate step: register them)
-    mBaseNameToBaseClass = new HashMap<String, SourceCodeBaseClass>(baseNames.size());
-    mBaseClasses = new TreeSet<SourceCodeBaseClass>();
+    mBaseNameToBaseClass = new HashMap<>(baseNames.size());
+    mBaseClasses = new TreeSet<>();
     for (String baseName : baseNames) {
       SourceCodeBaseClass javabaseclass =
           new SourceCodeBaseClass(baseName, baseNameElementsMap.get(baseName));
@@ -97,7 +97,7 @@ public class SourceCodeModel {
     }
 
     // Generate a map from element tag name to base classes
-    mElementBaseMap = new HashMap<String, SourceCodeBaseClass>(elementNameBaseNameMap.size());
+    mElementBaseMap = new HashMap<>(elementNameBaseNameMap.size());
     for (Map.Entry<String, String> entry : elementNameBaseNameMap.entrySet()) {
       String baseName = entry.getValue();
       SourceCodeBaseClass baseclass = mBaseNameToBaseClass.get(baseName);
@@ -137,7 +137,7 @@ public class SourceCodeModel {
   private static <V, K> Map<V, K> invertMap(Map<K, V> map) {
     Map<V, K> inversedMap = null;
     if (map != null && !map.isEmpty()) {
-      inversedMap = new HashMap<V, K>();
+      inversedMap = new HashMap<>();
       for (Map.Entry<K, V> entry : map.entrySet()) {
         if (!inversedMap.containsKey(entry.getKey())) {
           inversedMap.put(entry.getValue(), entry.getKey());
@@ -281,7 +281,7 @@ public class SourceCodeModel {
   public SortedSet<String> getValuetypes(PuzzleComponent datatypes) {
     SortedSet<String> retval = null;
     if (datatypes != null) {
-      retval = new TreeSet<String>();
+      retval = new TreeSet<>();
       for (PuzzlePiece datatype : datatypes.getCollection()) {
         String datatypename = datatype.getQName();
         String[] tuple = mDataTypeValueAndConversionMap.get(datatypename);

--- a/generator/schema2template/src/main/java/schema2template/template/SourceCodeModel.java
+++ b/generator/schema2template/src/main/java/schema2template/template/SourceCodeModel.java
@@ -23,13 +23,13 @@
  */
 package schema2template.template;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import schema2template.grammar.PuzzleComponent;
 import schema2template.grammar.PuzzlePiece;
+import schema2template.grammar.PuzzlePieceSet;
 import schema2template.grammar.XMLModel;
 
 /**
@@ -76,8 +76,8 @@ public class SourceCodeModel {
         SortedSet<PuzzlePiece> elements = baseNameElementsMap.computeIfAbsent(baseName, k -> new TreeSet<>());
         PuzzleComponent childElement = schemaModel.getElement(elementName);
       if (childElement != null) {
-        if (childElement instanceof Collection) {
-          elements.addAll((Collection) childElement);
+        if (childElement instanceof PuzzlePieceSet) {
+          elements.addAll((PuzzlePieceSet) childElement);
         } else {
           elements.add((PuzzlePiece) childElement);
         }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CachedInnerTableOperation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CachedInnerTableOperation.java
@@ -44,7 +44,7 @@ class CachedInnerTableOperation extends CachedOperation {
   public CachedOperation clone() {
     return new CachedInnerTableOperation(
         mComponentType,
-        new ArrayList<Integer>(mStart),
+            new ArrayList<>(mStart),
         mAbsolutePosition,
         mHardFormattingProperties,
         mComponentProperties);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CachedOperation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/CachedOperation.java
@@ -47,7 +47,7 @@ class CachedOperation {
   public CachedOperation clone() {
     return new CachedOperation(
         mComponentType,
-        new ArrayList<Integer>(mStart),
+      new ArrayList<>(mStart),
         mAbsolutePosition,
         mHardFormattingProperties,
         mComponentProperties);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
@@ -155,7 +155,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
   // the actual component. Linking each other building the tree view of the document
   private Component mCurrentComponent;
   // the position of the component, being updated for the operations being generated
-  private final List<Integer> mLastComponentPositions = new ArrayList<Integer>();
+  private final List<Integer> mLastComponentPositions = new ArrayList<>();
   /** DOM is created by default, but is in general not needed */
   private final boolean domCreationEnabled = true;
   //    private final ArrayDeque<ShapeProperties> mShapePropertiesStack;
@@ -184,7 +184,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
    * Quick cache to get the correct linked list. Key is the xml:id of the first list. The sequence
    * of all continued lists and usability functions are provided by ContinuedList
    */
-  private final Map<String, ContinuedList> mLinkedLists = new HashMap<String, ContinuedList>();
+  private final Map<String, ContinuedList> mLinkedLists = new HashMap<>();
   // *** FOR BLOCKING OPERATIONS
   // the number of elements above the current element during parsing.
   // Required to find out if the correct blocking element for the UI was found
@@ -421,15 +421,15 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
       mSchemaDoc.setJsonOperationQueue(mJsonOperationProducer);
     }
 
-    mAutoListStyles = new HashMap<String, TextListStyleElement>();
-    mUserFieldDecls = new HashMap<String, TextUserFieldDeclElement>();
+    mAutoListStyles = new HashMap<>();
+    mUserFieldDecls = new HashMap<>();
 
     // Stack to remember/track the nested delimiters not being components (spans) open-up by SAX
     // events
-    mTextSelectionStack = new ArrayDeque<TextSelection>();
-    mListStyleStack = new ArrayDeque<ParagraphListProperties>();
+    mTextSelectionStack = new ArrayDeque<>();
+    mListStyleStack = new ArrayDeque<>();
     //        mShapePropertiesStack = new ArrayDeque<ShapeProperties>();
-    mWhitespaceStatusStack = new ArrayDeque<WhitespaceStatus>();
+    mWhitespaceStatusStack = new ArrayDeque<>();
   }
 
   @Override
@@ -622,7 +622,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
             TextParagraphElementBase p = (TextParagraphElementBase) element;
             Map<String, Object> hardFormatting = mJsonOperationProducer.getHardStyles(p);
             if (hardFormatting == null) {
-              hardFormatting = new HashMap<String, Object>();
+              hardFormatting = new HashMap<>();
             }
             if (element instanceof TextHElement || !mListStyleStack.isEmpty()) {
               if (!hardFormatting.containsKey("paragraph")) {
@@ -797,7 +797,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
             // if there are absolute styles, but not the main property set, where the
             // templateStyleId should be placed in
             if (hardFormatting == null) {
-              hardFormatting = new HashMap<String, Object>();
+              hardFormatting = new HashMap<>();
             }
             hardFormatting.put("drawing", new JSONObject());
           }
@@ -806,7 +806,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
             // if there are absolute styles, but not the main property set, where the
             // templateStyleId should be placed in
             if (hardFormatting == null) {
-              hardFormatting = new HashMap<String, Object>();
+              hardFormatting = new HashMap<>();
             }
             hardFormatting.put("image", new JSONObject());
           }
@@ -1065,7 +1065,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
             }
 
             // The grid is known after columns had been parsed, updating later to row positino
-            List<Integer> tablePosition = new ArrayList<Integer>(mLastComponentPositions);
+            List<Integer> tablePosition = new ArrayList<>(mLastComponentPositions);
             cacheTableOperation(
                 OperationConstants.TABLE,
                 tablePosition,
@@ -1111,7 +1111,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
               // if there are absolute styles, but not the main property set, where the
               // templateStyleId should be placed in
               if (hardFormatting == null) {
-                hardFormatting = new HashMap<String, Object>();
+                hardFormatting = new HashMap<>();
               }
             }
             if (!hardFormatting.containsKey("row")) {
@@ -1173,7 +1173,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
               // templateStyleId should be placed in
               if (hardFormatting == null || !hardFormatting.containsKey("cell")) {
                 if (hardFormatting == null) {
-                  hardFormatting = new HashMap<String, Object>();
+                  hardFormatting = new HashMap<>();
                 }
               }
               JSONObject cellProps = (JSONObject) hardFormatting.get("cell");
@@ -1345,7 +1345,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
           }
         }
         if (mColumns == null) {
-          mColumns = new ArrayList<TableTableColumnElement>();
+          mColumns = new ArrayList<>();
         }
         mColumns.add(column);
       } else if (element instanceof TextListElement) {
@@ -1501,7 +1501,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
         int childNo = frameProps.incrementChildNumber();
         if (childNo == 1) {
 
-          Map<String, Object> hardFormatting = new HashMap<String, Object>();
+          Map<String, Object> hardFormatting = new HashMap<>();
           hardFormatting.putAll(frameProps.getShapeHardFormatting());
           JSONObject drawingProps = (JSONObject) hardFormatting.get("drawing");
           JSONObject imageProps = (JSONObject) hardFormatting.get("image");
@@ -1816,7 +1816,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                       // if there are absolute styles, but not the main property set, where the
                       // templateStyleId should be placed in
                       if (hardFormatting == null) {
-                        hardFormatting = new HashMap<String, Object>();
+                        hardFormatting = new HashMap<>();
                       }
                     }
                     if (s.hasUrl()) {
@@ -1904,7 +1904,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                   newOp.mStart.remove(0);
                 }
 
-                ArrayList<Object> componentProperties = new ArrayList<Object>();
+                ArrayList<Object> componentProperties = new ArrayList<>();
                 int propIndex = 0;
                 while (newOp.mComponentProperties.length > propIndex
                     && newOp.mComponentProperties[propIndex] != null) {
@@ -2445,12 +2445,12 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
   //    private List<CachedTable> mTableStack;
   //    boolean mWithinTable = false; //TODO: Detect via type of top element of mComponentStack
   // private int mNumberOfNestedTables = 0;
-  Stack<CachedComponent> mComponentStack = new Stack<CachedComponent>();
+  Stack<CachedComponent> mComponentStack = new Stack<>();
   // cache objects bound to page that are on top level of the document
-  ArrayDeque<ShapeProperties> m_cachedPageShapes = new ArrayDeque<ShapeProperties>();
+  ArrayDeque<ShapeProperties> m_cachedPageShapes = new ArrayDeque<>();
   boolean mPageBoundObjectsRelocated = false;
   HashMap<String, Integer> mTopLevelTables =
-      new HashMap<String, Integer>(); // mapping of spreadsheet index to their names
+    new HashMap<>(); // mapping of spreadsheet index to their names
 
   @SuppressWarnings("unchecked")
   public void cacheOperation(
@@ -2828,7 +2828,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
         if (putPageBreak && isParagraphOperation) {
           JSONObject paraProps = null;
           if (operation.mHardFormattingProperties == null) {
-            operation.mHardFormattingProperties = new HashMap<String, Object>();
+            operation.mHardFormattingProperties = new HashMap<>();
           }
           if (!operation.mHardFormattingProperties.containsKey("paragraph")) {
             paraProps = new JSONObject();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ChangesFileSaxHandler.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -98,7 +97,6 @@ import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeAutomaticStyles;
 import org.odftoolkit.odfdom.incubator.doc.office.OdfOfficeStyles;
 import org.odftoolkit.odfdom.incubator.doc.style.OdfStyle;
 import org.odftoolkit.odfdom.incubator.doc.style.OdfStylePageLayout;
-import org.odftoolkit.odfdom.incubator.doc.text.OdfTextListStyle;
 import org.odftoolkit.odfdom.pkg.OdfAttribute;
 import org.odftoolkit.odfdom.pkg.OdfElement;
 import org.odftoolkit.odfdom.pkg.OdfFileDom;
@@ -570,9 +568,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
         && (localName.equals("p") || localName.equals("h") || localName.equals("table"))) {
       // move nodes
       Node bodyNode = mCurrentNode.getParentNode();
-      Iterator<ShapeProperties> it = m_cachedPageShapes.iterator();
-      while (it.hasNext()) {
-        ShapeProperties component = it.next();
+      for (ShapeProperties component : m_cachedPageShapes) {
         bodyNode.insertBefore(component.mOwnNode, bodyNode.getFirstChild());
       }
       mLastComponentPositions.clear();
@@ -716,9 +712,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                     hardFormatting,
                     mContextName);
                 paragraphOpCreated = true;
-                Iterator<ShapeProperties> it = m_cachedPageShapes.iterator();
-                while (it.hasNext()) {
-                  ShapeProperties component = it.next();
+                for (ShapeProperties component : m_cachedPageShapes) {
                   Component frameComponent = component.getDrawFrameElement().getComponent();
                   Component frameComponentParent = frameComponent.getParent();
                   int framePosition = frameComponentParent.indexOf(frameComponent);
@@ -726,16 +720,14 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                   element.appendChild(component.mOwnNode);
                   component.mShapePosition.addAll(0, position);
                   component.createShapeOperation(
-                      this,
-                      mComponentStack,
-                      component.mDescription,
-                      component.hasImageSibling()
-                          ? ShapeType.ImageShape
-                          : component.isGroupShape() ? ShapeType.GroupShape : ShapeType.NormalShape,
-                      component.mContext);
-                  Iterator<CachedOperation> opIter = component.iterator();
-                  while (opIter.hasNext()) {
-                    CachedOperation op = opIter.next();
+                    this,
+                    mComponentStack,
+                    component.mDescription,
+                    component.hasImageSibling()
+                      ? ShapeType.ImageShape
+                      : component.isGroupShape() ? ShapeType.GroupShape : ShapeType.NormalShape,
+                    component.mContext);
+                  for (CachedOperation op : component) {
                     List<Integer> start = op.mStart;
                     if (!op.mAbsolutePosition) {
                       if (op.mComponentType.equals(OperationConstants.ATTRIBUTES)) {
@@ -749,12 +741,12 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                       start.addAll(0, position);
                     }
                     cacheOperation(
-                        false,
-                        op.mComponentType,
-                        start,
-                        false,
-                        op.mHardFormattingProperties,
-                        op.mComponentProperties);
+                      false,
+                      op.mComponentType,
+                      start,
+                      false,
+                      op.mHardFormattingProperties,
+                      op.mComponentProperties);
                   }
                 }
                 m_cachedPageShapes.clear();
@@ -1645,17 +1637,13 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
               defaultTabStopWidth = _defaultTabStopWidth;
             }
           }
-          final Iterator<OdfStyle> textStyleIter =
-              officeStyles.getStylesForFamily(OdfStyleFamily.Text).iterator();
-          while (textStyleIter.hasNext()) {
+          for (OdfStyle odfStyle : officeStyles.getStylesForFamily(OdfStyleFamily.Text)) {
             mJsonOperationProducer.triggerStyleHierarchyOps(
-                officeStyles, OdfStyleFamily.Text, textStyleIter.next());
+              officeStyles, OdfStyleFamily.Text, odfStyle);
           }
-          final Iterator<OdfStyle> graphicStyleIter =
-              officeStyles.getStylesForFamily(OdfStyleFamily.Graphic).iterator();
-          while (graphicStyleIter.hasNext()) {
+          for (OdfStyle odfStyle : officeStyles.getStylesForFamily(OdfStyleFamily.Graphic)) {
             mJsonOperationProducer.triggerStyleHierarchyOps(
-                officeStyles, OdfStyleFamily.Graphic, graphicStyleIter.next());
+              officeStyles, OdfStyleFamily.Graphic, odfStyle);
           }
           // always generate graphic default style
           mJsonOperationProducer.triggerDefaultStyleOp(
@@ -1689,11 +1677,7 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
           //    				mJsonOperationProducer.triggerStyleHierarchyOps(officeStyles,
           // OdfStyleFamily.List, style);
           //    			}
-          final Iterator<OdfTextListStyle> textListStyleIter =
-              officeStyles.getListStyles().iterator();
-          while (textListStyleIter.hasNext()) {
-            mJsonOperationProducer.addListStyle(textListStyleIter.next());
-          }
+          officeStyles.getListStyles().forEach(mJsonOperationProducer::addListStyle);
 
           // maps page properties, but returns the default page properties
           defaultPageStyles = mJsonOperationProducer.addPageProperties(stylesDom);
@@ -1755,16 +1739,14 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                 null);
           }
           // flush the inner operations of the shape
-          Iterator<CachedOperation> opIter = shapeProps.iterator();
-          while (opIter.hasNext()) {
-            CachedOperation op = opIter.next();
+          for (CachedOperation op : shapeProps) {
             cacheOperation(
-                true,
-                op.mComponentType,
-                op.mStart,
-                false,
-                op.mHardFormattingProperties,
-                op.mComponentProperties);
+              true,
+              op.mComponentType,
+              op.mStart,
+              false,
+              op.mHardFormattingProperties,
+              op.mComponentProperties);
           }
           mCurrentComponent = mCurrentComponent.getParent();
         }
@@ -2685,16 +2667,31 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
 
     boolean putPageBreak = false;
     boolean isBreakBefore = true;
-    ListIterator<CachedOperation> cachedOperationIterator = currentTable.listIterator();
-    while (cachedOperationIterator.hasNext()) {
-      CachedOperation operation = cachedOperationIterator.next();
+    for (CachedOperation operation : currentTable) {
       if (operation instanceof CachedInnerTableOperation
-          && operation.mComponentType.equals(OperationConstants.TABLE)) {
+        && operation.mComponentType.equals(OperationConstants.TABLE)) {
         if (isStartOfTable) {
           isStartOfTable = false;
           if (currentTable.mIsTooLarge) {
             // replacement table
             cacheOperation(
+              false,
+              OperationConstants.EXCEEDEDTABLE,
+              operation.mStart,
+              false,
+              null,
+              ((List) operation.mComponentProperties[0]).size(),
+              currentTable.mRowCount,
+              operation.mComponentProperties[0],
+              mContextName);
+            break;
+          } else {
+            if ((mMaxAllowedRowCount != 0 && currentTable.mRowCount > mMaxAllowedRowCount)
+              || (mMaxAllowedColumnCount != 0
+              && currentTable.mColumnCount > mMaxAllowedColumnCount)
+              || (mMaxAllowedCellCount != 0 && currentTable.mCellCount > mMaxAllowedCellCount)) {
+              // TODO: Exceeded table operation name
+              cacheOperation(
                 false,
                 OperationConstants.EXCEEDEDTABLE,
                 operation.mStart,
@@ -2704,31 +2701,14 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                 currentTable.mRowCount,
                 operation.mComponentProperties[0],
                 mContextName);
-            break;
-          } else {
-            if ((mMaxAllowedRowCount != 0 && currentTable.mRowCount > mMaxAllowedRowCount)
-                || (mMaxAllowedColumnCount != 0
-                    && currentTable.mColumnCount > mMaxAllowedColumnCount)
-                || (mMaxAllowedCellCount != 0 && currentTable.mCellCount > mMaxAllowedCellCount)) {
-              // TODO: Exceeded table operation name
-              cacheOperation(
-                  false,
-                  OperationConstants.EXCEEDEDTABLE,
-                  operation.mStart,
-                  false,
-                  null,
-                  ((List) operation.mComponentProperties[0]).size(),
-                  currentTable.mRowCount,
-                  operation.mComponentProperties[0],
-                  mContextName);
               break;
             } else {
               // the last parameter are: mColumnRelWidths, mTableName, mIsTableVisible);
               JSONObject tableAttr = null;
               if (operation.mHardFormattingProperties.containsKey("table")
-                  && (((tableAttr = (JSONObject) operation.mHardFormattingProperties.get("table"))
-                          .has("pageBreakBefore"))
-                      || tableAttr.has("pageBreakAfter"))) {
+                && (((tableAttr = (JSONObject) operation.mHardFormattingProperties.get("table"))
+                .has("pageBreakBefore"))
+                || tableAttr.has("pageBreakAfter"))) {
                 isBreakBefore = tableAttr.has("pageBreakBefore");
                 String breakString = isBreakBefore ? "pageBreakBefore" : "pageBreakAfter";
                 boolean breakAttr = tableAttr.getBoolean(breakString);
@@ -2738,14 +2718,14 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
                 tableAttr.remove(breakString);
               }
               cacheOperation(
-                  false,
-                  OperationConstants.TABLE,
-                  operation.mStart,
-                  false,
-                  operation.mHardFormattingProperties,
-                  operation.mComponentProperties[0],
-                  operation.mComponentProperties[1],
-                  mContextName);
+                false,
+                OperationConstants.TABLE,
+                operation.mStart,
+                false,
+                operation.mHardFormattingProperties,
+                operation.mComponentProperties[0],
+                operation.mComponentProperties[1],
+                mContextName);
             }
           }
         } else {
@@ -2754,77 +2734,77 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
       } else if (operation.mComponentType.equals(OperationConstants.TEXT)) {
         String context = mContextName;
         if (operation.mComponentProperties.length > 1
-            && operation.mComponentProperties[1] != null) {
+          && operation.mComponentProperties[1] != null) {
           context = (String) operation.mComponentProperties[1];
         }
         cacheOperation(
-            false,
-            operation.mComponentType,
-            operation.mStart,
-            false,
-            null,
-            operation.mComponentProperties[0],
-            context);
+          false,
+          operation.mComponentType,
+          operation.mStart,
+          false,
+          null,
+          operation.mComponentProperties[0],
+          context);
       } else if (operation.mComponentType.equals(OperationConstants.ATTRIBUTES)) {
         String context = mContextName;
         if (operation.mComponentProperties.length > 1
-            && operation.mComponentProperties[1] != null) {
+          && operation.mComponentProperties[1] != null) {
           context = (String) operation.mComponentProperties[1];
         }
         cacheOperation(
-            false,
-            OperationConstants.ATTRIBUTES,
-            operation.mStart,
-            false,
-            operation.mHardFormattingProperties,
-            operation.mComponentProperties[0],
-            context);
+          false,
+          OperationConstants.ATTRIBUTES,
+          operation.mStart,
+          false,
+          operation.mHardFormattingProperties,
+          operation.mComponentProperties[0],
+          context);
       } else if (operation.mComponentType.equals(OperationConstants.SHAPE)
-          || operation.mComponentType.equals(OperationConstants.IMAGE)
-          || operation.mComponentType.equals(OperationConstants.SHAPE_GROUP)) {
+        || operation.mComponentType.equals(OperationConstants.IMAGE)
+        || operation.mComponentType.equals(OperationConstants.SHAPE_GROUP)) {
         cacheOperation(
-            false,
-            operation.mComponentType,
-            operation.mStart,
-            false,
-            operation.mHardFormattingProperties,
-            mContextName);
+          false,
+          operation.mComponentType,
+          operation.mStart,
+          false,
+          operation.mHardFormattingProperties,
+          mContextName);
       } else if (operation.mComponentType.equals(OperationConstants.FIELD)) {
         // TODO: Why do I have to check for map<> casts but not with String casts?
         @SuppressWarnings("unchecked")
         Map<String, Object> attrMap = (Map<String, Object>) operation.mComponentProperties[2];
         cacheOperation(
-            false,
-            operation.mComponentType,
-            operation.mStart,
-            false,
-            null,
-            operation.mComponentProperties[0],
-            operation.mComponentProperties[1],
-            attrMap,
-            mContextName);
+          false,
+          operation.mComponentType,
+          operation.mStart,
+          false,
+          null,
+          operation.mComponentProperties[0],
+          operation.mComponentProperties[1],
+          attrMap,
+          mContextName);
       } else if (operation.mComponentType.equals(OperationConstants.TABLE)
-          || operation.mComponentType.equals(OperationConstants.COMMENT)
-          || operation.mComponentType.equals(OperationConstants.COMMENTRANGE)) {
+        || operation.mComponentType.equals(OperationConstants.COMMENT)
+        || operation.mComponentType.equals(OperationConstants.COMMENTRANGE)) {
         cacheOperation(
-            false,
-            operation.mComponentType,
-            operation.mStart,
-            false,
-            operation.mHardFormattingProperties,
-            operation.mComponentProperties);
+          false,
+          operation.mComponentType,
+          operation.mStart,
+          false,
+          operation.mHardFormattingProperties,
+          operation.mComponentProperties);
       } else if (operation.mComponentType.equals(OperationConstants.COMMENT)
-          || operation.mComponentType.equals(OperationConstants.COMMENTRANGE)) {
+        || operation.mComponentType.equals(OperationConstants.COMMENTRANGE)) {
         cacheOperation(
-            false,
-            operation.mComponentType,
-            operation.mStart,
-            false,
-            operation.mHardFormattingProperties,
-            operation.mComponentProperties);
+          false,
+          operation.mComponentType,
+          operation.mStart,
+          false,
+          operation.mHardFormattingProperties,
+          operation.mComponentProperties);
       } else {
         boolean isParagraphOperation =
-            operation.mComponentType.equals(OperationConstants.PARAGRAPH);
+          operation.mComponentType.equals(OperationConstants.PARAGRAPH);
         if (putPageBreak && isParagraphOperation) {
           JSONObject paraProps = null;
           if (operation.mHardFormattingProperties == null) {
@@ -2844,12 +2824,12 @@ public class ChangesFileSaxHandler extends org.odftoolkit.odfdom.pkg.OdfFileSaxH
           context = (String) operation.mComponentProperties[0];
         }
         cacheOperation(
-            false,
-            operation.mComponentType,
-            operation.mStart,
-            false,
-            operation.mHardFormattingProperties,
-            context);
+          false,
+          operation.mComponentType,
+          operation.mStart,
+          false,
+          operation.mHardFormattingProperties,
+          context);
       }
     }
   }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Component.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Component.java
@@ -818,7 +818,7 @@ public class Component {
   public void addChild(int index, Component c) {
     if (mChildren == null) {
       if (mChildren == null) {
-        mChildren = new ArrayList<Component>();
+        mChildren = new ArrayList<>();
       }
     }
     if (index >= 0) {
@@ -977,7 +977,7 @@ public class Component {
   public static Map<String, OdfStylePropertiesSet> getAllStyleGroupingIdProperties(
       OdfStyleFamily styleFamily) {
     Map<String, OdfStylePropertiesSet> familyProperties =
-        new HashMap<String, OdfStylePropertiesSet>();
+      new HashMap<>();
     if (styleFamily.equals(OdfStyleFamily.Paragraph)) {
       familyProperties.put("paragraph", OdfStylePropertiesSet.ParagraphProperties);
       familyProperties.put("character", OdfStylePropertiesSet.TextProperties);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/FieldMap.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/FieldMap.java
@@ -15,8 +15,6 @@
  */
 package org.odftoolkit.odfdom.changes;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 class FieldMap {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/FieldMap.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/FieldMap.java
@@ -249,283 +249,81 @@ class FieldMap {
   }
 
   private static Map<String, FieldMap> createMap() {
-    Map<String, FieldMap> map = new HashMap<String, FieldMap>();
-    map.put(
-        "author-initials", new FieldMap("authorinitials", "TextAuthorInitialsElement", PROP_FIXED));
-    map.put("author-name", new FieldMap("author-name", "TextAuthorNameElement", PROP_FIXED));
-    map.put(
-        "bookmark-ref",
-        new FieldMap("bookmark-ref", "TextBookmarkRefElement", PROP_REFFORMAT | PROP_REFNAME));
-    map.put(
-        "chapter", new FieldMap("chapter", "TextChapterElement", PROP_DISPLAY | PROP_OUTLINELEVEL));
-    map.put(
-        "character-count",
-        new FieldMap(
-            "character-count",
-            "TextCharacterCountElement",
-            PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC));
-    map.put(
-        "conditional-text",
-        new FieldMap(
-            "conditional-text",
-            "TextConditionalTextElement",
-            PROP_CONDITION | PROP_CURRENTVALUE | PROP_FALSEVALUE | PROP_TRUEVALUE));
-    map.put(
-        "creation-date",
-        new FieldMap(
-            "creation-date",
-            "TextCreationDateElement",
-            PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT));
-    map.put(
-        "creation-time",
-        new FieldMap(
-            "creation-time",
-            "TextCreationTimeElement",
-            PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT | PROP_TIMESTYLE));
-    map.put("creator", new FieldMap("creator", "TextCreatorElement", PROP_FIXED));
-    map.put(
-        "database-display",
-        new FieldMap(
-            "database-display",
-            "TextDatabaseDisplayElement",
-            PROP_DBTABLE | PROP_DBNAME | PROP_DBCOLUMN));
-    map.put(
-        "database-name",
-        new FieldMap("database-name", "TextDatabaseNameElement", PROP_DBTABLE | PROP_DBNAME));
-    map.put(
-        "database-row-number",
-        new FieldMap(
-            "database-row-number",
-            "TextDatabaseRowNumberElement",
-            PROP_T_VALUE | PROP_DBTABLE | PROP_DBNAME));
-    map.put(
-        "database-row-select",
-        new FieldMap(
-            "database-row-select",
-            "TextDatabaseRowSelectElement",
-            PROP_CONDITION | PROP_DBTABLE | PROP_DBNAME | PROP_ROWNUMBER | PROP_TABLETYPE));
-    map.put(
-        "date",
-        new FieldMap("date", "TextDateElement", PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT));
-    map.put(
-        "dde-connection",
-        new FieldMap("dde-connection", "TextDdeConnectionElement", PROP_CONNECTIONNAME));
-    map.put("description", new FieldMap("description", "TextDescriptionElement", PROP_FIXED));
-    map.put(
-        "editing-cycles", new FieldMap("editing-cycles", "TextEditingCyclesElement", PROP_FIXED));
-    map.put(
-        "editing-duration",
-        new FieldMap(
-            "editing-duration",
-            "TextEditingDurationElement",
-            PROP_FIXED | PROP_DURATION | PROP_DATEFORMAT));
-    map.put("execute-macro", new FieldMap("execute-macro", "TextExecuteMacroElement", PROP_NAME));
-    map.put(
-        "expression",
-        new FieldMap(
-            "expression",
-            "TextExpressionElement",
-            PROP_BOOLVALUE
-                | PROP_CURRENCY
-                | PROP_DATEVALUE
-                | PROP_STRINGVALUE
-                | PROP_TIMEVALUE
-                | PROP_O_VALUE
-                | PROP_VALUETYPE
-                | PROP_DATEFORMAT
-                | PROP_DISPLAY
-                | PROP_FORMULA));
-    map.put(
-        "file-name", new FieldMap("file-name", "TextFileNameElement", PROP_DISPLAY | PROP_FIXED));
-    map.put(
-        "hidden-paragraph",
-        new FieldMap(
-            "hidden-paragraph", "TextHiddenParagraphElement", PROP_CONDITION | PROP_ISHIDDEN));
-    map.put(
-        "hidden-text",
-        new FieldMap(
-            "hidden-text",
-            "TextHiddenTextElement",
-            PROP_CONDITION | PROP_ISHIDDEN | PROP_STRINGVALUE));
-    map.put(
-        "image-count",
-        new FieldMap(
-            "image-count", "TextImageCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC));
-    map.put(
-        "initial-creator",
-        new FieldMap("initial-creator", "TextInitialCreatorElement", PROP_FIXED));
-    map.put("keywords", new FieldMap("keywords", "TextKeywordsElement", 0));
-    map.put("measure", new FieldMap("measure", "TextMeasureElement", PROP_KIND));
-    map.put(
-        "meta-field",
-        new FieldMap("meta-field", "TextMetaFieldElement", PROP_DATEFORMAT | PROP_ID));
-    map.put(
-        "modification-date",
-        new FieldMap(
-            "modification-date",
-            "TextModificationDateElement",
-            PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT));
-    map.put(
-        "modification-time",
-        new FieldMap(
-            "modification-time",
-            "TextModificationTimeElement",
-            PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT));
-    map.put(
-        "note-ref", new FieldMap("note-ref", "TextNoteRefElement", PROP_REFFORMAT | PROP_REFNAME));
-    map.put(
-        "object-count",
-        new FieldMap(
-            "object-count", "TextObjectCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC));
-    map.put(
-        "page-continuation", new FieldMap("page-continuation", "TextPageContinuationElement", 0));
-    map.put(
-        "page-count",
-        new FieldMap(
-            "page-count", "TextPageCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC));
-    map.put(
-        "page-number",
-        new FieldMap(
-            "page-number", "TextPageNumberElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC));
-    map.put(
-        "page-variable-get",
-        new FieldMap(
-            "page-variable-get",
-            "TextPageVariableGetElement",
-            PROP_NUMFORMAT | PROP_NUMLETTERSYNC));
-    map.put(
-        "page-variable-set",
-        new FieldMap(
-            "page-variable-set", "TextPageVariableSetElement", PROP_PAGEADJUST | PROP_ACTIVE));
-    map.put(
-        "paragraph-count",
-        new FieldMap(
-            "paragraph-count",
-            "TextParagraphCountElement",
-            PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC));
-    map.put(
-        "placeholder",
-        new FieldMap(
-            "placeholder", "TextPlaceholderElement", PROP_DESCRIPTION | PROP_PLACEHOLDERTYPE));
-    map.put(
-        "print-date",
-        new FieldMap(
-            "print-date", "TextPrintDateElement", PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT));
-    map.put(
-        "print-time",
-        new FieldMap(
-            "print-time",
-            "TextPrintTimeElement",
-            PROP_FIXED | PROP_TIMESTYLE | PROP_DATEVALUE | PROP_DATEFORMAT));
-    map.put("printed-by", new FieldMap("printed-by", "TextPrintedByElement", PROP_FIXED));
-    map.put(
-        "reference-ref",
-        new FieldMap("reference-ref", "TextReferenceRefElement", PROP_REFFORMAT | PROP_REFNAME));
-    map.put(
-        "script",
-        new FieldMap("script", "TextScriptElement", PROP_LANGUAGE | PROP_HREF | PROP_LINKTYPE));
-    map.put("sender-city", new FieldMap("sender-city", "TextSenderCityElement", 0));
-    map.put("sender-company", new FieldMap("sender-company", "TextSenderCompanyElement", 0));
-    map.put("sender-country", new FieldMap("sender-country", "TextSenderCountryElement", 0));
-    map.put("sender-email", new FieldMap("sender-email", "TextSenderEmailElement", 0));
-    map.put("sender-fax", new FieldMap("sender-fax", "TextSenderFaxElement", 0));
-    map.put("sender-firstname", new FieldMap("sender-firstname", "TextSenderFirstnameElement", 0));
-    map.put("sender-initials", new FieldMap("sender-initials", "TextSenderInitialsElement", 0));
-    map.put("sender-lastname", new FieldMap("sender-lastname", "TextSenderLastnameElement", 0));
-    map.put(
-        "sender-phone-private",
-        new FieldMap("sender-phone-private", "TextSenderPhonePrivateElement", 0));
-    map.put(
-        "sender-phone-work", new FieldMap("sender-phone-work", "TextSenderPhoneWorkElement", 0));
-    map.put("sender-position", new FieldMap("sender-position", "TextSenderPositionElement", 0));
-    map.put(
-        "sender-postal-code", new FieldMap("sender-postal-code", "TextSenderPostalCodeElement", 0));
-    map.put(
-        "sender-state-or-province",
-        new FieldMap("sender-state-or-province", "TextSenderStateOrProvinceElement", 0));
-    map.put("sender-street", new FieldMap("sender-street", "TextSenderStreetElement", 0));
-    map.put("sender-title", new FieldMap("sender-title", "TextSenderTitleElement", 0));
-    map.put(
-        "sequence-ref",
-        new FieldMap("sequence-ref", "TextSequenceRefElement", PROP_REFFORMAT | PROP_REFNAME));
-    map.put(
-        "sequence",
-        new FieldMap(
-            "sequence",
-            "TextSequenceElement",
-            PROP_DATEFORMAT | PROP_NUMLETTERSYNC | PROP_FORMULA | PROP_NAME | PROP_REFNAME));
-    map.put("sheet-name", new FieldMap("sheet-name", "TextSheetNameElement", 0));
-    map.put("subject", new FieldMap("subject", "TextSubjectElement", PROP_FIXED));
-    map.put(
-        "table-count",
-        new FieldMap(
-            "table-count", "TextTableCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC));
-    map.put(
-        "template-name", new FieldMap("template-name", "TextTemplateNameElement", PROP_DISPLAY));
-    map.put("text-input", new FieldMap("text-input", "TextTextInputElement", PROP_DESCRIPTION));
-    map.put(
-        "time",
-        new FieldMap(
-            "time",
-            "TextTimeElement",
-            PROP_FIXED | PROP_DATEVALUE | PROP_TIMESTYLE | PROP_DATEFORMAT));
-    map.put("title", new FieldMap("title", "TextTitleElement", PROP_FIXED));
-    map.put(
-        "user-defined",
-        new FieldMap(
-            "user-defined",
-            "TextUserDefinedElement",
-            PROP_BOOLVALUE
-                | PROP_CURRENCY
-                | PROP_DATEVALUE
-                | PROP_STRINGVALUE
-                | PROP_TIMEVALUE
-                | PROP_O_VALUE
-                | PROP_DATEFORMAT
-                | PROP_FIXED
-                | PROP_NAME));
-    map.put(
-        "user-field-get",
-        new FieldMap(
-            "user-field-get",
-            "TextUserFieldGetElement",
-            PROP_DATEFORMAT | PROP_DISPLAY | PROP_NAME | PROP_VALUETYPE));
-    map.put(
-        "user-field-input",
-        new FieldMap(
-            "user-field-input",
-            "TextUserFieldInputElement",
-            PROP_DATEFORMAT | PROP_DESCRIPTION | PROP_NAME));
-    map.put(
-        "variable-get",
-        new FieldMap("variable-get", "TextVariableGetElement", PROP_DATEFORMAT | PROP_DISPLAY));
-    map.put(
-        "variable-input",
-        new FieldMap(
-            "variable-input",
-            "TextVariableInputElement",
-            PROP_BOOLVALUE | PROP_DATEFORMAT | PROP_DISPLAY | PROP_DESCRIPTION | PROP_NAME));
-    map.put(
-        "variable-set",
-        new FieldMap(
-            "variable-set",
-            "TextVariableSetElement",
-            PROP_BOOLVALUE
-                | PROP_CURRENCY
-                | PROP_DATEVALUE
-                | PROP_STRINGVALUE
-                | PROP_TIMEVALUE
-                | PROP_O_VALUE
-                | PROP_VALUETYPE
-                | PROP_DATEFORMAT
-                | PROP_DISPLAY
-                | PROP_FORMULA
-                | PROP_NAME));
-    map.put(
-        "word-count",
-        new FieldMap(
-            "word-count", "TextWordCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC));
-
-    return Collections.unmodifiableMap(map);
+    return Map.<String, FieldMap>ofEntries(
+      Map.entry("author-initials", new FieldMap("authorinitials", "TextAuthorInitialsElement", PROP_FIXED)),
+      Map.entry("author-name", new FieldMap("author-name", "TextAuthorNameElement", PROP_FIXED)),
+      Map.entry("bookmark-ref", new FieldMap("bookmark-ref", "TextBookmarkRefElement", PROP_REFFORMAT | PROP_REFNAME)),
+      Map.entry("chapter", new FieldMap("chapter", "TextChapterElement", PROP_DISPLAY | PROP_OUTLINELEVEL)),
+      Map.entry("character-count", new FieldMap("character-count", "TextCharacterCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC)),
+      Map.entry("conditional-text", new FieldMap("conditional-text", "TextConditionalTextElement", PROP_CONDITION | PROP_CURRENTVALUE | PROP_FALSEVALUE | PROP_TRUEVALUE)),
+      Map.entry("creation-date", new FieldMap("creation-date", "TextCreationDateElement", PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT)),
+      Map.entry("creation-time", new FieldMap("creation-time", "TextCreationTimeElement", PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT | PROP_TIMESTYLE)),
+      Map.entry("creator", new FieldMap("creator", "TextCreatorElement", PROP_FIXED)),
+      Map.entry("database-display", new FieldMap("database-display", "TextDatabaseDisplayElement", PROP_DBTABLE | PROP_DBNAME | PROP_DBCOLUMN)),
+      Map.entry("database-name", new FieldMap("database-name", "TextDatabaseNameElement", PROP_DBTABLE | PROP_DBNAME)),
+      Map.entry("database-row-number", new FieldMap("database-row-number", "TextDatabaseRowNumberElement", PROP_T_VALUE | PROP_DBTABLE | PROP_DBNAME)),
+      Map.entry("database-row-select", new FieldMap("database-row-select", "TextDatabaseRowSelectElement", PROP_CONDITION | PROP_DBTABLE | PROP_DBNAME | PROP_ROWNUMBER | PROP_TABLETYPE)),
+      Map.entry("date", new FieldMap("date", "TextDateElement", PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT)),
+      Map.entry("dde-connection", new FieldMap("dde-connection", "TextDdeConnectionElement", PROP_CONNECTIONNAME)),
+      Map.entry("description", new FieldMap("description", "TextDescriptionElement", PROP_FIXED)),
+      Map.entry("editing-cycles", new FieldMap("editing-cycles", "TextEditingCyclesElement", PROP_FIXED)),
+      Map.entry("editing-duration", new FieldMap("editing-duration", "TextEditingDurationElement", PROP_FIXED | PROP_DURATION | PROP_DATEFORMAT)),
+      Map.entry("execute-macro", new FieldMap("execute-macro", "TextExecuteMacroElement", PROP_NAME)),
+      Map.entry("expression", new FieldMap("expression", "TextExpressionElement", PROP_BOOLVALUE | PROP_CURRENCY | PROP_DATEVALUE | PROP_STRINGVALUE | PROP_TIMEVALUE | PROP_O_VALUE | PROP_VALUETYPE | PROP_DATEFORMAT | PROP_DISPLAY | PROP_FORMULA)),
+      Map.entry("file-name", new FieldMap("file-name", "TextFileNameElement", PROP_DISPLAY | PROP_FIXED)),
+      Map.entry("hidden-paragraph", new FieldMap("hidden-paragraph", "TextHiddenParagraphElement", PROP_CONDITION | PROP_ISHIDDEN)),
+      Map.entry("hidden-text", new FieldMap("hidden-text", "TextHiddenTextElement", PROP_CONDITION | PROP_ISHIDDEN | PROP_STRINGVALUE)),
+      Map.entry("image-count", new FieldMap("image-count", "TextImageCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC)),
+      Map.entry("initial-creator", new FieldMap("initial-creator", "TextInitialCreatorElement", PROP_FIXED)),
+      Map.entry("keywords", new FieldMap("keywords", "TextKeywordsElement", 0)),
+      Map.entry("measure", new FieldMap("measure", "TextMeasureElement", PROP_KIND)),
+      Map.entry("meta-field", new FieldMap("meta-field", "TextMetaFieldElement", PROP_DATEFORMAT | PROP_ID)),
+      Map.entry("modification-date", new FieldMap("modification-date", "TextModificationDateElement", PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT)),
+      Map.entry("modification-time", new FieldMap("modification-time", "TextModificationTimeElement", PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT)),
+      Map.entry("note-ref", new FieldMap("note-ref", "TextNoteRefElement", PROP_REFFORMAT | PROP_REFNAME)),
+      Map.entry("object-count", new FieldMap("object-count", "TextObjectCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC)),
+      Map.entry("page-continuation", new FieldMap("page-continuation", "TextPageContinuationElement", 0)),
+      Map.entry("page-count", new FieldMap("page-count", "TextPageCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC)),
+      Map.entry("page-number", new FieldMap("page-number", "TextPageNumberElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC)),
+      Map.entry("page-variable-get", new FieldMap("page-variable-get", "TextPageVariableGetElement", PROP_NUMFORMAT | PROP_NUMLETTERSYNC)),
+      Map.entry("page-variable-set", new FieldMap("page-variable-set", "TextPageVariableSetElement", PROP_PAGEADJUST | PROP_ACTIVE)),
+      Map.entry("paragraph-count", new FieldMap("paragraph-count", "TextParagraphCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC)),
+      Map.entry("placeholder", new FieldMap("placeholder", "TextPlaceholderElement", PROP_DESCRIPTION | PROP_PLACEHOLDERTYPE)),
+      Map.entry("print-date", new FieldMap("print-date", "TextPrintDateElement", PROP_FIXED | PROP_DATEVALUE | PROP_DATEFORMAT)),
+      Map.entry("print-time", new FieldMap("print-time", "TextPrintTimeElement", PROP_FIXED | PROP_TIMESTYLE | PROP_DATEVALUE | PROP_DATEFORMAT)),
+      Map.entry("printed-by", new FieldMap("printed-by", "TextPrintedByElement", PROP_FIXED)),
+      Map.entry("reference-ref", new FieldMap("reference-ref", "TextReferenceRefElement", PROP_REFFORMAT | PROP_REFNAME)),
+      Map.entry("script", new FieldMap("script", "TextScriptElement", PROP_LANGUAGE | PROP_HREF | PROP_LINKTYPE)),
+      Map.entry("sender-city", new FieldMap("sender-city", "TextSenderCityElement", 0)),
+      Map.entry("sender-company", new FieldMap("sender-company", "TextSenderCompanyElement", 0)),
+      Map.entry("sender-country", new FieldMap("sender-country", "TextSenderCountryElement", 0)),
+      Map.entry("sender-email", new FieldMap("sender-email", "TextSenderEmailElement", 0)),
+      Map.entry("sender-fax", new FieldMap("sender-fax", "TextSenderFaxElement", 0)),
+      Map.entry("sender-firstname", new FieldMap("sender-firstname", "TextSenderFirstnameElement", 0)),
+      Map.entry("sender-initials", new FieldMap("sender-initials", "TextSenderInitialsElement", 0)),
+      Map.entry("sender-lastname", new FieldMap("sender-lastname", "TextSenderLastnameElement", 0)),
+      Map.entry("sender-phone-private", new FieldMap("sender-phone-private", "TextSenderPhonePrivateElement", 0)),
+      Map.entry("sender-phone-work", new FieldMap("sender-phone-work", "TextSenderPhoneWorkElement", 0)),
+      Map.entry("sender-position", new FieldMap("sender-position", "TextSenderPositionElement", 0)),
+      Map.entry("sender-postal-code", new FieldMap("sender-postal-code", "TextSenderPostalCodeElement", 0)),
+      Map.entry("sender-state-or-province", new FieldMap("sender-state-or-province", "TextSenderStateOrProvinceElement", 0)),
+      Map.entry("sender-street", new FieldMap("sender-street", "TextSenderStreetElement", 0)),
+      Map.entry("sender-title", new FieldMap("sender-title", "TextSenderTitleElement", 0)),
+      Map.entry("sequence-ref", new FieldMap("sequence-ref", "TextSequenceRefElement", PROP_REFFORMAT | PROP_REFNAME)),
+      Map.entry("sequence", new FieldMap("sequence", "TextSequenceElement", PROP_DATEFORMAT | PROP_NUMLETTERSYNC | PROP_FORMULA | PROP_NAME | PROP_REFNAME)),
+      Map.entry("sheet-name", new FieldMap("sheet-name", "TextSheetNameElement", 0)),
+      Map.entry("subject", new FieldMap("subject", "TextSubjectElement", PROP_FIXED)),
+      Map.entry("table-count", new FieldMap("table-count", "TextTableCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC)),
+      Map.entry("template-name", new FieldMap("template-name", "TextTemplateNameElement", PROP_DISPLAY)),
+      Map.entry("text-input", new FieldMap("text-input", "TextTextInputElement", PROP_DESCRIPTION)),
+      Map.entry("time", new FieldMap("time", "TextTimeElement", PROP_FIXED | PROP_DATEVALUE | PROP_TIMESTYLE | PROP_DATEFORMAT)),
+      Map.entry("title", new FieldMap("title", "TextTitleElement", PROP_FIXED)),
+      Map.entry("user-defined", new FieldMap("user-defined", "TextUserDefinedElement", PROP_BOOLVALUE | PROP_CURRENCY | PROP_DATEVALUE | PROP_STRINGVALUE | PROP_TIMEVALUE | PROP_O_VALUE | PROP_DATEFORMAT | PROP_FIXED | PROP_NAME)),
+      Map.entry("user-field-get", new FieldMap("user-field-get", "TextUserFieldGetElement", PROP_DATEFORMAT | PROP_DISPLAY | PROP_NAME | PROP_VALUETYPE)),
+      Map.entry("user-field-input", new FieldMap("user-field-input", "TextUserFieldInputElement", PROP_DATEFORMAT | PROP_DESCRIPTION | PROP_NAME)),
+      Map.entry("variable-get", new FieldMap("variable-get", "TextVariableGetElement", PROP_DATEFORMAT | PROP_DISPLAY)),
+      Map.entry("variable-input", new FieldMap("variable-input", "TextVariableInputElement", PROP_BOOLVALUE | PROP_DATEFORMAT | PROP_DISPLAY | PROP_DESCRIPTION | PROP_NAME)),
+      Map.entry("variable-set", new FieldMap("variable-set", "TextVariableSetElement", PROP_BOOLVALUE | PROP_CURRENCY | PROP_DATEVALUE | PROP_STRINGVALUE | PROP_TIMEVALUE | PROP_O_VALUE | PROP_VALUETYPE | PROP_DATEFORMAT | PROP_DISPLAY | PROP_FORMULA | PROP_NAME)),
+      Map.entry("word-count", new FieldMap("word-count", "TextWordCountElement", PROP_PAGENUMFORMAT | PROP_NUMLETTERSYNC)));
   }
 }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
@@ -3831,40 +3831,38 @@ public class JsonOperationConsumer {
 
         OdfOfficeMasterStyles masterStyles = stylesDom.getOrCreateMasterStyles();
         OdfOfficeAutomaticStyles autoStyles = stylesDom.getOrCreateAutomaticStyles();
-        Iterator<StyleMasterPageElement> masterIt = masterStyles.iterator();
-        while (masterIt.hasNext()) {
-          StyleMasterPageElement masterPage = masterIt.next();
+        for (StyleMasterPageElement masterPage : masterStyles) {
           String pageLayoutName = masterPage.getStylePageLayoutNameAttribute();
           OdfStylePageLayout pageLayout = autoStyles.getPageLayout(pageLayoutName);
           if (pageAttrs.has("marginLeft")) {
             double value = pageAttrs.getDouble("marginLeft");
             pageLayout.setProperty(
-                StylePageLayoutPropertiesElement.MarginLeft, Double.toString(value / 100) + "mm");
+              StylePageLayoutPropertiesElement.MarginLeft, Double.toString(value / 100) + "mm");
           }
           if (pageAttrs.has("marginRight")) {
             double value = pageAttrs.getDouble("marginRight");
             pageLayout.setProperty(
-                StylePageLayoutPropertiesElement.MarginRight, Double.toString(value / 100) + "mm");
+              StylePageLayoutPropertiesElement.MarginRight, Double.toString(value / 100) + "mm");
           }
           if (pageAttrs.has("marginTop")) {
             double value = pageAttrs.getDouble("marginTop");
             pageLayout.setProperty(
-                StylePageLayoutPropertiesElement.MarginTop, Double.toString(value / 100) + "mm");
+              StylePageLayoutPropertiesElement.MarginTop, Double.toString(value / 100) + "mm");
           }
           if (pageAttrs.has("marginBottom")) {
             double value = pageAttrs.getDouble("marginBottom");
             pageLayout.setProperty(
-                StylePageLayoutPropertiesElement.MarginBottom, Double.toString(value / 100) + "mm");
+              StylePageLayoutPropertiesElement.MarginBottom, Double.toString(value / 100) + "mm");
           }
           if (pageAttrs.has("width")) {
             double value = pageAttrs.getInt("width");
             pageLayout.setProperty(
-                StylePageLayoutPropertiesElement.PageWidth, Double.toString(value / 100) + "mm");
+              StylePageLayoutPropertiesElement.PageWidth, Double.toString(value / 100) + "mm");
           }
           if (pageAttrs.has("height")) {
             double value = pageAttrs.getInt("height");
             pageLayout.setProperty(
-                StylePageLayoutPropertiesElement.PageHeight, Double.toString(value / 100) + "mm");
+              StylePageLayoutPropertiesElement.PageHeight, Double.toString(value / 100) + "mm");
           }
         }
       }
@@ -3939,7 +3937,7 @@ public class JsonOperationConsumer {
       TableTableElement tableElement = (TableTableElement) tableComponent.getRootElement();
       // WORK AROUND for "UNDO COLUMN WIDTH" problem (see TableTableElement for further changes)
       List<TableTableColumnElement> existingColumnList =
-          Table.getTableColumnElements(tableElement, new ArrayList<TableTableColumnElement>());
+          Table.getTableColumnElements(tableElement, new ArrayList<>());
       int columnCount = 0;
       for (TableTableColumnElement column : existingColumnList) {
         columnCount += column.getRepetition();
@@ -4041,7 +4039,7 @@ public class JsonOperationConsumer {
         // groups, columns and header elements
         List<TableTableColumnElement> existingColumnList =
             Table.getTableColumnElements(
-                parentComponent.getRootElement(), new ArrayList<TableTableColumnElement>());
+                parentComponent.getRootElement(), new ArrayList<>());
         addColumnAndCellElements(
             parentComponent,
             start,
@@ -4642,7 +4640,7 @@ public class JsonOperationConsumer {
         // Returns all TableTableColumn descendants that exist within the tableElement, even within
         // groups, columns and header elements
         List<TableTableColumnElement> existingColumnList =
-            Table.getTableColumnElements(tableElement, new ArrayList<TableTableColumnElement>());
+            Table.getTableColumnElements(tableElement, new ArrayList<>());
         // Column creation only required
         addColumnAndCellElements(
             tableElement.getComponent(),
@@ -5014,9 +5012,7 @@ public class JsonOperationConsumer {
       Object language = null;
       Object noProof = null;
 
-      final Iterator<String> keySetIter = attrs.keySet().iterator();
-      while (keySetIter.hasNext()) {
-        final String key = (String) keySetIter.next();
+      for (String key : attrs.keySet()) {
         final Object value = attrs.get(key);
         // TODO -- !!!!!!!!!!!!!!!!ROUNDTRIP WITH THESE VALUES!!!!!!!!!!!
         //	<define name="fontWeight">
@@ -5049,29 +5045,29 @@ public class JsonOperationConsumer {
         } else if (key.equals("boldAsian")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.FO.getUri(), "font-weight-asian");
+              OdfDocumentNamespace.FO.getUri(), "font-weight-asian");
           } else {
             Boolean isBold = (Boolean) value;
             if (isBold) {
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:font-weight-asian", "bold");
+                OdfDocumentNamespace.STYLE.getUri(), "style:font-weight-asian", "bold");
             } else {
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:font-weight-asian", "normal");
+                OdfDocumentNamespace.STYLE.getUri(), "style:font-weight-asian", "normal");
             }
           }
         } else if (key.equals("boldComplex")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.FO.getUri(), "font-weight-complex");
+              OdfDocumentNamespace.FO.getUri(), "font-weight-complex");
           } else {
             Boolean isBold = (Boolean) value;
             if (isBold) {
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:font-weight-complex", "bold");
+                OdfDocumentNamespace.STYLE.getUri(), "style:font-weight-complex", "bold");
             } else {
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:font-weight-complex", "normal");
+                OdfDocumentNamespace.STYLE.getUri(), "style:font-weight-complex", "normal");
             }
           }
         } //	<define name="lineStyle">
@@ -5089,13 +5085,13 @@ public class JsonOperationConsumer {
         else if (key.equals("underline")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-underline-style");
+              OdfDocumentNamespace.STYLE.getUri(), "text-underline-style");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-underline-width");
+              OdfDocumentNamespace.STYLE.getUri(), "text-underline-width");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-underline-color");
+              OdfDocumentNamespace.STYLE.getUri(), "text-underline-color");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-underline-type");
+              OdfDocumentNamespace.STYLE.getUri(), "text-underline-type");
           } else {
             Boolean isUnderline = (Boolean) value;
             if (isUnderline) {
@@ -5126,30 +5122,30 @@ public class JsonOperationConsumer {
         } else if (key.equals("italicAsian")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.FO.getUri(), "font-style-asian");
+              OdfDocumentNamespace.FO.getUri(), "font-style-asian");
           } else {
             Boolean isItalic = (Boolean) value;
             if (isItalic) {
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:font-style-asian", "italic");
+                OdfDocumentNamespace.STYLE.getUri(), "style:font-style-asian", "italic");
 
             } else {
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:font-style-asian", "normal");
+                OdfDocumentNamespace.STYLE.getUri(), "style:font-style-asian", "normal");
             }
           }
         } else if (key.equals("italicComplex")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.FO.getUri(), "font-style-complex");
+              OdfDocumentNamespace.FO.getUri(), "font-style-complex");
           } else {
             Boolean isItalic = (Boolean) value;
             if (isItalic) {
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:font-style-complex", "italic");
+                OdfDocumentNamespace.STYLE.getUri(), "style:font-style-complex", "italic");
             } else {
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:font-style-complex", "normal");
+                OdfDocumentNamespace.STYLE.getUri(), "style:font-style-complex", "normal");
             }
           }
         } else if (key.equals("color")) {
@@ -5162,20 +5158,20 @@ public class JsonOperationConsumer {
               if (!type.equals(MapHelper.AUTO)) {
                 propertiesElement.setFoColorAttribute(getColor(color, null));
                 propertiesElement.removeAttributeNS(
-                    OdfDocumentNamespace.STYLE.getUri(), "use-window-font-color");
+                  OdfDocumentNamespace.STYLE.getUri(), "use-window-font-color");
               } else {
                 propertiesElement.setAttributeNS(
-                    OdfDocumentNamespace.STYLE.getUri(), "style:use-window-font-color", "true");
+                  OdfDocumentNamespace.STYLE.getUri(), "style:use-window-font-color", "true");
               }
             } else { // DEFAULT IS AUTO
               propertiesElement.setAttributeNS(
-                  OdfDocumentNamespace.STYLE.getUri(), "style:use-window-font-color", "true");
+                OdfDocumentNamespace.STYLE.getUri(), "style:use-window-font-color", "true");
             }
           }
         } else if (key.equals("fillColor")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.FO.getUri(), "background-color");
+              OdfDocumentNamespace.FO.getUri(), "background-color");
           } else {
             JSONObject color = (JSONObject) value;
             propertiesElement.setFoBackgroundColorAttribute(getColor(color, MapHelper.TRANSPARENT));
@@ -5189,22 +5185,22 @@ public class JsonOperationConsumer {
         } else if (key.equals("fontSizeAsian")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "font-size-asian");
+              OdfDocumentNamespace.STYLE.getUri(), "font-size-asian");
           } else {
             propertiesElement.setAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(),
-                "style:font-size-asian",
-                value + "pt");
+              OdfDocumentNamespace.STYLE.getUri(),
+              "style:font-size-asian",
+              value + "pt");
           }
         } else if (key.equals("fontSizeComplex")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "font-size-complex");
+              OdfDocumentNamespace.STYLE.getUri(), "font-size-complex");
           } else {
             propertiesElement.setAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(),
-                "style:font-size-complex",
-                value + "pt");
+              OdfDocumentNamespace.STYLE.getUri(),
+              "style:font-size-complex",
+              value + "pt");
           }
         } else if (key.equals("fontName")) {
           if (value == null || value.equals(JSONObject.NULL)) {
@@ -5217,25 +5213,25 @@ public class JsonOperationConsumer {
         } else if (key.equals("fontNameAsian")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "font-name-asian");
+              OdfDocumentNamespace.STYLE.getUri(), "font-name-asian");
           } else {
             String fontName = (String) value;
             propertiesElement.setAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "style:font-name-asian", fontName);
+              OdfDocumentNamespace.STYLE.getUri(), "style:font-name-asian", fontName);
           }
         } else if (key.equals("fontNameComplex")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "font-name-complex");
+              OdfDocumentNamespace.STYLE.getUri(), "font-name-complex");
           } else {
             String fontName = (String) value;
             propertiesElement.setAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "style:font-name-complex", fontName);
+              OdfDocumentNamespace.STYLE.getUri(), "style:font-name-complex", fontName);
           }
         } else if (key.equals("vertAlign")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-position");
+              OdfDocumentNamespace.STYLE.getUri(), "text-position");
           } else {
             String alignment = (String) value;
             if (alignment.equals("sub")) {
@@ -5249,21 +5245,21 @@ public class JsonOperationConsumer {
         } else if (key.equals("strike")) {
           if (value == null || value.equals(JSONObject.NULL)) {
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-position");
+              OdfDocumentNamespace.STYLE.getUri(), "text-position");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-line-through-color");
+              OdfDocumentNamespace.STYLE.getUri(), "text-line-through-color");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-line-through-mode");
+              OdfDocumentNamespace.STYLE.getUri(), "text-line-through-mode");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-line-through-style");
+              OdfDocumentNamespace.STYLE.getUri(), "text-line-through-style");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-line-through-text");
+              OdfDocumentNamespace.STYLE.getUri(), "text-line-through-text");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-line-through-text-style");
+              OdfDocumentNamespace.STYLE.getUri(), "text-line-through-text-style");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-line-through-type");
+              OdfDocumentNamespace.STYLE.getUri(), "text-line-through-type");
             propertiesElement.removeAttributeNS(
-                OdfDocumentNamespace.STYLE.getUri(), "text-line-through-width");
+              OdfDocumentNamespace.STYLE.getUri(), "text-line-through-width");
           } else {
             String strikeType = (String) value;
             if (strikeType.equals("single")) {
@@ -5289,33 +5285,33 @@ public class JsonOperationConsumer {
                * a value of type nonNegativeLength
                * normal: disables the effects of style:line-height-at-least and style:line-spacing.
                * a value of type percent  */
-        //				<attribute name="fo:line-height">
-        //					<choice>
-        //						<value>normal</value>
-        //						<ref name="nonNegativeLength"/>
-        //						<ref name="percent"/>
-        //					</choice>
-        //				</attribute>
-        // { type: 'percent', value: 100 }
-        if (key.equals("letterSpacing")) {
-          if (value == null || value.equals(JSONObject.NULL)) {
-            propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "letter-spacing");
-          } else {
-            if (value.equals("normal")) {
-              propertiesElement.setFoLetterSpacingAttribute("normal");
+          //				<attribute name="fo:line-height">
+          //					<choice>
+          //						<value>normal</value>
+          //						<ref name="nonNegativeLength"/>
+          //						<ref name="percent"/>
+          //					</choice>
+          //				</attribute>
+          // { type: 'percent', value: 100 }
+          if (key.equals("letterSpacing")) {
+            if (value == null || value.equals(JSONObject.NULL)) {
+              propertiesElement.removeAttributeNS(OdfDocumentNamespace.FO.getUri(), "letter-spacing");
             } else {
-              propertiesElement.setFoLetterSpacingAttribute(
+              if (value.equals("normal")) {
+                propertiesElement.setFoLetterSpacingAttribute("normal");
+              } else {
+                propertiesElement.setFoLetterSpacingAttribute(
                   (getSafelyInteger(value)) / 100.0 + "mm");
+              }
+            }
+          } else if (key.equals("url")) {
+            if (value == null || value.equals(JSONObject.NULL)) {
+              propertiesElement.removeAttributeNS(OdfDocumentNamespace.XLINK.getUri(), "href");
+            } else {
+              propertiesElement.setAttributeNS(
+                OdfDocumentNamespace.XLINK.getUri(), "xlink:href", (String) value);
             }
           }
-        } else if (key.equals("url")) {
-          if (value == null || value.equals(JSONObject.NULL)) {
-            propertiesElement.removeAttributeNS(OdfDocumentNamespace.XLINK.getUri(), "href");
-          } else {
-            propertiesElement.setAttributeNS(
-                OdfDocumentNamespace.XLINK.getUri(), "xlink:href", (String) value);
-          }
-        }
       }
       if (noProof != null || language != null) {
         Object newLanguage = language;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
@@ -893,7 +893,7 @@ public class JsonOperationConsumer {
     // DELETING TEXT
     if (parentComponent instanceof TextContainer) {
       int pos = start.optInt(start.length() - 1);
-      ((TextContainer) parentComponent).removeText(pos, pos + 1);
+      ((TextContainer<?>) parentComponent).removeText(pos, pos + 1);
     } else {
       // DELETING COMPONENT
       try {
@@ -919,13 +919,13 @@ public class JsonOperationConsumer {
             TableTableElement tableElement = (TableTableElement) tableComponent.mRootElement;
 
             // WORK AROUND for "UNDO COLUMN WIDTH" problem
-            if (((Table) tableElement.getComponent()).isWidthChangeRequired()) {
+            if (((Table<?>) tableElement.getComponent()).isWidthChangeRequired()) {
               // INSERT COLUMN
               // Returns all TableTableColumn descendants that exist within the tableElement, even
               // within groups, columns and header elements
               OdfTable table = OdfTable.getInstance(tableElement);
               table.removeColumnsByIndex(endPos, deletionCount - 1 + endPos, true);
-              ((Table) tableElement.getComponent()).hasChangedWidth();
+              ((Table<?>) tableElement.getComponent()).hasChangedWidth();
             }
           }
           if (repetition > 1) {
@@ -1249,17 +1249,17 @@ public class JsonOperationConsumer {
       OdfTable table = OdfTable.getInstance(tableElement);
 
       // WORK AROUND for "UNDO COLUMN WIDTH" problem
-      if (!((Table) tableElement.getComponent()).isWidthChangeRequired()) {
+      if (!((Table<?>) tableElement.getComponent()).isWidthChangeRequired()) {
         Table.stashColumnWidths(tableElement);
       }
       table.removeColumnsByIndex(startGrid, endGrid - startGrid + 1);
 
       // WORK AROUND for "UNDO COLUMN WIDTH" problem (see JsonOperationConsumer for further changes)
-      if (((Table) tableElement.getComponent()).isWidthChangeRequired()) {
+      if (((Table<?>) tableElement.getComponent()).isWidthChangeRequired()) {
         JsonOperationConsumer.setColumnsWidth(
             tableElement.getComponent(),
-            ((Table) tableElement.getComponent()).getPosition(),
-            ((Table) tableElement.getComponent()).popTableGrid(),
+            ((Table<?>) tableElement.getComponent()).getPosition(),
+            ((Table<?>) tableElement.getComponent()).popTableGrid(),
             true);
       }
     }
@@ -2983,7 +2983,7 @@ public class JsonOperationConsumer {
           } else {
             endPos = startPos;
           }
-          ((TextContainer) parentComponent).removeText(startPos, endPos);
+          ((TextContainer<?>) parentComponent).removeText(startPos, endPos);
           // LO let the value attribute overrule the content, therefore this value have to vanish!
           OdfElement grandParentElement = (OdfElement) parentComponent.mRootElement.getParentNode();
           if (grandParentElement instanceof TableTableCellElement) {
@@ -3096,7 +3096,7 @@ public class JsonOperationConsumer {
           boolean isTime = currentMap.hasTimeStyle();
           String dateFormat = fieldAttrs.getString("dateFormat");
           OdfOfficeAutomaticStyles autoStyles = contentDom.getOrCreateAutomaticStyles();
-          Iterator styleIter = null;
+          Iterator<? extends OdfElement> styleIter;
           if (isTime) {
             styleIter = autoStyles.getTimeStyles().iterator();
           } else {
@@ -3332,7 +3332,7 @@ public class JsonOperationConsumer {
         try {
           fieldClass = (Class<OdfElement>) Class.forName(currentMap.getClassName());
           if (fieldClass != null) {
-            Class[] types = {OdfFileDom.class};
+            Class<?>[] types = {OdfFileDom.class};
             Constructor<OdfElement> constructor = fieldClass.getConstructor(types);
             newFieldElement = constructor.newInstance(xmlDoc);
           }
@@ -3946,8 +3946,8 @@ public class JsonOperationConsumer {
       }
       if (tableGrid.length() != columnCount) {
         // reuse the width from later caching
-        ((Table) tableElement.getComponent()).pushTableGrid(tableGrid);
-        ((Table) tableElement.getComponent()).requireLaterWidthChange(start);
+        ((Table<?>) tableElement.getComponent()).pushTableGrid(tableGrid);
+        ((Table<?>) tableElement.getComponent()).requireLaterWidthChange(start);
       } else {
         addColumnAndCellElements(
             tableComponent,
@@ -3981,7 +3981,7 @@ public class JsonOperationConsumer {
       int absTableWidth = MapHelper.normalizeLength(tableWidth);
       double relTableWidth = 0.0;
       int columnCount = tableGrid.length();
-      absColumnWidths = new ArrayList(columnCount);
+      absColumnWidths = new ArrayList<>(columnCount);
       for (int i = 0; columnCount > i; i++) {
         relTableWidth += tableGrid.optLong(i);
       }
@@ -4033,7 +4033,7 @@ public class JsonOperationConsumer {
         TableTableElement tableElement = (TableTableElement) parentComponent.mRootElement;
 
         // WORK AROUND for "UNDO COLUMN WIDTH" problem
-        if (!((Table) tableElement.getComponent()).isWidthChangeRequired()) {
+        if (!((Table<?>) tableElement.getComponent()).isWidthChangeRequired()) {
           Table.stashColumnWidths(tableElement);
         }
         // INSERT COLUMN
@@ -4054,11 +4054,11 @@ public class JsonOperationConsumer {
             false);
         // WORK AROUND for "UNDO COLUMN WIDTH" problem (see JsonOperationConsumer for further
         // changes)
-        if (((Table) tableElement.getComponent()).isWidthChangeRequired()) {
+        if (((Table<?>) tableElement.getComponent()).isWidthChangeRequired()) {
           JsonOperationConsumer.setColumnsWidth(
               tableElement.getComponent(),
-              ((Table) tableElement.getComponent()).getPosition(),
-              ((Table) tableElement.getComponent()).popTableGrid(),
+              ((Table<?>) tableElement.getComponent()).getPosition(),
+              ((Table<?>) tableElement.getComponent()).popTableGrid(),
               true);
         }
       } else {
@@ -4391,7 +4391,7 @@ public class JsonOperationConsumer {
     TableTableElement tableElement = (TableTableElement) tableComponent.mRootElement;
     OdfTable table = OdfTable.getInstance(tableElement);
     for (TableTableRowElement rowElement : table.getRowElementList()) {
-      Row rowComponent = (Row) rowElement.getComponent();
+      Row<?> rowComponent = (Row<?>) rowElement.getComponent();
       // if there is no cell at this position, skip this row
       if (cellReferencePosition == null || cellReferencePosition == -1) {
         clonedCellElement =
@@ -4637,7 +4637,7 @@ public class JsonOperationConsumer {
       TableTableElement tableElement = (TableTableElement) tableComponent.mRootElement;
 
       // WORK AROUND for "UNDO COLUMN WIDTH" problem
-      if (((Table) tableElement.getComponent()).isWidthChangeRequired()) {
+      if (((Table<?>) tableElement.getComponent()).isWidthChangeRequired()) {
         // INSERT COLUMN
         // Returns all TableTableColumn descendants that exist within the tableElement, even within
         // groups, columns and header elements
@@ -4647,14 +4647,14 @@ public class JsonOperationConsumer {
         addColumnAndCellElements(
             tableElement.getComponent(),
             start,
-            ((Table) tableElement.getComponent()).popTableGrid(),
+            ((Table<?>) tableElement.getComponent()).popTableGrid(),
             cellPosition,
             INSERT_AFTER,
             -1,
             true,
             existingColumnList,
             true);
-        ((Table) tableElement.getComponent()).hasChangedWidth();
+        ((Table<?>) tableElement.getComponent()).hasChangedWidth();
       }
 
     } else {
@@ -4754,7 +4754,7 @@ public class JsonOperationConsumer {
       } else {
         // IF IT IS A TEXT COMPONENT
         if (parentComponent instanceof TextContainer
-            && ((TextContainer) parentComponent).getChildNode(newPosition) != null) {
+            && ((TextContainer<?>) parentComponent).getChildNode(newPosition) != null) {
           Element parentElement = parentComponent.getRootElement();
           if (parentElement instanceof OdfElement) {
             ((OdfElement) parentElement).insert(newElement, newPosition);
@@ -5014,7 +5014,7 @@ public class JsonOperationConsumer {
       Object language = null;
       Object noProof = null;
 
-      final Iterator keySetIter = attrs.keySet().iterator();
+      final Iterator<String> keySetIter = attrs.keySet().iterator();
       while (keySetIter.hasNext()) {
         final String key = (String) keySetIter.next();
         final Object value = attrs.get(key);
@@ -5403,7 +5403,7 @@ public class JsonOperationConsumer {
   private static void addFontToDocument(String fontName, OdfDocument doc) {
     if (doc != null) {
 
-      Set fontNames = doc.getFontNames();
+      Set<String> fontNames = doc.getFontNames();
       if (fontName != null && !fontName.isEmpty()) {
         if (!fontNames.contains(fontName)) {
           fontNames.add(fontName);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationConsumer.java
@@ -1775,7 +1775,7 @@ public class JsonOperationConsumer {
             if (base.getAttributes().getLength() > 0) {
 
               Map<String, Map<String, String>> allOdfProps =
-                  new HashMap<String, Map<String, String>>();
+                new HashMap<>();
               Map<String, OdfStylePropertiesSet> familyPropertyGroups =
                   Component.getAllStyleGroupingIdProperties(OdfStyleFamily.Text);
               MapHelper.getStyleProperties(paraAutoStyle, familyPropertyGroups, allOdfProps);
@@ -6067,7 +6067,7 @@ public class JsonOperationConsumer {
             Object value = attrs.get(key);
             if (value != null && !value.equals(JSONObject.NULL)) {
               String horBase = (String) value;
-              Map<String, String> relMap = new HashMap<String, String>();
+              Map<String, String> relMap = new HashMap<>();
               relMap.put("margin", "page-start-margin");
               relMap.put("page", "page");
               relMap.put("column", "paragraph");
@@ -6091,7 +6091,7 @@ public class JsonOperationConsumer {
             Object value = attrs.get(key);
             if (value != null && !value.equals(JSONObject.NULL)) {
               String horBase = (String) value;
-              Map<String, String> relMap = new HashMap<String, String>();
+              Map<String, String> relMap = new HashMap<>();
               relMap.put("margin", "page-content");
               relMap.put("page", "page");
               relMap.put("paragraph", "paragraph");

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationNormalizer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationNormalizer.java
@@ -166,19 +166,19 @@ public class JsonOperationNormalizer {
 
   private static Iterator<String> getSortedIterator(JSONObject jsonObject) {
     // have to duplicate set, as the original set is read-only
-    Set<String> keySet = new HashSet<String>(jsonObject.keySet());
+    Set<String> keySet = new HashSet<>(jsonObject.keySet());
     List<String> firstListedKeys = null;
     for (String SORTING_SEQUENCE_OF_KEYS1 : SORTING_SEQUENCE_OF_KEYS) {
       // do not sort 'name' property
       if (keySet.contains(SORTING_SEQUENCE_OF_KEYS1)) {
         if (firstListedKeys == null) {
-          firstListedKeys = new ArrayList<String>(3);
+          firstListedKeys = new ArrayList<>(3);
         }
         firstListedKeys.add(SORTING_SEQUENCE_OF_KEYS1);
         keySet.remove(SORTING_SEQUENCE_OF_KEYS1);
       }
     }
-    List<String> list = new ArrayList<String>(keySet);
+    List<String> list = new ArrayList<>(keySet);
     // sort the remaining keys
     Collections.sort(list);
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
@@ -405,10 +405,10 @@ public class JsonOperationProducer {
   /** */
   public void mergeCells(List<Integer> position, int columns, int rows) {
     final JSONObject newOperation = new JSONObject();
-    List<Integer> rangeStart = new ArrayList<Integer>();
+    List<Integer> rangeStart = new ArrayList<>();
     rangeStart.add(position.get(2));
     rangeStart.add(position.get(1));
-    List<Integer> rangeEnd = new ArrayList<Integer>();
+    List<Integer> rangeEnd = new ArrayList<>();
     rangeEnd.add(position.get(2) + columns - 1);
     rangeEnd.add(position.get(1) + rows - 1);
     try {
@@ -503,7 +503,7 @@ public class JsonOperationProducer {
     if (attrs != null && attrs.size() > 0) {
       // Not the next position, but the last character to be marked will be referenced
       final JSONObject newOp = new JSONObject();
-      List<Integer> lastCharacterPos = new ArrayList<Integer>();
+      List<Integer> lastCharacterPos = new ArrayList<>();
       // text position is usually -1 as we take the first and the last character to be styled
       if (end != null) {
         for (int i = 0; i < end.size(); i++) {
@@ -619,7 +619,7 @@ public class JsonOperationProducer {
         tableAttrs = (JSONObject) hardFormatations.get("table");
       } else {
         if (hardFormatations == null) {
-          hardFormatations = new HashMap<String, Object>();
+          hardFormatations = new HashMap<>();
         }
       }
       if (tableAttrs == null) {
@@ -671,11 +671,11 @@ public class JsonOperationProducer {
       if (context != null) {
         newOperation.put(OPK_CONTEXT, context);
       }
-      Map<String, Integer> sizeExceeded = new HashMap<String, Integer>();
+      Map<String, Integer> sizeExceeded = new HashMap<>();
       sizeExceeded.put("columns", columns);
       sizeExceeded.put("rows", rows);
       newOperation.put("sizeExceeded", sizeExceeded);
-      Map<String, Object> hardFormatations = new HashMap<String, Object>();
+      Map<String, Object> hardFormatations = new HashMap<>();
       JSONObject tableAttrs = new JSONObject();
       //			JSONObject tableAttrs = null;
       //			if (hardFormatations != null && !hardFormatations.isEmpty()) {
@@ -879,7 +879,7 @@ public class JsonOperationProducer {
       } else {
         result = panose1.split("\\s");
       }
-      panose1_Integers = new ArrayList<Integer>();
+      panose1_Integers = new ArrayList<>();
       for (String token : result) {
         try {
           panose1_Integers.add(Integer.parseInt(token));
@@ -1020,8 +1020,8 @@ public class JsonOperationProducer {
         OdfStyleBase style = styleElement.getAutomaticStyle();
 
         // all ODF properties
-        allOdfProps = new HashMap<String, Map<String, String>>();
-        List<OdfStyleBase> parents = new ArrayList<OdfStyleBase>();
+        allOdfProps = new HashMap<>();
+        List<OdfStyleBase> parents = new ArrayList<>();
         parents.add(style);
         OdfStyleBase parent = style.getParentStyle();
         // if automatic style inheritance is possible
@@ -1619,7 +1619,7 @@ public class JsonOperationProducer {
       if (!(style instanceof OdfDefaultStyle)) {
 
         if (!knownStyles.containsKey(((OdfStyle) style).getStyleNameAttribute())) {
-          List<OdfStyleBase> parents = new ArrayList<OdfStyleBase>();
+          List<OdfStyleBase> parents = new ArrayList<>();
           OdfStyleBase parent = style;
 
           // Collecting hierachy, to go back through the style hierarchy from the end, to be able to
@@ -1668,7 +1668,7 @@ public class JsonOperationProducer {
           String lastWrittenStyleName = null; // Only write out parents with mapped styles
           boolean skippedEmptyParent = false;
           // Intermediate ODF properties
-          Map<String, Map<String, String>> allOdfProps = new HashMap<String, Map<String, String>>();
+          Map<String, Map<String, String>> allOdfProps = new HashMap<>();
           // The property groups for this component, e.g. cell, paragraph, text for a cell with
           // properties
           Map<String, OdfStylePropertiesSet> familyPropertyGroups =
@@ -1769,7 +1769,7 @@ public class JsonOperationProducer {
   public Integer triggerDefaultStyleOp(OdfStyleFamily styleFamily, OdfStyleBase style) {
     Integer defaultTabStopWidth = null;
     // Intermediate ODF properties
-    Map<String, Map<String, String>> allOdfProps = new HashMap<String, Map<String, String>>();
+    Map<String, Map<String, String>> allOdfProps = new HashMap<>();
     // The property groups for this component, e.g. cell, paragraph, text for a cell with properties
     Map<String, OdfStylePropertiesSet> familyPropertyGroups =
         Component.getAllStyleGroupingIdProperties(styleFamily);
@@ -1945,7 +1945,7 @@ public class JsonOperationProducer {
   // \u00dcberschreiben kann aber auch die gemappten werte, dann w\u00fcrde man ggf. mehrmals
   // umsonst mappen..
   private Map<String, String> transformMap(Map<OdfStyleProperty, String> props) {
-    Map<String, String> odfProps = new HashMap<String, String>();
+    Map<String, String> odfProps = new HashMap<>();
     for (Map.Entry<OdfStyleProperty, String> entry : props.entrySet()) {
       odfProps.put(entry.getKey().getName().getQName(), entry.getValue());
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/JsonOperationProducer.java
@@ -94,10 +94,10 @@ public class JsonOperationProducer {
   private final JSONObject mDocumentAttributes = new JSONObject();
   /** The maximum empty cell number before starting a new operation */
   /** Every knonwStyle does not have to be read */
-  Map knownStyles = new HashMap<String, Boolean>();
+  Map<String, Boolean> knownStyles = new HashMap<>();
   // Added an own map for list styles as it is not 100% certain that the names between styles and
   // list style might be overlapping.
-  Map knownListStyles = new HashMap<String, Boolean>();
+  Map<String, Boolean> knownListStyles = new HashMap<>();
   /**
    * There is a special style for the replacement table of too large tables, which have to be added
    * only once to a document
@@ -345,7 +345,7 @@ public class JsonOperationProducer {
 
     // the row start/end number 0 based, therefore - 1
     int rowStartNo = firstRow + repeatedRowOffset;
-    List rangeStart = new ArrayList<Integer>();
+    List<Integer> rangeStart = new ArrayList<>();
 
     // if there is a repeated row, there will be repeated cells (at least vertical)
     if (hasHorizontalRepetition || lastRow != null && !firstRow.equals(lastRow)) {
@@ -354,7 +354,7 @@ public class JsonOperationProducer {
       // second the start row position
       rangeStart.add(rowStartNo);
 
-      List rangeEnd = new ArrayList<Integer>();
+      List<Integer> rangeEnd = new ArrayList<>();
 
       // first the end column position: StartPos of content plus any repetiton (including itself,
       // therefore - 1)
@@ -386,7 +386,7 @@ public class JsonOperationProducer {
    *     cell contents for each single row. The lengths of the inner arrays may be different. Cells
    *     not covered by a row array will not be modified.
    */
-  private void setCellContents(Integer sheet, List rangeStart, JSONArray spreadsheetRange) {
+  private void setCellContents(Integer sheet, List<Integer> rangeStart, JSONArray spreadsheetRange) {
     final JSONObject newOperation = new JSONObject();
 
     try {
@@ -694,7 +694,7 @@ public class JsonOperationProducer {
       tableAttrs.put("tableGrid", tableGrid);
       tableAttrs.put("style", "LightShading-Accent1");
       tableAttrs.put("width", "auto");
-      List exclude = new ArrayList(3);
+      List<String> exclude = new ArrayList<>(3);
       exclude.add("lastRow");
       exclude.add("lastCol");
       exclude.add("bandsVert");

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
@@ -182,7 +182,7 @@ public final class MapHelper {
 
   /** see Changes API Color */
   public static Map<String, String> createColorMap(String rgbValue) {
-    Map color = new HashMap<String, String>();
+    Map<String, String> color = new HashMap<>();
     if (rgbValue.contains(HASH)) {
       color.put("type", "rgb");
       rgbValue = rgbValue.subSequence(rgbValue.indexOf('#') + 1, rgbValue.length()).toString();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
@@ -1437,7 +1437,7 @@ public final class MapHelper {
       Map<String, OdfStylePropertiesSet> familyPropertyGroups,
       Map<String, Map<String, String>> allOdfProps) {
 
-    Map<String, Object> allProps = new HashMap<String, Object>();
+    Map<String, Object> allProps = new HashMap<>();
     for (String styleFamilyKey : familyPropertyGroups.keySet()) {
       // NOTE: Perhaps we should first inherit everything from the parents and map afterwards
       // the ODF properties of one family group
@@ -1477,7 +1477,7 @@ public final class MapHelper {
     Map<String, Object> mappedFormatting = null;
     if (style != null) {
       // Intermediate ODF properties
-      Map<String, Map<String, String>> allOdfProps = new HashMap<String, Map<String, String>>();
+      Map<String, Map<String, String>> allOdfProps = new HashMap<>();
       // The property groups for this component, e.g. cell, paragraph, text for a cell with
       // properties
       Map<String, OdfStylePropertiesSet> familyPropertyGroups =
@@ -1507,7 +1507,7 @@ public final class MapHelper {
     if (style != null) {
       for (Entry<String, OdfStylePropertiesSet> entry : familyPropertyGroups.entrySet()) {
         // the ODF properties of one family group
-        Map<String, String> odfProps = new HashMap<String, String>();
+        Map<String, String> odfProps = new HashMap<>();
         OdfStylePropertiesSet key = entry.getValue();
         OdfStylePropertiesBase propsElement = style.getPropertiesElement(key);
         if (propsElement != null) {
@@ -1734,7 +1734,7 @@ public final class MapHelper {
           }
           jsonStyleProperties.put("cell", jsonCellProps);
         } else {
-          Map<String, String> stringCellProps = new HashMap<String, String>();
+          Map<String, String> stringCellProps = new HashMap<>();
           if (stringProperties.containsKey("cell")) {
             stringCellProps = stringProperties.get("cell");
           }
@@ -2155,8 +2155,8 @@ public final class MapHelper {
 
   private static void fillLocaleMaps() {
     if (localeToLanguageMap == null) {
-      localeToLanguageMap = new HashMap<String, Integer>();
-      languageToLocaleMap = new HashMap<Integer, String>();
+      localeToLanguageMap = new HashMap<>();
+      languageToLocaleMap = new HashMap<>();
 
       class StringAndInt {
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/MapHelper.java
@@ -100,8 +100,7 @@ public final class MapHelper {
         boolean checkedColor = false;
         boolean checkedStyle = false;
         boolean checkedWidth = false;
-        for (int i = 0; i < tokens.length; i++) {
-          String token = tokens[i];
+        for (String token : tokens) {
           if (!token.isEmpty()) {
             boolean isTokenTaken = false;
             if (!checkedColor) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ShapeProperties.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/ShapeProperties.java
@@ -66,9 +66,9 @@ public class ShapeProperties extends CachedComponent {
   //        }
   public ShapeProperties(List<Integer> start, Map<String, Object> hardFormatations) {
     // Maps are being reused, for upcoming components, therefore the collections have to be cloned
-    mShapePosition = new ArrayList<Integer>(start);
+    mShapePosition = new ArrayList<>(start);
     if (hardFormatations != null) {
-      mShapeHardFormatations = new HashMap<String, Object>();
+      mShapeHardFormatations = new HashMap<>();
       mShapeHardFormatations.putAll(hardFormatations);
       JSONObject originalDrawingProps = (JSONObject) hardFormatations.get("drawing");
       // Unfortunately the JSON lib being used, does not support deep cloning

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
@@ -97,7 +97,7 @@ public class Table<T> extends Component {
 
   // Svante ToDo: After all the refactoring this looks like something to change after the release as
   // well.
-  private List<Component> list(final Table tableComponent) {
+  private List<Component> list(final Table<?> tableComponent) {
     return new AbstractList<>() {
       @Override
       public int size() {
@@ -218,7 +218,7 @@ public class Table<T> extends Component {
     boolean hasRelColumnWidth = false;
     boolean hasAbsColumnWidth = false;
     boolean hasColumnWithoutWidth = false;
-    List<Integer> columnRelWidths = new ArrayList();
+    List<Integer> columnRelWidths = new ArrayList<>();
     for (TableTableColumnElement column : columns) {
       if (column.hasAttributeNS(OdfDocumentNamespace.TABLE.getUri(), "style-name")) {
         Length tableWidth = getPropertyLength(StyleTablePropertiesElement.Width, tableElement);
@@ -296,20 +296,20 @@ public class Table<T> extends Component {
     List<TableTableColumnElement> existingColumnList =
         Table.getTableColumnElements(tableElement, new ArrayList<TableTableColumnElement>());
     List<Integer> tableColumWidths = collectColumnWidths(tableElement, existingColumnList);
-    ((Table) tableElement.getComponent()).pushTableGrid(tableColumWidths);
+    ((Table<?>) tableElement.getComponent()).pushTableGrid(tableColumWidths);
   }
 
   /**
    * Returns all TableTableColumn descendants that exist within the tableElement, even within
    * groups, columns and header elements
    */
-  public static List<TableTableColumnElement> getTableColumnElements(Element parent, List columns) {
+  public static List<TableTableColumnElement> getTableColumnElements(Element parent, List<TableTableColumnElement> columns) {
     NodeList children = parent.getChildNodes();
     for (int i = 0; i < children.getLength(); i++) {
       Node child = children.item(i);
       if (child instanceof Element) {
         if (child instanceof TableTableColumnElement) {
-          columns.add(child);
+          columns.add((TableTableColumnElement) child);
         } else if (child instanceof TableTableColumnGroupElement
             || child instanceof TableTableHeaderColumnsElement
             || child instanceof TableTableColumnsElement) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
@@ -98,7 +98,7 @@ public class Table<T> extends Component {
   // Svante ToDo: After all the refactoring this looks like something to change after the release as
   // well.
   private List<Component> list(final Table tableComponent) {
-    return new AbstractList<Component>() {
+    return new AbstractList<>() {
       @Override
       public int size() {
         return tableComponent.size();
@@ -333,7 +333,7 @@ public class Table<T> extends Component {
   /** OH PLEASE DELETE ME AFTER THE API WAS FIXED */
   public void pushTableGrid(JSONArray tableGrid) {
     if (mColumnWidthCache == null) {
-      mColumnWidthCache = new ArrayList<JSONArray>();
+      mColumnWidthCache = new ArrayList<>();
     }
     mColumnWidthCache.add(tableGrid);
   }
@@ -373,7 +373,7 @@ public class Table<T> extends Component {
 
   public void replaceLastTableGrid(JSONArray tableGrid) {
     if (mColumnWidthCache == null) {
-      mColumnWidthCache = new ArrayList<JSONArray>();
+      mColumnWidthCache = new ArrayList<>();
       mColumnWidthCache.add(tableGrid);
     } else if (mColumnWidthCache.size() > 0) {
       mColumnWidthCache.remove(mColumnWidthCache.size() - 1);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/Table.java
@@ -294,7 +294,7 @@ public class Table<T> extends Component {
 
   static void stashColumnWidths(TableTableElement tableElement) {
     List<TableTableColumnElement> existingColumnList =
-        Table.getTableColumnElements(tableElement, new ArrayList<TableTableColumnElement>());
+        Table.getTableColumnElements(tableElement, new ArrayList<>());
     List<Integer> tableColumWidths = collectColumnWidths(tableElement, existingColumnList);
     ((Table<?>) tableElement.getComponent()).pushTableGrid(tableColumWidths);
   }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextContainingElement.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextContainingElement.java
@@ -125,9 +125,8 @@ public abstract class TextContainingElement extends OdfStylableElement {
               mSelections.subSet(outerSelection, true, outerSelection, true);
           if (equalSet.size() < 2) {
             TextSelection innerSelection;
-            Iterator<TextSelection> it = equalSet.iterator();
-            while (it.hasNext()) {
-              innerSelection = it.next();
+            for (TextSelection textSelection : equalSet) {
+              innerSelection = textSelection;
               if (innerSelection.mSelectionElement instanceof TextSpanElement) {
                 if (innerSelection.getURL() == null) {
                   innerSelection.setURL(url);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextFieldSelection.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/changes/TextFieldSelection.java
@@ -30,7 +30,7 @@ import org.odftoolkit.odfdom.pkg.OdfElement;
 public class TextFieldSelection extends TextSelection {
 
   private String mReplacementText;
-  private final Map<String, Object> mAttrs = new HashMap<String, Object>();
+  private final Map<String, Object> mAttrs = new HashMap<>();
 
   /**
    * Constructor.

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfDocument.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -882,8 +881,8 @@ public abstract class OdfDocument extends OdfSchemaDocument {
     try {
       List<TableTableElement> tableElementList = getTables(doRecursiveSearch);
       tableList = new ArrayList<>(tableElementList.size());
-      for (int i = 0; i < tableElementList.size(); i++) {
-        tableList.add(OdfTable.getInstance(tableElementList.get(i)));
+      for (TableTableElement tableTableElement : tableElementList) {
+        tableList.add(OdfTable.getInstance(tableTableElement));
       }
     } catch (Exception e) {
       LOG.log(Level.SEVERE, null, e);
@@ -1122,10 +1121,7 @@ public abstract class OdfDocument extends OdfSchemaDocument {
     }
     // if no default style setting for paragraph
     // get language and country setting from other default style settings
-    Iterable<OdfDefaultStyle> defaultStyles = styles.getDefaultStyles();
-    Iterator<OdfDefaultStyle> itera = defaultStyles.iterator();
-    while (itera.hasNext()) {
-      OdfDefaultStyle style = itera.next();
+    for (OdfDefaultStyle style : styles.getDefaultStyles()) {
       if (style.hasProperty(countryProp) && style.hasProperty(languageProp)) {
         ctry = style.getProperty(countryProp);
         lang = style.getProperty(languageProp);
@@ -1146,9 +1142,7 @@ public abstract class OdfDocument extends OdfSchemaDocument {
     OdfOfficeStyles styles = getStylesDom().getOfficeStyles();
     Iterable<OdfDefaultStyle> defaultStyles = styles.getDefaultStyles();
     if (defaultStyles != null) {
-      Iterator<OdfDefaultStyle> itera = defaultStyles.iterator();
-      while (itera.hasNext()) {
-        OdfDefaultStyle style = itera.next();
+      for (OdfDefaultStyle style : defaultStyles) {
         if (style.getFamily().getProperties().contains(OdfTextProperties.Language)) {
           style.setProperty(OdfTextProperties.Language, locale.getLanguage());
           style.setProperty(OdfTextProperties.Country, locale.getCountry());
@@ -1170,9 +1164,7 @@ public abstract class OdfDocument extends OdfSchemaDocument {
     OdfOfficeStyles styles = getStylesDom().getOfficeStyles();
     Iterable<OdfDefaultStyle> defaultStyles = styles.getDefaultStyles();
     if (defaultStyles != null) {
-      Iterator<OdfDefaultStyle> itera = defaultStyles.iterator();
-      while (itera.hasNext()) {
-        OdfDefaultStyle style = itera.next();
+      for (OdfDefaultStyle style : defaultStyles) {
         if (style.getFamily().getProperties().contains(OdfTextProperties.LanguageAsian)) {
           style.setProperty(OdfTextProperties.LanguageAsian, locale.getLanguage());
           style.setProperty(OdfTextProperties.CountryAsian, locale.getCountry());
@@ -1193,9 +1185,7 @@ public abstract class OdfDocument extends OdfSchemaDocument {
     OdfOfficeStyles styles = getStylesDom().getOfficeStyles();
     Iterable<OdfDefaultStyle> defaultStyles = styles.getDefaultStyles();
     if (defaultStyles != null) {
-      Iterator<OdfDefaultStyle> itera = defaultStyles.iterator();
-      while (itera.hasNext()) {
-        OdfDefaultStyle style = itera.next();
+      for (OdfDefaultStyle style : defaultStyles) {
         if (style.getFamily().getProperties().contains(OdfTextProperties.LanguageComplex)) {
           style.setProperty(OdfTextProperties.LanguageComplex, locale.getLanguage());
           style.setProperty(OdfTextProperties.CountryComplex, locale.getCountry());

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfDocument.java
@@ -594,7 +594,7 @@ public abstract class OdfDocument extends OdfSchemaDocument {
     if (desiredMediaType != null) {
       wantedMediaString = desiredMediaType.getMediaTypeString();
     }
-    Map<String, OdfDocument> embeddedObjectsMap = new HashMap<String, OdfDocument>();
+    Map<String, OdfDocument> embeddedObjectsMap = new HashMap<>();
     // check manifest for current embedded OdfPackageDocuments
     Set<String> manifestEntries = mPackage.getFilePaths();
     for (String path : manifestEntries) {
@@ -881,7 +881,7 @@ public abstract class OdfDocument extends OdfSchemaDocument {
     List<OdfTable> tableList = null;
     try {
       List<TableTableElement> tableElementList = getTables(doRecursiveSearch);
-      tableList = new ArrayList<OdfTable>(tableElementList.size());
+      tableList = new ArrayList<>(tableElementList.size());
       for (int i = 0; i < tableElementList.size(); i++) {
         tableList.add(OdfTable.getInstance(tableElementList.get(i)));
       }
@@ -1213,14 +1213,14 @@ public abstract class OdfDocument extends OdfSchemaDocument {
    */
   public Set<String> getFontNames() {
     if (mFontNames == null) {
-      mFontNames = new HashSet<String>();
+      mFontNames = new HashSet<>();
     }
     return mFontNames;
   }
 
   public void addAnnotation(String name, OfficeAnnotationElement element) {
     if (annotations == null) {
-      annotations = new HashMap<String, OfficeAnnotationElement>();
+      annotations = new HashMap<>();
     }
     annotations.put(name, element);
   }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
@@ -466,8 +466,8 @@ public class OdfPresentationDocument extends OdfDocument {
           }
         }
       }
-      for (int i = 0; i < removeStyles.size(); i++) {
-        autoStyles.removeChild(removeStyles.get(i));
+      for (OdfElement removeStyle : removeStyles) {
+        autoStyles.removeChild(removeStyle);
       }
     } catch (Exception e) {
       LOG.log(Level.SEVERE, null, e);
@@ -957,15 +957,14 @@ public class OdfPresentationDocument extends OdfDocument {
             newStyleNameList.add(newStyleName);
             styleRenameMap.put(styleName, newStyleNameList);
           } else {
-            for (int i = 0; i < newStyleNameList.size(); i++) {
-              String styleNameIter = newStyleNameList.get(i);
+            for (String styleNameIter : newStyleNameList) {
               OdfElement destStyleElementWithNewName =
-                  isStyleNameExist(destStyleNodeList, styleNameIter);
+                isStyleNameExist(destStyleNodeList, styleNameIter);
               // check if the two style elements have the same content
               // if not, the cloneStyleElement should rename, rather than reuse the new style name
               cloneStyleElement.setAttributeNS(styleURI, styleQName, styleNameIter);
               if ((destStyleElementWithNewName != null)
-                  && destStyleElementWithNewName.equals(cloneStyleElement)) {
+                && destStyleElementWithNewName.equals(cloneStyleElement)) {
                 newStyleName = styleNameIter;
                 break;
               }
@@ -1178,8 +1177,7 @@ public class OdfPresentationDocument extends OdfDocument {
   private boolean changeStyleRefName(
       List<OdfElement> list, String oldStyleName, String newStyleName) {
     boolean rtn = false;
-    for (int index = 0; index < list.size(); index++) {
-      OdfElement element = list.get(index);
+    for (OdfElement element : list) {
       NamedNodeMap attributes = element.getAttributes();
 
       if (attributes != null) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/OdfPresentationDocument.java
@@ -229,9 +229,9 @@ public class OdfPresentationDocument extends OdfDocument {
   // while if the style elements really have the same style name but with different content
   // such as that these style elements are from different document
   // so the value for each key should be a list
-  private Map<String, List<String>> styleRenameMap = new HashMap<String, List<String>>();
+  private Map<String, List<String>> styleRenameMap = new HashMap<>();
   // the map is used to record if the renamed style name is appended to the current dom
-  private Map<String, Boolean> styleAppendMap = new HashMap<String, Boolean>();
+  private Map<String, Boolean> styleAppendMap = new HashMap<>();
   // the object rename map for image.
   // can not easily recognize if the embedded document are the same.
   //	private Map<String, String> objectRenameMap = new HashMap<String, String>();
@@ -323,7 +323,7 @@ public class OdfPresentationDocument extends OdfDocument {
     if (hasCheckSlideName) {
       return;
     }
-    List<String> slideNameList = new ArrayList<String>();
+    List<String> slideNameList = new ArrayList<>();
     OfficePresentationElement contentRoot = null;
     try {
       contentRoot = getContentRoot();
@@ -359,7 +359,7 @@ public class OdfPresentationDocument extends OdfDocument {
       LOG.log(Level.SEVERE, null, e);
       return null;
     }
-    ArrayList<OdfSlide> slideList = new ArrayList<OdfSlide>();
+    ArrayList<OdfSlide> slideList = new ArrayList<>();
     NodeList slideNodes =
         contentRoot.getElementsByTagNameNS(OdfDocumentNamespace.DRAW.getUri(), "page");
     for (int i = 0; i < slideNodes.getLength(); i++) {
@@ -416,7 +416,7 @@ public class OdfPresentationDocument extends OdfDocument {
       ////////////////
       // method 2:
       // 2.1. get the list of the style definition
-      ArrayList<OdfElement> removeStyles = new ArrayList<OdfElement>();
+      ArrayList<OdfElement> removeStyles = new ArrayList<>();
       OdfOfficeAutomaticStyles autoStyles = getContentDom().getAutomaticStyles();
 
       NodeList stylesList = autoStyles.getChildNodes();
@@ -751,7 +751,7 @@ public class OdfPresentationDocument extends OdfDocument {
       OdfPackageDocument srcDoc = fileDom.getDocument();
       // new a map to put the original name and the rename string, in case that the same name might
       // be referred by the slide several times.
-      HashMap<String, String> objectRenameMap = new HashMap<String, String>();
+      HashMap<String, String> objectRenameMap = new HashMap<>();
       NodeList linkNodes =
           (NodeList) xpath.evaluate(".//*[@xlink:href]", sourceCloneEle, XPathConstants.NODESET);
       for (int i = 0; i <= linkNodes.getLength(); i++) {
@@ -831,9 +831,9 @@ public class OdfPresentationDocument extends OdfDocument {
       NodeList srcStyleDefNodeList =
           (NodeList) xpath.evaluate("//*[@" + styleQName + "]", contentDom, XPathConstants.NODESET);
       HashMap<OdfElement, List<OdfElement>> srcContentStyleCloneEleList =
-          new HashMap<OdfElement, List<OdfElement>>();
+        new HashMap<>();
       HashMap<OdfElement, OdfElement> appendContentStyleList =
-          new HashMap<OdfElement, OdfElement>();
+        new HashMap<>();
       getCopyStyleList(
           null,
           sourceCloneEle,
@@ -848,8 +848,8 @@ public class OdfPresentationDocument extends OdfDocument {
               xpath.evaluate(
                   "//*[@" + styleQName + "]", doc.getStylesDom(), XPathConstants.NODESET);
       HashMap<OdfElement, List<OdfElement>> srcStylesStyleCloneEleList =
-          new HashMap<OdfElement, List<OdfElement>>();
-      HashMap<OdfElement, OdfElement> appendStylesStyleList = new HashMap<OdfElement, OdfElement>();
+        new HashMap<>();
+      HashMap<OdfElement, OdfElement> appendStylesStyleList = new HashMap<>();
       getCopyStyleList(
           null,
           sourceCloneEle,
@@ -877,8 +877,8 @@ public class OdfPresentationDocument extends OdfDocument {
               xpath.evaluate(
                   "//*[@" + styleQName + "]", doc.getStylesDom(), XPathConstants.NODESET);
       HashMap<OdfElement, List<OdfElement>> srcDrawStyleCloneEleList =
-          new HashMap<OdfElement, List<OdfElement>>();
-      HashMap<OdfElement, OdfElement> appendDrawStyleList = new HashMap<OdfElement, OdfElement>();
+        new HashMap<>();
+      HashMap<OdfElement, OdfElement> appendDrawStyleList = new HashMap<>();
       Iterator<OdfElement> iter = appendContentStyleList.keySet().iterator();
       while (iter.hasNext()) {
         OdfElement styleElement = iter.next();
@@ -952,7 +952,7 @@ public class OdfPresentationDocument extends OdfDocument {
             || (isStyleNameExist(destStyleNodeList, styleName) != null)) {
           String newStyleName = null;
           if (newStyleNameList == null) {
-            newStyleNameList = new ArrayList<String>();
+            newStyleNameList = new ArrayList<>();
             newStyleName = styleName + "-" + makeUniqueName();
             newStyleNameList.add(newStyleName);
             styleRenameMap.put(styleName, newStyleNameList);
@@ -1077,7 +1077,7 @@ public class OdfPresentationDocument extends OdfDocument {
               }
               boolean hasLoopStyleDef = true;
               if (copyStyleEleList.get(styleElement) == null) {
-                List<OdfElement> styleRefEleList = new ArrayList<OdfElement>();
+                List<OdfElement> styleRefEleList = new ArrayList<>();
                 copyStyleEleList.put(styleElement, styleRefEleList);
                 hasLoopStyleDef = false;
               }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/presentation/OdfPresentationNotes.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/presentation/OdfPresentationNotes.java
@@ -35,7 +35,7 @@ import org.w3c.dom.NodeList;
 public class OdfPresentationNotes {
   PresentationNotesElement maNoteElement;
   private static Hashtable<PresentationNotesElement, OdfPresentationNotes> maNotesRepository =
-      new Hashtable<PresentationNotesElement, OdfPresentationNotes>();
+          new Hashtable<>();
 
   private OdfPresentationNotes(PresentationNotesElement noteElement) {
     maNoteElement = noteElement;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/presentation/OdfSlide.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/presentation/OdfSlide.java
@@ -39,7 +39,7 @@ public class OdfSlide {
 
   DrawPageElement maSlideElement;
   private static Hashtable<DrawPageElement, OdfSlide> maSlideRepository =
-      new Hashtable<DrawPageElement, OdfSlide>();
+    new Hashtable<>();
 
   private OdfSlide(DrawPageElement pageElement) {
     maSlideElement = pageElement;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
@@ -129,11 +129,11 @@ public class OdfTable {
     if (mCellRepository.containsKey(cell)) {
       Vector<OdfTableCell> list = mCellRepository.get(cell);
       OdfTableCell fCell = null;
-      for (int i = 0; i < list.size(); i++) {
-        if (list.get(i).getOdfElement() == cell
-            && list.get(i).mnRepeatedColIndex == repeatedColIndex
-            && list.get(i).mnRepeatedRowIndex == repeatedRowIndex) {
-          fCell = list.get(i);
+      for (OdfTableCell odfTableCell : list) {
+        if (odfTableCell.getOdfElement() == cell
+          && odfTableCell.mnRepeatedColIndex == repeatedColIndex
+          && odfTableCell.mnRepeatedRowIndex == repeatedRowIndex) {
+          fCell = odfTableCell;
           break;
         }
       }
@@ -591,8 +591,8 @@ public class OdfTable {
 
     while (notUnique) {
       notUnique = false;
-      for (int i = 0; i < tableList.size(); i++) {
-        if (tableList.get(i).getTableNameAttribute().equalsIgnoreCase(tablename)) {
+      for (TableTableElement tableTableElement : tableList) {
+        if (tableTableElement.getTableNameAttribute().equalsIgnoreCase(tablename)) {
           notUnique = true;
           break;
         }
@@ -1912,12 +1912,11 @@ public class OdfTable {
     // check if the table name is already exist
     boolean isSpreadsheet = mDocument instanceof OdfSpreadsheetDocument;
     List<OdfTable> tableList = mDocument.getTableList(!isSpreadsheet);
-    for (int i = 0; i < tableList.size(); i++) {
-      OdfTable table = tableList.get(i);
+    for (OdfTable table : tableList) {
       if (tableName.equals(table.getTableName())) {
         if (table != this) {
           throw new IllegalArgumentException(
-              "The table name is duplicate with one of tables in the current document.");
+            "The table name is duplicate with one of tables in the current document.");
         }
       }
     }
@@ -2218,20 +2217,20 @@ public class OdfTable {
       OdfTableCell cell = getCellByPosition(nCol, nRow);
       return cell;
     } else {
-      for (int m = 0; m < coverList.size(); m++) {
-        info = coverList.get(m);
+      for (CellCoverInfo cellCoverInfo : coverList) {
+        info = cellCoverInfo;
         if (((nCol > info.nStartCol)
-                && (nCol <= info.nEndCol)
-                && (nRow == info.nStartRow)
-                && (nRow == info.nEndRow))
-            || ((nCol == info.nStartCol)
-                && (nCol == info.nEndCol)
-                && (nRow > info.nStartRow)
-                && (nRow <= info.nEndRow))
-            || ((nCol > info.nStartCol)
-                && (nCol <= info.nEndCol)
-                && (nRow > info.nStartRow)
-                && (nRow <= info.nEndRow))) {
+          && (nCol <= info.nEndCol)
+          && (nRow == info.nStartRow)
+          && (nRow == info.nEndRow))
+          || ((nCol == info.nStartCol)
+          && (nCol == info.nEndCol)
+          && (nRow > info.nStartRow)
+          && (nRow <= info.nEndRow))
+          || ((nCol > info.nStartCol)
+          && (nCol <= info.nEndCol)
+          && (nRow > info.nStartRow)
+          && (nRow <= info.nEndRow))) {
           OdfTableCell cell = getCellByPosition(info.nStartCol, info.nStartRow);
           return cell;
         }
@@ -2243,20 +2242,20 @@ public class OdfTable {
   // the parameter is the column/row index in the ownerTable,rather than in the cell range
   boolean isCoveredCellInOwnerTable(List<CellCoverInfo> coverList, int nCol, int nRow) {
     CellCoverInfo info;
-    for (int m = 0; m < coverList.size(); m++) {
-      info = coverList.get(m);
+    for (CellCoverInfo cellCoverInfo : coverList) {
+      info = cellCoverInfo;
       if (((nCol > info.nStartCol)
-              && (nCol <= info.nEndCol)
-              && (nRow == info.nStartRow)
-              && (nRow == info.nEndRow))
-          || ((nCol == info.nStartCol)
-              && (nCol == info.nEndCol)
-              && (nRow > info.nStartRow)
-              && (nRow <= info.nEndRow))
-          || ((nCol > info.nStartCol)
-              && (nCol <= info.nEndCol)
-              && (nRow > info.nStartRow)
-              && (nRow <= info.nEndRow))) // covered cell
+        && (nCol <= info.nEndCol)
+        && (nRow == info.nStartRow)
+        && (nRow == info.nEndRow))
+        || ((nCol == info.nStartCol)
+        && (nCol == info.nEndCol)
+        && (nRow > info.nStartRow)
+        && (nRow <= info.nEndRow))
+        || ((nCol > info.nStartCol)
+        && (nCol <= info.nEndCol)
+        && (nRow > info.nStartRow)
+        && (nRow <= info.nEndRow))) // covered cell
       {
         return true;
       }
@@ -2405,8 +2404,7 @@ public class OdfTable {
               }
 
               // update the mnRepeatedRowIndex of the cell which locate after the removed row
-              for (int j = 0; j < updateCellList.size(); j++) {
-                OdfTableCell cell = updateCellList.get(j);
+              for (OdfTableCell cell : updateCellList) {
                 if (cell.mnRepeatedRowIndex > oldRepeatIndex) {
                   cell.mnRepeatedRowIndex--;
                 }
@@ -2445,11 +2443,11 @@ public class OdfTable {
     if (mCellRepository.containsKey(oldElement)) {
       OdfTableCell oldCell = null;
       Vector<OdfTableCell> oldList = mCellRepository.get(oldElement);
-      for (int i = 0; i < oldList.size(); i++) {
-        if (oldList.get(i).getOdfElement() == oldElement
-            && oldList.get(i).mnRepeatedColIndex == oldRepeatColIndex
-            && oldList.get(i).mnRepeatedRowIndex == oldRepeatRowIndex) {
-          oldCell = oldList.get(i);
+      for (OdfTableCell odfTableCell : oldList) {
+        if (odfTableCell.getOdfElement() == oldElement
+          && odfTableCell.mnRepeatedColIndex == oldRepeatColIndex
+          && odfTableCell.mnRepeatedRowIndex == oldRepeatRowIndex) {
+          oldCell = odfTableCell;
           break;
         }
       }
@@ -2458,11 +2456,10 @@ public class OdfTable {
         if (oldCell != null) {
           // update the mnRepeateRowIndex &  mnRepeateColIndex of the cell which locate after the
           // removed cell
-          for (int i = 0; i < oldList.size(); i++) {
-            OdfTableCell cell = oldList.get(i);
+          for (OdfTableCell cell : oldList) {
             if (cell != null && (cell.getOdfElement() == oldElement)) {
               if ((cell.mnRepeatedRowIndex == oldRepeatRowIndex)
-                  && (cell.mnRepeatedColIndex > oldRepeatColIndex)) {
+                && (cell.mnRepeatedColIndex > oldRepeatColIndex)) {
                 cell.mnRepeatedColIndex--;
               }
             }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTable.java
@@ -90,11 +90,11 @@ public class OdfTable {
   private static final String DEFAULT_TABLE_ALIGN = "margins";
 
   IdentityHashMap<TableTableCellElementBase, Vector<OdfTableCell>> mCellRepository =
-      new IdentityHashMap<TableTableCellElementBase, Vector<OdfTableCell>>();
+    new IdentityHashMap<>();
   IdentityHashMap<TableTableRowElement, Vector<OdfTableRow>> mRowRepository =
-      new IdentityHashMap<TableTableRowElement, Vector<OdfTableRow>>();
+    new IdentityHashMap<>();
   IdentityHashMap<TableTableColumnElement, Vector<OdfTableColumn>> mColumnRepository =
-      new IdentityHashMap<TableTableColumnElement, Vector<OdfTableColumn>>();
+    new IdentityHashMap<>();
 
   private OdfTable(TableTableElement table) {
     mTableElement = table;
@@ -144,7 +144,7 @@ public class OdfTable {
       return fCell;
     } else {
       OdfTableCell newCell = new OdfTableCell(cell, repeatedColIndex, repeatedRowIndex);
-      Vector<OdfTableCell> list = new Vector<OdfTableCell>();
+      Vector<OdfTableCell> list = new Vector<>();
       list.add(newCell);
       mCellRepository.put(cell, list);
       return newCell;
@@ -166,7 +166,7 @@ public class OdfTable {
     } else {
       OdfTableRow newCell = new OdfTableRow(row, repeatedRowIndex);
       int size = (repeatedRowIndex > 7) ? (repeatedRowIndex + 1) : 8;
-      Vector<OdfTableRow> list = new Vector<OdfTableRow>(size);
+      Vector<OdfTableRow> list = new Vector<>(size);
       list.setSize(repeatedRowIndex + 1);
       list.set(repeatedRowIndex, newCell);
       mRowRepository.put(row, list);
@@ -189,7 +189,7 @@ public class OdfTable {
     } else {
       OdfTableColumn newCell = new OdfTableColumn(col, repeatedColIndex);
       int size = (repeatedColIndex > 7) ? (repeatedColIndex + 1) : 8;
-      Vector<OdfTableColumn> list = new Vector<OdfTableColumn>(size);
+      Vector<OdfTableColumn> list = new Vector<>(size);
       list.setSize(repeatedColIndex + 1);
       list.set(repeatedColIndex, newCell);
       mColumnRepository.put(col, list);
@@ -1070,7 +1070,7 @@ public class OdfTable {
   }
 
   List<OdfTableRow> appendRows(int rowCount, boolean isCleanStyle) {
-    List<OdfTableRow> resultList = new ArrayList<OdfTableRow>();
+    List<OdfTableRow> resultList = new ArrayList<>();
     if (rowCount <= 0) {
       return resultList;
     }
@@ -1177,7 +1177,7 @@ public class OdfTable {
   }
 
   List<OdfTableColumn> appendColumns(int columnCount, boolean isCleanStyle) {
-    List<OdfTableColumn> resultList = new ArrayList<OdfTableColumn>();
+    List<OdfTableColumn> resultList = new ArrayList<>();
     if (columnCount <= 0) {
       return resultList;
     }
@@ -1204,7 +1204,7 @@ public class OdfTable {
   /** This method is to insert a numbers of row */
   private List<OdfTableRow> insertMultipleRowBefore(
       OdfTableRow refRow, OdfTableRow positionRow, int count) {
-    List<OdfTableRow> resultList = new ArrayList<OdfTableRow>();
+    List<OdfTableRow> resultList = new ArrayList<>();
     int j = 1;
 
     if (count <= 0) {
@@ -1342,7 +1342,7 @@ public class OdfTable {
    */
   public List<OdfTableColumn> insertColumnsBefore(int index, int columnCount) {
     OdfTableColumn refColumn, positionCol;
-    ArrayList<OdfTableColumn> list = new ArrayList<OdfTableColumn>();
+    ArrayList<OdfTableColumn> list = new ArrayList<>();
     int columncount = getColumnCount();
 
     if (index >= columncount) {
@@ -1534,7 +1534,7 @@ public class OdfTable {
       throw new IndexOutOfBoundsException();
     }
 
-    ArrayList<OdfTableRow> list = new ArrayList<OdfTableRow>();
+    ArrayList<OdfTableRow> list = new ArrayList<>();
 
     if (index == 0) {
       OdfTableRow refRow = getRowByIndex(index);
@@ -1583,7 +1583,7 @@ public class OdfTable {
    * @return a list of table columns
    */
   public List<OdfTableColumn> getColumnList() {
-    ArrayList<OdfTableColumn> list = new ArrayList<OdfTableColumn>();
+    ArrayList<OdfTableColumn> list = new ArrayList<>();
     TableTableColumnElement colEle = null;
     for (Node n : new DomNodeList(mTableElement.getChildNodes())) {
       if (n instanceof TableTableHeaderColumnsElement) {
@@ -1613,7 +1613,7 @@ public class OdfTable {
    * @return a list of table rows
    */
   public List<OdfTableRow> getRowList() {
-    ArrayList<OdfTableRow> list = new ArrayList<OdfTableRow>();
+    ArrayList<OdfTableRow> list = new ArrayList<>();
     TableTableRowElement rowEle = null;
     for (Node n : new DomNodeList(mTableElement.getChildNodes())) {
       if (n instanceof TableTableHeaderRowsElement) {
@@ -1643,7 +1643,7 @@ public class OdfTable {
    * @return a list of table rows
    */
   public List<TableTableRowElement> getRowElementList() {
-    ArrayList<TableTableRowElement> list = new ArrayList<TableTableRowElement>();
+    ArrayList<TableTableRowElement> list = new ArrayList<>();
     TableTableRowElement rowEle = null;
     for (Node n : new DomNodeList(mTableElement.getChildNodes())) {
       if (n instanceof TableTableHeaderRowsElement) {
@@ -2265,7 +2265,7 @@ public class OdfTable {
   }
 
   List<CellCoverInfo> getCellCoverInfos(int nStartCol, int nStartRow, int nEndCol, int nEndRow) {
-    List<CellCoverInfo> coverList = new ArrayList<CellCoverInfo>();
+    List<CellCoverInfo> coverList = new ArrayList<>();
     int nColSpan, nRowSpan;
     for (int i = nStartRow; i < nEndRow + 1; ) {
       OdfTableRow row = getRowByIndex(i);
@@ -2319,7 +2319,7 @@ public class OdfTable {
               oldColumn.maColumnElement = newElement;
               oldColumn.mnRepeatedIndex = newRepeatIndex;
               int size = (newRepeatIndex > 7) ? (newRepeatIndex + 1) : 8;
-              Vector<OdfTableColumn> list = new Vector<OdfTableColumn>(size);
+              Vector<OdfTableColumn> list = new Vector<>(size);
               list.setSize(newRepeatIndex + 1);
               list.set(newRepeatIndex, oldColumn);
               mColumnRepository.put(newElement, list);
@@ -2358,7 +2358,7 @@ public class OdfTable {
         if (oldElement != newElement) {
           // the new row replace the old row
           OdfTableRow oldRow = oldList.get(oldRepeatIndex);
-          Vector<OdfTableCell> updateCellList = new Vector<OdfTableCell>();
+          Vector<OdfTableCell> updateCellList = new Vector<>();
           if (oldRow != null) {
             // update the mnRepeateIndex of the row which locate after the removed row
             for (int i = oldRepeatIndex + 1; i < oldList.size(); i++) {
@@ -2385,7 +2385,7 @@ public class OdfTable {
               oldRow.maRowElement = newElement;
               oldRow.mnRepeatedIndex = newRepeatIndex;
               int size = (newRepeatIndex > 7) ? (newRepeatIndex + 1) : 8;
-              Vector<OdfTableRow> list = new Vector<OdfTableRow>(size);
+              Vector<OdfTableRow> list = new Vector<>(size);
               list.setSize(newRepeatIndex + 1);
               list.set(newRepeatIndex, oldRow);
               mRowRepository.put(newElement, list);
@@ -2495,7 +2495,7 @@ public class OdfTable {
                 list.add(oldCell);
               }
             } else {
-              list = new Vector<OdfTableCell>();
+              list = new Vector<>();
               list.add(oldCell);
               mCellRepository.put(newElement, list);
             }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableCellRange.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableCellRange.java
@@ -323,7 +323,7 @@ public class OdfTableCellRange {
   // table
   // the returned value is all measured with "mm" unit
   private List<Long> getCellRangeWidthList() {
-    List<Long> list = new ArrayList<Long>();
+    List<Long> list = new ArrayList<>();
     long length = 0L;
     for (int i = 0; i < maOwnerTable.getColumnCount() - 1; i++) {
       OdfTableColumn col = maOwnerTable.getColumnByIndex(i);
@@ -354,7 +354,7 @@ public class OdfTableCellRange {
     List<CellCoverInfo> coverList =
         maOwnerTable.getCellCoverInfos(mnStartColumn, mnStartRow, mnEndColumn, mnEndRow);
     // then get the real(uncovered) cell x coordinate
-    List<Long> tmpList = new ArrayList<Long>();
+    List<Long> tmpList = new ArrayList<>();
     List<Long> widthList = getCellRangeWidthList();
     for (int i = mnStartColumn; i < mnEndColumn + 1; i++) {
       for (int j = mnStartRow; j < mnEndRow + 1; j++) {
@@ -373,7 +373,7 @@ public class OdfTableCellRange {
     // last, reorder the tmpVector and split it to splitNum between each item
     Long[] widthArray = (Long[]) tmpList.toArray();
     Arrays.sort(widthArray);
-    List<Long> rtnValues = new ArrayList<Long>();
+    List<Long> rtnValues = new ArrayList<>();
     long colWidth;
     long unitWidth;
     rtnValues.add(widthArray[0]);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableRow.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/doc/table/OdfTableRow.java
@@ -288,7 +288,7 @@ public class OdfTableRow {
    */
   public int getCellCount() {
     OdfTable table = getTable();
-    Set<OdfTableCell> realCells = new HashSet<OdfTableCell>();
+    Set<OdfTableCell> realCells = new HashSet<>();
     List<CellCoverInfo> coverList =
         table.getCellCoverInfos(0, 0, table.getColumnCount() - 1, table.getRowCount() - 1);
     int rowIndex = getRowIndex();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfContentOrStylesDomBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfContentOrStylesDomBase.java
@@ -39,7 +39,7 @@ public class OdfContentOrStylesDomBase extends OdfFileDom {
   private static final long serialVersionUID = 6823264460360047745L;
 
   IdentityHashMap<TableTableElement, OdfTable> mTableRepository =
-      new IdentityHashMap<TableTableElement, OdfTable>();
+          new IdentityHashMap<>();
 
   public OdfContentOrStylesDomBase(OdfPackageDocument packageDocument, String packagePath) {
     super(packageDocument, packagePath);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfSchemaConstraint.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfSchemaConstraint.java
@@ -88,8 +88,8 @@ public enum OdfSchemaConstraint implements ValidationConstraint {
   /**
    * Returns the detail message string of this Constraint.
    *
-   * @return the detail message string of this <tt>Constraint</tt> instance (which may be
-   *     <tt>null</tt>).
+   * @return the detail message string of this <code>Constraint</code> instance (which may be
+   *     <code>null</code>).
    */
   public String getMessage() {
     return mMessage;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfSchemaDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfSchemaDocument.java
@@ -658,7 +658,7 @@ public abstract class OdfSchemaDocument extends OdfPackageDocument {
   // ToDo: Instead of a method to receive all possible feature/components on the document, there
   // might be a generic or one each element?
   public List<TableTableElement> getTables(boolean deepSearch) {
-    List<TableTableElement> tableList = new ArrayList<TableTableElement>();
+    List<TableTableElement> tableList = new ArrayList<>();
     try {
       // find tables from content.xml
       OfficeBodyElement officeBody =

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfSchemaDocument.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/OdfSchemaDocument.java
@@ -733,7 +733,7 @@ public abstract class OdfSchemaDocument extends OdfPackageDocument {
       NodeList lstMasterPages =
           stylesDoc.getElementsByTagNameNS(OdfDocumentNamespace.STYLE.getUri(), "master-page");
       if (lstMasterPages != null && lstMasterPages.getLength() > 0) {
-        masterPages = new HashMap();
+        masterPages = new HashMap<>();
         for (int i = 0; i < lstMasterPages.getLength(); i++) {
           StyleMasterPageElement masterPage =
               (StyleMasterPageElement) lstMasterPages.item(i); // Take the node from the list

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStylableElement.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStylableElement.java
@@ -465,7 +465,7 @@ public abstract class OdfStylableElement extends OdfElement implements OdfStyleP
    */
   @Override
   public Map<OdfStyleProperty, String> getProperties(Set<OdfStyleProperty> properties) {
-    HashMap<OdfStyleProperty, String> map = new HashMap<OdfStyleProperty, String>();
+    HashMap<OdfStyleProperty, String> map = new HashMap<>();
     for (OdfStyleProperty property : properties) {
       map.put(property, getProperty(property));
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
@@ -68,7 +68,7 @@ import org.w3c.dom.NodeList;
  * automatic or the template styles parent, e.g. StyleStyleElement is inheriting from it
  */
 public abstract class OdfStyleBase extends OdfContainerElementBase
-    implements OdfStylePropertySet, Comparable {
+    implements OdfStylePropertySet, Comparable<OdfStyleBase> {
 
   /** */
   private static final long serialVersionUID = 8271282184913774000L;
@@ -373,18 +373,15 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
    * @return 0 if this object is the same as the obj argument; -1 if this object is less than the
    *     obj argument; 1 if this object is greater than the obj argument
    */
-  public int compareTo(Object obj) {
+  public int compareTo(OdfStyleBase obj) {
     if (this == obj) {
       return 0;
     }
 
-    if (!(obj instanceof OdfStyleBase)) {
-      if (obj == null) {
-        throw new ClassCastException("The object to be compared is null!");
-      } else {
-        throw new ClassCastException("The object to be compared is not a style!");
-      }
+    if (obj == null) {
+      throw new ClassCastException("The object to be compared is null!");
     }
+
     OdfStyleBase compare = (OdfStyleBase) obj;
 
     int c = compareNodes(this, compare);
@@ -533,7 +530,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
    */
   @Override
   public boolean equals(Object obj) {
-    return obj != null ? compareTo(obj) == 0 : false;
+    return obj instanceof OdfStyleBase && compareTo((OdfStyleBase) obj) == 0;
   }
 
   @Override

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/OdfStyleBase.java
@@ -78,7 +78,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
   static HashMap<OdfName, OdfStylePropertiesSet> mStylePropertiesElementToSetMap;
 
   static {
-    mStylePropertiesElementToSetMap = new HashMap<OdfName, OdfStylePropertiesSet>();
+    mStylePropertiesElementToSetMap = new HashMap<>();
     mStylePropertiesElementToSetMap.put(
         StyleChartPropertiesElement.ELEMENT_NAME, OdfStylePropertiesSet.ChartProperties);
     mStylePropertiesElementToSetMap.put(
@@ -125,7 +125,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
 
   public void addStyleUser(OdfStylableElement user) {
     if (mStyleUser == null) {
-      mStyleUser = new ArrayList<OdfStylableElement>();
+      mStyleUser = new ArrayList<>();
     }
     mStyleUser.add(user);
   }
@@ -137,7 +137,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
    *     multiple times and would be overwritten (e.g. background color exist 3times in cells).
    */
   public Map<OdfStyleProperty, String> getStyleProperties() {
-    TreeMap<OdfStyleProperty, String> result = new TreeMap<OdfStyleProperty, String>();
+    TreeMap<OdfStyleProperty, String> result = new TreeMap<>();
     OdfStyleFamily family = getFamily();
     if (family != null) {
       for (OdfStyleProperty property : family.getProperties()) {
@@ -158,7 +158,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
    *     cells).
    */
   public Map<OdfStyleProperty, String> getStylePropertiesDeep() {
-    TreeMap<OdfStyleProperty, String> result = new TreeMap<OdfStyleProperty, String>();
+    TreeMap<OdfStyleProperty, String> result = new TreeMap<>();
     OdfStyleBase style = this;
     while (style != null) {
       OdfStyleFamily family = style.getFamily();
@@ -194,7 +194,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
     if (mStyleUser != null) {
       return mStyleUser;
     }
-    return new ArrayList<OdfStylableElement>();
+    return new ArrayList<>();
   }
 
   public String getFamilyName() {
@@ -328,7 +328,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
   }
 
   public Map<OdfStyleProperty, String> getProperties(Set<OdfStyleProperty> properties) {
-    HashMap<OdfStyleProperty, String> map = new HashMap<OdfStyleProperty, String>();
+    HashMap<OdfStyleProperty, String> map = new HashMap<>();
     for (OdfStyleProperty property : properties) {
       map.put(property, getProperty(property));
     }
@@ -492,7 +492,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
   // helper function for compareTo.
   // sorts attributes by namespace:localname
   private static SortedMap<String, String> getSortedAttributes(Node node) {
-    SortedMap<String, String> ret = new TreeMap<String, String>();
+    SortedMap<String, String> ret = new TreeMap<>();
     NamedNodeMap attrs = node.getAttributes();
     for (int i = 0; i < attrs.getLength(); i++) {
       Node cur = attrs.item(i);
@@ -510,7 +510,7 @@ public abstract class OdfStyleBase extends OdfContainerElementBase
   // helper function for compareTo.
   // all except "empty" text nodes will be returned
   private static ArrayList<Node> getNonEmptyChildNodes(Node node) {
-    ArrayList<Node> ret = new ArrayList<Node>();
+    ArrayList<Node> ret = new ArrayList<>();
     NodeList childs = node.getChildNodes();
     for (int i = 0; i < childs.getLength(); i++) {
       Node cur = childs.item(i);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/number/DataStyleElement.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/element/number/DataStyleElement.java
@@ -171,7 +171,7 @@ public abstract class DataStyleElement extends OdfElement {
    *     <p>TODO: at first only detecting currencies -
    */
   protected static List<StringToken> tokenize(String format, NumberFormatType type) {
-    ArrayList<StringToken> tokens = new ArrayList<StringToken>();
+    ArrayList<StringToken> tokens = new ArrayList<>();
     boolean hasNumber =
         false; // only one number token can be created, next one will be part of a text token
     String currentTextToken = "";

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/rdfa/BookmarkRDFMetadataExtractor.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/rdfa/BookmarkRDFMetadataExtractor.java
@@ -206,8 +206,8 @@ public class BookmarkRDFMetadataExtractor extends DefaultElementVisitor {
    * @param element the ODF element whose text would be extracted.
    */
   private BookmarkRDFMetadataExtractor() {
-    builderMap = new HashMap<TextBookmarkStartElement, ExtractorStringBuilder>();
-    stringMap = new HashMap<TextBookmarkStartElement, String>();
+    builderMap = new HashMap<>();
+    stringMap = new HashMap<>();
   }
 
   /**

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/style/OdfStyleFamily.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/style/OdfStyleFamily.java
@@ -40,8 +40,8 @@ import org.odftoolkit.odfdom.dom.style.props.OdfStyleProperty;
 public class OdfStyleFamily implements Comparable<OdfStyleFamily> {
 
   private String m_name;
-  private Set<OdfStyleProperty> m_properties = new TreeSet<OdfStyleProperty>();
-  private static Map<String, OdfStyleFamily> m_familyByName = new HashMap<String, OdfStyleFamily>();
+  private Set<OdfStyleProperty> m_properties = new TreeSet<>();
+  private static Map<String, OdfStyleFamily> m_familyByName = new HashMap<>();
 
   public static OdfStyleFamily getByName(String name) {
     return m_familyByName.get(name);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/dom/style/props/OdfStyleProperty.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/dom/style/props/OdfStyleProperty.java
@@ -41,7 +41,7 @@ public class OdfStyleProperty implements Comparable<OdfStyleProperty> {
     m_name = name;
   }
 
-  private static TreeSet<OdfStyleProperty> m_styleProperties = new TreeSet<OdfStyleProperty>();
+  private static TreeSet<OdfStyleProperty> m_styleProperties = new TreeSet<>();
 
   /**
    * Looks if an OdfStyleProperty is already listed in the static sytleProperties set, otherwise

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/draw/OdfDrawImage.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/draw/OdfDrawImage.java
@@ -29,7 +29,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -230,9 +229,7 @@ public class OdfDrawImage extends DrawImageElement {
   public static void deleteImageByPath(OdfSchemaDocument doc, String imagePath) {
     List<OdfDrawImage> imageList = getImageByPath(doc, imagePath);
     if (imageList != null) {
-      Iterator<OdfDrawImage> it = imageList.iterator();
-      while (it.hasNext()) {
-        OdfDrawImage image = it.next();
+      for (OdfDrawImage image : imageList) {
         // remove the inserted picture
         String ref = image.getXlinkHrefAttribute().toString();
         doc.getPackage().remove(ref);
@@ -337,9 +334,7 @@ public class OdfDrawImage extends DrawImageElement {
   public static Set<String> getImagePathSet(OdfSchemaDocument doc) {
     Set<String> paths = new HashSet<>();
     List<OdfDrawImage> imageList = getImages(doc);
-    Iterator<OdfDrawImage> it = imageList.iterator();
-    while (it.hasNext()) {
-      OdfDrawImage image = it.next();
+    for (OdfDrawImage image : imageList) {
       paths.add(image.getXlinkHrefAttribute().toString());
     }
     return paths;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/draw/OdfDrawImage.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/draw/OdfDrawImage.java
@@ -200,7 +200,7 @@ public class OdfDrawImage extends DrawImageElement {
    *     path, return an empty list.
    */
   public static List<OdfDrawImage> getImageByPath(OdfSchemaDocument doc, String imagePath) {
-    ArrayList<OdfDrawImage> imageList = new ArrayList<OdfDrawImage>();
+    ArrayList<OdfDrawImage> imageList = new ArrayList<>();
 
     try {
       NodeList imageNodes =
@@ -314,7 +314,7 @@ public class OdfDrawImage extends DrawImageElement {
    * @return an image list in this document if no images is found, return an empty list.
    */
   public static List<OdfDrawImage> getImages(OdfSchemaDocument doc) {
-    ArrayList<OdfDrawImage> imageList = new ArrayList<OdfDrawImage>();
+    ArrayList<OdfDrawImage> imageList = new ArrayList<>();
     try {
       NodeList imageNodes =
           doc.getContentDom().getElementsByTagNameNS(OdfDocumentNamespace.DRAW.getUri(), "image");
@@ -335,7 +335,7 @@ public class OdfDrawImage extends DrawImageElement {
    * @return an image path set in this document
    */
   public static Set<String> getImagePathSet(OdfSchemaDocument doc) {
-    Set<String> paths = new HashSet<String>();
+    Set<String> paths = new HashSet<>();
     List<OdfDrawImage> imageList = getImages(doc);
     Iterator<OdfDrawImage> it = imageList.iterator();
     while (it.hasNext()) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeAutomaticStyles.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeAutomaticStyles.java
@@ -241,7 +241,7 @@ public abstract class OdfOfficeAutomaticStyles extends OdfStylesBase {
     if (node instanceof OdfStylePageLayout) {
       OdfStylePageLayout pageLayout = (OdfStylePageLayout) node;
       if (mPageLayouts == null) {
-        mPageLayouts = new HashMap<String, OdfStylePageLayout>();
+        mPageLayouts = new HashMap<>();
       }
 
       mPageLayouts.put(pageLayout.getStyleNameAttribute(), pageLayout);
@@ -268,7 +268,7 @@ public abstract class OdfOfficeAutomaticStyles extends OdfStylesBase {
    */
   public void optimize() {
     Iterator<OdfStyle> iter = getAllStyles().iterator();
-    SortedSet<OdfStyle> stylesSet = new TreeSet<OdfStyle>();
+    SortedSet<OdfStyle> stylesSet = new TreeSet<>();
     while (iter.hasNext()) {
       OdfStyle cur = iter.next();
 
@@ -282,7 +282,7 @@ public abstract class OdfOfficeAutomaticStyles extends OdfStylesBase {
       if (found != null && found.equals(cur)) {
         // cur already in set. Replace all usages of cur by found:
         Iterator<OdfStylableElement> styleUsersIter = cur.getStyleUsers().iterator();
-        ArrayList<OdfStylableElement> styleUsers = new ArrayList<OdfStylableElement>();
+        ArrayList<OdfStylableElement> styleUsers = new ArrayList<>();
         while (styleUsersIter.hasNext()) {
           styleUsers.add(styleUsersIter.next());
         }
@@ -397,7 +397,7 @@ public abstract class OdfOfficeAutomaticStyles extends OdfStylesBase {
         three parts: "value()>0";"value()<0";value()==0
         The last one is in general
     */
-    ArrayList<String> partArray = new ArrayList<String>();
+    ArrayList<String> partArray = new ArrayList<>();
     // TODO: skip quoted parts - check fails if semicolon is in quotes
     while (numberFormatCode.contains(";")) {
       int partStart = numberFormatCode.lastIndexOf(";", numberFormatCode.length());

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeMasterStyles.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeMasterStyles.java
@@ -127,7 +127,7 @@ public abstract class OdfOfficeMasterStyles extends OdfStylesBase
       StyleMasterPageElement masterPage = (StyleMasterPageElement) node;
 
       if (mMasterPages == null) {
-        mMasterPages = new HashMap<String, StyleMasterPageElement>();
+        mMasterPages = new HashMap<>();
       }
       mMasterPages.put(masterPage.getStyleNameAttribute(), masterPage);
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeStyles.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfOfficeStyles.java
@@ -170,7 +170,7 @@ public abstract class OdfOfficeStyles extends OdfStylesBase {
     if (mDefaultStyles != null) {
       return mDefaultStyles.values();
     } else {
-      return new ArrayList<OdfDefaultStyle>();
+      return new ArrayList<>();
     }
   }
 
@@ -197,7 +197,7 @@ public abstract class OdfOfficeStyles extends OdfStylesBase {
     if (mMarker != null) {
       return mMarker.values();
     } else {
-      return new ArrayList<DrawMarkerElement>();
+      return new ArrayList<>();
     }
   }
 
@@ -224,7 +224,7 @@ public abstract class OdfOfficeStyles extends OdfStylesBase {
     if (mGradients != null) {
       return mGradients.values();
     } else {
-      return new ArrayList<DrawGradientElement>();
+      return new ArrayList<>();
     }
   }
 
@@ -251,7 +251,7 @@ public abstract class OdfOfficeStyles extends OdfStylesBase {
     if (mHatches != null) {
       return mHatches.values();
     } else {
-      return new ArrayList<DrawHatchElement>();
+      return new ArrayList<>();
     }
   }
 
@@ -278,7 +278,7 @@ public abstract class OdfOfficeStyles extends OdfStylesBase {
     if (mFillImages != null) {
       return mFillImages.values();
     } else {
-      return new ArrayList<DrawFillImageElement>();
+      return new ArrayList<>();
     }
   }
 
@@ -287,28 +287,28 @@ public abstract class OdfOfficeStyles extends OdfStylesBase {
     if (node instanceof OdfDefaultStyle) {
       OdfDefaultStyle defaultStyle = (OdfDefaultStyle) node;
       if (mDefaultStyles == null) {
-        mDefaultStyles = new HashMap<OdfStyleFamily, OdfDefaultStyle>();
+        mDefaultStyles = new HashMap<>();
       }
 
       mDefaultStyles.put(defaultStyle.getFamily(), defaultStyle);
     } else if (node instanceof DrawMarkerElement) {
       DrawMarkerElement marker = (DrawMarkerElement) node;
       if (mMarker == null) {
-        mMarker = new HashMap<String, DrawMarkerElement>();
+        mMarker = new HashMap<>();
       }
 
       mMarker.put(marker.getDrawNameAttribute(), marker);
     } else if (node instanceof DrawGradientElement) {
       DrawGradientElement gradient = (DrawGradientElement) node;
       if (mGradients == null) {
-        mGradients = new HashMap<String, DrawGradientElement>();
+        mGradients = new HashMap<>();
       }
 
       mGradients.put(gradient.getDrawNameAttribute(), gradient);
     } else if (node instanceof DrawHatchElement) {
       DrawHatchElement hatch = (DrawHatchElement) node;
       if (mHatches == null) {
-        mHatches = new HashMap<String, DrawHatchElement>();
+        mHatches = new HashMap<>();
       }
 
       mHatches.put(hatch.getDrawNameAttribute(), hatch);
@@ -316,7 +316,7 @@ public abstract class OdfOfficeStyles extends OdfStylesBase {
       DrawFillImageElement fillImage = (DrawFillImageElement) node;
 
       if (mFillImages == null) {
-        mFillImages = new HashMap<String, DrawFillImageElement>();
+        mFillImages = new HashMap<>();
       }
 
       mFillImages.put(fillImage.getDrawNameAttribute(), fillImage);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfStylesBase.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/office/OdfStylesBase.java
@@ -67,7 +67,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
   private Map<String, NumberTextStyleElement> mTextStyles;
 
   private Map<String, DataStyleElement> mAllDataStyles =
-      new HashMap<String, DataStyleElement>();
+    new HashMap<>();
 
   public OdfStylesBase(OdfFileDom ownerDoc, OdfName odfName) {
     super(ownerDoc, odfName);
@@ -129,7 +129,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
    * @return iterator for all <code>OdfStyle</code> elements
    */
   public Iterable<OdfStyle> getAllStyles() {
-    ArrayList<OdfStyle> allStyles = new ArrayList<OdfStyle>();
+    ArrayList<OdfStyle> allStyles = new ArrayList<>();
     if (mStyles != null) {
       for (HashMap<String, OdfStyle> familySet : mStyles.values()) {
         Collection<OdfStyle> familyStyles = familySet.values();
@@ -147,7 +147,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
         return familyMap.values();
       }
     }
-    return new ArrayList<OdfStyle>();
+    return new ArrayList<>();
   }
 
   // For documentation see OdfAutomaticStyles or OdfStyles.
@@ -164,7 +164,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (mListStyles != null) {
       return mListStyles.values();
     } else {
-      return new ArrayList<OdfTextListStyle>();
+      return new ArrayList<>();
     }
   }
 
@@ -182,7 +182,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (mNumberStyles != null) {
       return mNumberStyles.values();
     } else {
-      return new ArrayList<OdfNumberStyle>();
+      return new ArrayList<>();
     }
   }
 
@@ -200,7 +200,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (mDateStyles != null) {
       return mDateStyles.values();
     } else {
-      return new ArrayList<OdfNumberDateStyle>();
+      return new ArrayList<>();
     }
   }
 
@@ -218,7 +218,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (mPercentageStyles != null) {
       return mPercentageStyles.values();
     } else {
-      return new ArrayList<OdfNumberPercentageStyle>();
+      return new ArrayList<>();
     }
   }
 
@@ -236,7 +236,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (mCurrencyStyles != null) {
       return mCurrencyStyles.values();
     } else {
-      return new ArrayList<OdfNumberCurrencyStyle>();
+      return new ArrayList<>();
     }
   }
 
@@ -254,7 +254,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (mTimeStyles != null) {
       return mTimeStyles.values();
     } else {
-      return new ArrayList<OdfNumberTimeStyle>();
+      return new ArrayList<>();
     }
   }
 
@@ -272,7 +272,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (mBooleanStyles != null) {
       return mBooleanStyles.values();
     } else {
-      return new ArrayList<NumberBooleanStyleElement>();
+      return new ArrayList<>();
     }
   }
 
@@ -290,7 +290,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (mTextStyles != null) {
       return mTextStyles.values();
     } else {
-      return new ArrayList<NumberTextStyleElement>();
+      return new ArrayList<>();
     }
   }
 
@@ -304,16 +304,16 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
     if (node instanceof OdfStyle) {
       OdfStyle style = (OdfStyle) node;
       if (mStyles == null) {
-        mStyles = new HashMap<OdfStyleFamily, HashMap<String, OdfStyle>>();
+        mStyles = new HashMap<>();
       }
 
-      HashMap<String, OdfStyle> familyMap = mStyles.computeIfAbsent(style.getFamily(), k -> new HashMap<String, OdfStyle>());
+      HashMap<String, OdfStyle> familyMap = mStyles.computeIfAbsent(style.getFamily(), k -> new HashMap<>());
 
       familyMap.put(style.getStyleNameAttribute(), style);
     } else if (node instanceof OdfTextListStyle) {
       OdfTextListStyle listStyle = (OdfTextListStyle) node;
       if (mListStyles == null) {
-        mListStyles = new HashMap<String, OdfTextListStyle>();
+        mListStyles = new HashMap<>();
       }
 
       mListStyles.put(listStyle.getStyleNameAttribute(), listStyle);
@@ -321,7 +321,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
       OdfNumberStyle numberStyle = (OdfNumberStyle) node;
 
       if (mNumberStyles == null) {
-        mNumberStyles = new HashMap<String, OdfNumberStyle>();
+        mNumberStyles = new HashMap<>();
       }
 
       mNumberStyles.put(numberStyle.getStyleNameAttribute(), numberStyle);
@@ -329,7 +329,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
       OdfNumberDateStyle dateStyle = (OdfNumberDateStyle) node;
 
       if (mDateStyles == null) {
-        mDateStyles = new HashMap<String, OdfNumberDateStyle>();
+        mDateStyles = new HashMap<>();
       }
 
       mDateStyles.put(dateStyle.getStyleNameAttribute(), dateStyle);
@@ -337,7 +337,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
       OdfNumberPercentageStyle percentageStyle = (OdfNumberPercentageStyle) node;
 
       if (mPercentageStyles == null) {
-        mPercentageStyles = new HashMap<String, OdfNumberPercentageStyle>();
+        mPercentageStyles = new HashMap<>();
       }
 
       mPercentageStyles.put(percentageStyle.getStyleNameAttribute(), percentageStyle);
@@ -345,7 +345,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
       OdfNumberCurrencyStyle currencyStyle = (OdfNumberCurrencyStyle) node;
 
       if (mCurrencyStyles == null) {
-        mCurrencyStyles = new HashMap<String, OdfNumberCurrencyStyle>();
+        mCurrencyStyles = new HashMap<>();
       }
 
       mCurrencyStyles.put(currencyStyle.getStyleNameAttribute(), currencyStyle);
@@ -353,7 +353,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
       OdfNumberTimeStyle timeStyle = (OdfNumberTimeStyle) node;
 
       if (mTimeStyles == null) {
-        mTimeStyles = new HashMap<String, OdfNumberTimeStyle>();
+        mTimeStyles = new HashMap<>();
       }
 
       mTimeStyles.put(timeStyle.getStyleNameAttribute(), timeStyle);
@@ -361,7 +361,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
       NumberBooleanStyleElement booleanStyle = (NumberBooleanStyleElement) node;
 
       if (mBooleanStyles == null) {
-        mBooleanStyles = new HashMap<String, NumberBooleanStyleElement>();
+        mBooleanStyles = new HashMap<>();
       }
 
       mBooleanStyles.put(booleanStyle.getStyleNameAttribute(), booleanStyle);
@@ -369,7 +369,7 @@ public abstract class OdfStylesBase extends OdfContainerElementBase {
       NumberTextStyleElement textStyle = (NumberTextStyleElement) node;
 
       if (mTextStyles == null) {
-        mTextStyles = new HashMap<String, NumberTextStyleElement>();
+        mTextStyles = new HashMap<>();
       }
 
       mTextStyles.put(textStyle.getStyleNameAttribute(), textStyle);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfEditableTextExtractor.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfEditableTextExtractor.java
@@ -139,8 +139,7 @@ public class OdfEditableTextExtractor extends OdfTextExtractor {
   public void visit(TableTableElement ele) {
     OdfTable table = OdfTable.getInstance(ele);
     List<OdfTableRow> rowlist = table.getRowList();
-    for (int i = 0; i < rowlist.size(); i++) {
-      OdfTableRow row = rowlist.get(i);
+    for (OdfTableRow row : rowlist) {
       for (int j = 0; j < row.getCellCount(); j++) {
         mTextBuilder.append(row.getCellByIndex(j).getDisplayText()).append(TabChar);
       }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextList.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextList.java
@@ -64,15 +64,13 @@ public class OdfTextList extends TextListElement {
     OdfTextList[] listArray = new OdfTextList[10];
     TextListItemElement listItem;
     OdfTextParagraph para;
-    String item;
     int level = 0;
     int lastLevel = 0;
     int lev; // loop counter
 
     listArray[0] = this;
-    for (int i = 0; i < itemList.length; i++) {
+    for (String item : itemList) {
       level = 0;
-      item = itemList[i];
 
       // determine level of indenting by counting delimiters,
       // then get rid of the delimiters

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextListStyle.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/doc/text/OdfTextListStyle.java
@@ -30,6 +30,7 @@ import org.odftoolkit.odfdom.dom.element.text.TextListLevelStyleElementBase;
 import org.odftoolkit.odfdom.dom.element.text.TextListStyleElement;
 import org.odftoolkit.odfdom.dom.style.OdfStyleFamily;
 import org.odftoolkit.odfdom.dom.style.props.OdfListLevelProperties;
+import org.odftoolkit.odfdom.pkg.OdfElement;
 import org.odftoolkit.odfdom.pkg.OdfFileDom;
 import org.w3c.dom.Node;
 
@@ -128,7 +129,7 @@ public class OdfTextListStyle extends TextListStyleElement {
    * @return a list level style with the given level and class
    */
   @SuppressWarnings("unchecked")
-  public TextListLevelStyleElementBase getOrCreateListLevel(int level, Class clazz) {
+  public TextListLevelStyleElementBase getOrCreateListLevel(int level, Class<? extends OdfElement> clazz) {
     TextListLevelStyleElementBase levelStyle = getLevel(level);
     if ((levelStyle != null) && clazz.isInstance(levelStyle)) {
       return levelStyle;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/meta/OdfOfficeMeta.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/meta/OdfOfficeMeta.java
@@ -292,9 +292,9 @@ public class OdfOfficeMeta {
       mOfficeMetaElement.removeChild(keyele);
     }
     // add new
-    for (int i = 0; i < keyList.size(); i++) {
+    for (String s : keyList) {
       MetaKeywordElement keywordElement = mOfficeMetaElement.newMetaKeywordElement();
-      keywordElement.setTextContent(keyList.get(i));
+      keywordElement.setTextContent(s);
     }
   }
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/SelectionManager.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/SelectionManager.java
@@ -34,7 +34,7 @@ public class SelectionManager {
   private Map<OdfElement, ArrayList<Selection>> repository = null;
 
   public SelectionManager() {
-    repository = new HashMap<OdfElement, ArrayList<Selection>>();
+    repository = new HashMap<>();
   }
 
   /**
@@ -58,7 +58,7 @@ public class SelectionManager {
         selections.add(item);
       }
     } else {
-      ArrayList<Selection> al = new ArrayList<Selection>();
+      ArrayList<Selection> al = new ArrayList<>();
       al.add(item);
       repository.put(element, al);
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/SelectionManager.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/SelectionManager.java
@@ -74,9 +74,9 @@ public class SelectionManager {
     OdfElement element = cutItem.getElement();
     if (repository.containsKey(element)) {
       ArrayList<Selection> selections = repository.get(element);
-      for (int i = 0; i < selections.size(); i++) {
-        if (selections.get(i).getIndex() > cutItem.getIndex()) {
-          selections.get(i).refreshAfterFrontalDelete(cutItem);
+      for (Selection selection : selections) {
+        if (selection.getIndex() > cutItem.getIndex()) {
+          selection.refreshAfterFrontalDelete(cutItem);
         }
       }
     }
@@ -93,9 +93,9 @@ public class SelectionManager {
     OdfElement element = positionItem.getElement();
     if (repository.containsKey(element)) {
       ArrayList<Selection> selections = repository.get(element);
-      for (int i = 0; i < selections.size(); i++) {
-        if (selections.get(i).getIndex() >= positionItem.getIndex()) {
-          selections.get(i).refreshAfterFrontalInsert(item);
+      for (Selection selection : selections) {
+        if (selection.getIndex() >= positionItem.getIndex()) {
+          selection.refreshAfterFrontalInsert(item);
         }
       }
     }
@@ -119,9 +119,9 @@ public class SelectionManager {
 
     if (repository.containsKey(element)) {
       ArrayList<Selection> selections = repository.get(element);
-      for (int i = 0; i < selections.size(); i++) {
-        if (selections.get(i).getIndex() >= positionIndex) {
-          selections.get(i).refreshAfterFrontalInsert(item);
+      for (Selection selection : selections) {
+        if (selection.getIndex() >= positionIndex) {
+          selection.refreshAfterFrontalInsert(item);
         }
       }
     }
@@ -157,9 +157,9 @@ public class SelectionManager {
   public void refresh(OdfElement containerElement, int offset, int positionIndex) {
     if (repository.containsKey(containerElement)) {
       ArrayList<Selection> selections = repository.get(containerElement);
-      for (int i = 0; i < selections.size(); i++) {
-        if (selections.get(i).getIndex() >= positionIndex) {
-          selections.get(i).refresh(offset);
+      for (Selection selection : selections) {
+        if (selection.getIndex() >= positionIndex) {
+          selection.refresh(offset);
         }
       }
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextSelection.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextSelection.java
@@ -876,7 +876,7 @@ public class TextSelection extends Selection {
                 .getDocumentStyles()
                 .getDefaultStyle(styleElement.getFamily());
       }
-      TreeMap<OdfStyleProperty, String> result = new TreeMap<OdfStyleProperty, String>();
+      TreeMap<OdfStyleProperty, String> result = new TreeMap<>();
       OdfStyleFamily family = OdfStyleFamily.Text;
       if (family != null) {
         for (OdfStyleProperty property : family.getProperties()) {
@@ -904,7 +904,7 @@ public class TextSelection extends Selection {
     if (styleElement == null) {
       styleElement = element.getDocumentStyle();
     }
-    TreeMap<OdfStyleProperty, String> result = new TreeMap<OdfStyleProperty, String>();
+    TreeMap<OdfStyleProperty, String> result = new TreeMap<>();
     while (styleElement != null) {
       // check if it is the style:defaut-style
       if ((styleElement.getPropertiesElement(OdfStylePropertiesSet.ParagraphProperties) == null)

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
@@ -278,10 +278,7 @@ public class TextStyleNavigation extends Navigation<TextSelection> {
         }
       }
       // get all automatic styles
-      Iterator<OdfStyle> cStyles =
-          mTextDocument.getContentDom().getAutomaticStyles().getAllStyles().iterator();
-      while (cStyles.hasNext()) {
-        OdfStyle cStyle = cStyles.next();
+      for (OdfStyle cStyle : mTextDocument.getContentDom().getAutomaticStyles().getAllStyles()) {
         // get default properties and style properties
         Map<OdfStyleProperty, String> map = cStyle.getStylePropertiesDeep();
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigation.java
@@ -237,9 +237,9 @@ public class TextStyleNavigation extends Navigation<TextSelection> {
   }
 
   private Set<String> getMatchStyleNames() {
-    Set<String> styleNames = new HashSet<String>();
+    Set<String> styleNames = new HashSet<>();
     String sname;
-    HashMap<String, OdfDefaultStyle> defaultStyles = new HashMap<String, OdfDefaultStyle>();
+    HashMap<String, OdfDefaultStyle> defaultStyles = new HashMap<>();
     try {
 
       NodeList defStyleList =

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfElement.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfElement.java
@@ -663,7 +663,7 @@ public abstract class OdfElement extends ElementNSImpl {
     int attr_count1 = attributes.getLength();
     int attr_count2 = compare.attributes.getLength();
 
-    List<Node> attr1 = new ArrayList<Node>();
+    List<Node> attr1 = new ArrayList<>();
     for (int i = 0; i < attr_count1; i++) {
       Node node = attributes.item(i);
       if (node.getNodeValue().length() == 0) {
@@ -672,7 +672,7 @@ public abstract class OdfElement extends ElementNSImpl {
       attr1.add(node);
     }
 
-    List<Node> attr2 = new ArrayList<Node>();
+    List<Node> attr2 = new ArrayList<>();
     for (int i = 0; i < attr_count2; i++) {
       Node node = compare.attributes.item(i);
       if (node.getNodeValue().length() == 0) {
@@ -722,7 +722,7 @@ public abstract class OdfElement extends ElementNSImpl {
       return true;
     }
 
-    List<Node> nodes1 = new ArrayList<Node>();
+    List<Node> nodes1 = new ArrayList<>();
     for (int i = 0; i < child_count1; i++) {
       Node node = childs1.item(i);
       if (node.getNodeType() == Node.TEXT_NODE) {
@@ -733,7 +733,7 @@ public abstract class OdfElement extends ElementNSImpl {
       nodes1.add(node);
     }
 
-    List<Node> nodes2 = new ArrayList<Node>();
+    List<Node> nodes2 = new ArrayList<>();
     for (int i = 0; i < child_count2; i++) {
       Node node = childs2.item(i);
       if (node.getNodeType() == Node.TEXT_NODE) {
@@ -1246,7 +1246,7 @@ public abstract class OdfElement extends ElementNSImpl {
       LOG.warning("A negative index " + textPosStart + " was given to insert text into the paragraph!");
     }
     // start recrusion
-    ArrayList<Node> nodeContainer = new ArrayList<Node>(1);
+    ArrayList<Node> nodeContainer = new ArrayList<>(1);
     boolean withinTextContainer = this instanceof TextPElement || this instanceof TextHElement;
     TextContentTraverser.traverseSiblings(
         this.getFirstChild(),
@@ -1393,7 +1393,7 @@ public abstract class OdfElement extends ElementNSImpl {
         this.appendChild((Element) content);
       }
     } else {
-      List<Object> newData = new ArrayList<Object>(2);
+      List<Object> newData = new ArrayList<>(2);
       newData.add(content);
       int currentPos =
           TextContentTraverser.traverseSiblings(

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfElement.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfElement.java
@@ -685,10 +685,9 @@ public abstract class OdfElement extends ElementNSImpl {
       return false;
     }
 
-    for (int i = 0; i < attr1.size(); i++) {
-      Node n1 = attr1.get(i);
+    for (Node n1 : attr1) {
       if (n1.getLocalName().equals("name")
-          && n1.getNamespaceURI().equals(OdfDocumentNamespace.STYLE.getUri())) {
+        && n1.getNamespaceURI().equals(OdfDocumentNamespace.STYLE.getUri())) {
         continue; // do not compare style names
       }
       Node n2 = null;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfElement.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfElement.java
@@ -1444,7 +1444,7 @@ public abstract class OdfElement extends ElementNSImpl {
      * Afterwards all following-sibling, text and nodes will be deleted, until the end text position
      * is found 3) Split the text take the returned and remove it from parent
      */
-    List deleteStatus = new ArrayList(1);
+    List<Boolean> deleteStatus = new ArrayList<>(1);
 
     // start recrusion
     TextContentTraverser.traverseSiblings(
@@ -1814,10 +1814,10 @@ public abstract class OdfElement extends ElementNSImpl {
       int execute(Node currentNode, int currentPos, int posStart, int posEnd, Object... content) {
         switch (mId) {
           case 1:
-            currentPos = insert(currentNode, currentPos, posStart, posEnd, (List) content[0]);
+            currentPos = insert(currentNode, currentPos, posStart, posEnd, (List<Object>) content[0]);
             break;
           case 2:
-            currentPos = delete(currentNode, currentPos, posStart, posEnd, (List) content[0]);
+            currentPos = delete(currentNode, currentPos, posStart, posEnd, (List<Boolean>) content[0]);
             break;
           case 3:
             currentPos =
@@ -1830,7 +1830,7 @@ public abstract class OdfElement extends ElementNSImpl {
                     (Map<OdfName, OdfElement>) content[1]);
             break;
           case 4:
-            currentPos = receive(currentNode, currentPos, posStart, posEnd, (ArrayList) content[0]);
+            currentPos = receive(currentNode, currentPos, posStart, posEnd, (ArrayList<Node>) content[0]);
             break;
           case 5:
             moveChildrenTo(currentNode, currentPos, posStart, posEnd, (Element) content[0]);
@@ -1938,7 +1938,7 @@ public abstract class OdfElement extends ElementNSImpl {
         return currentPos;
       }
 
-      int insert(Node currentNode, int currentPos, int posStart, int posEnd, List content) {
+      int insert(Node currentNode, int currentPos, int posStart, int posEnd, List<Object> content) {
         if (currentNode != null) {
           // // ** GET NODE SIZE
           // Integer contentLength = getNodeWidth(currentNode);
@@ -2034,7 +2034,7 @@ public abstract class OdfElement extends ElementNSImpl {
 
       // Within the text node, either the first or the last part have to be deleted (best
       // selectable)
-      int delete(Node currentNode, int currentPos, int posStart, int posEnd, List deleteStatus) {
+      int delete(Node currentNode, int currentPos, int posStart, int posEnd, List<Boolean> deleteStatus) {
 
         if (currentNode != null) {
           int nextSplitPos;
@@ -2224,7 +2224,7 @@ public abstract class OdfElement extends ElementNSImpl {
       }
 
       private int receive(
-          Node currentNode, int currentPos, int posStart, int posEnd, ArrayList newNodeContainer) {
+          Node currentNode, int currentPos, int posStart, int posEnd, ArrayList<Node> newNodeContainer) {
         if (currentNode != null) {
 
           // ** GET NODE SIZE

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfFileDom.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfFileDom.java
@@ -95,10 +95,10 @@ public class OdfFileDom extends DocumentImpl implements NamespaceContext {
       mPackageDocument = packageDocument;
       mPackage = packageDocument.getPackage();
       mPackagePath = packagePath;
-      mUriByPrefix = new HashMap<String, String>();
-      mPrefixByUri = new HashMap<String, String>();
-      mDuplicatePrefixesByUri = new HashMap<String, Set<String>>();
-      inCententMetadataCache = new IdentityHashMap<Node, Model>();
+      mUriByPrefix = new HashMap<>();
+      mPrefixByUri = new HashMap<>();
+      mDuplicatePrefixesByUri = new HashMap<>();
+      inCententMetadataCache = new IdentityHashMap<>();
       try {
         initialize();
       } catch (SAXException | IOException | ParserConfigurationException ex) {
@@ -125,10 +125,10 @@ public class OdfFileDom extends DocumentImpl implements NamespaceContext {
       mPackageDocument = null;
       mPackage = pkg;
       mPackagePath = packagePath;
-      mUriByPrefix = new HashMap<String, String>();
-      mPrefixByUri = new HashMap<String, String>();
-      mDuplicatePrefixesByUri = new HashMap<String, Set<String>>();
-      inCententMetadataCache = new HashMap<Node, Model>();
+      mUriByPrefix = new HashMap<>();
+      mPrefixByUri = new HashMap<>();
+      mDuplicatePrefixesByUri = new HashMap<>();
+      inCententMetadataCache = new HashMap<>();
       try {
         initialize();
       } catch (SAXException | IOException | ParserConfigurationException ex) {
@@ -580,7 +580,7 @@ public class OdfFileDom extends DocumentImpl implements NamespaceContext {
   public Iterator<String> getPrefixes(String namespaceURI) {
     Set<String> prefixes = mDuplicatePrefixesByUri.get(namespaceURI);
     if (prefixes == null) {
-      prefixes = new HashSet<String>();
+      prefixes = new HashSet<>();
     }
     String givenPrefix = mPrefixByUri.get(namespaceURI);
     if (givenPrefix != null) {
@@ -618,7 +618,7 @@ public class OdfFileDom extends DocumentImpl implements NamespaceContext {
       newNamespace = OdfNamespace.newNamespace(existingPrefix, uri);
 
       // Add the new prefix to the duplicate prefix map for getPrefixes(String uri)
-      Set<String> prefixes = mDuplicatePrefixesByUri.computeIfAbsent(uri, k -> new HashSet<String>());
+      Set<String> prefixes = mDuplicatePrefixesByUri.computeIfAbsent(uri, k -> new HashSet<>());
       prefixes.add(prefix);
     } else {
       // Scenario b) the prefix already exists and the URI does not exist

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfFileSaxHandler.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfFileSaxHandler.java
@@ -45,7 +45,7 @@ public class OdfFileSaxHandler extends DefaultHandler {
   protected Node
       mCurrentNode; // a stack of sub handlers. handlers will be pushed on the stack whenever
   // they are required and must pop themselves from the stack when done
-  private Stack<ContentHandler> mHandlerStack = new Stack<ContentHandler>();
+  private Stack<ContentHandler> mHandlerStack = new Stack<>();
   private StringBuilder mCharsForTextNode = new StringBuilder();
   private JenaSink sink;
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfName.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfName.java
@@ -35,7 +35,7 @@ public class OdfName implements Comparable<OdfName> {
   private final String mLocalName;
   private final String mQName;
   private final String mExpandedName; // i.e. {nsURI}localName
-  private static HashMap<String, OdfName> mOdfNames = new HashMap<String, OdfName>();
+  private static HashMap<String, OdfName> mOdfNames = new HashMap<>();
 
   private OdfName(OdfNamespace ns, String localname, String expandedName) {
     mNS = ns;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfNamespace.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfNamespace.java
@@ -34,7 +34,7 @@ import org.odftoolkit.odfdom.dom.OdfDocumentNamespace;
  */
 public class OdfNamespace implements Comparable<OdfNamespace>, NamespaceName {
 
-  private static Map<String, OdfNamespace> mNamespacesByURI = new HashMap<String, OdfNamespace>();
+  private static Map<String, OdfNamespace> mNamespacesByURI = new HashMap<>();
   private String mUri;
   private String mPrefix;
   /**

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfNamespace.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfNamespace.java
@@ -104,7 +104,7 @@ public class OdfNamespace implements Comparable<OdfNamespace>, NamespaceName {
    * loader
    */
   public static void initializeUrl2DefaultPrefixMap() {
-    mUrlToPrefix = new HashMap(32);
+    mUrlToPrefix = new HashMap<>(32);
     // add all namespaces from the ODF package specification
     for (OdfPackageNamespace packageNamespace : OdfPackageNamespace.values()) {
       mUrlToPrefix.put(packageNamespace.getUri(), packageNamespace.getPrefix());

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackage.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackage.java
@@ -630,15 +630,13 @@ public class OdfPackage implements Closeable {
       if (mErrorHandler != null) {
         validateManifest();
       }
-      Iterator<String> zipPaths = mZipEntries.keySet().iterator();
-      while (zipPaths.hasNext()) {
-        String internalPath = zipPaths.next();
+      for (String internalPath : mZipEntries.keySet()) {
         // every resource aside the /META-INF/manifest.xml (and
         // META-INF/ directory)
         // and "mimetype" will be added as fileEntry
-        if (!internalPath.equals(OdfPackage.OdfFile.MANIFEST.getPath())
-            && !internalPath.equals("META-INF/")
-            && !internalPath.equals(OdfPackage.OdfFile.MEDIA_TYPE.getPath())) {
+        if (!internalPath.equals(OdfFile.MANIFEST.getPath())
+          && !internalPath.equals("META-INF/")
+          && !internalPath.equals(OdfFile.MEDIA_TYPE.getPath())) {
           // aside "mediatype" and "META-INF/manifest"
           // add manifest entry as to be described by a
           // <manifest:file-entry>
@@ -687,16 +685,14 @@ public class OdfPackage implements Closeable {
 
       // No directory are listed in a ZIP removing all directory with
       // content
-      Iterator<String> manifestOnlyPaths = zipPathSubset.iterator();
-      while (manifestOnlyPaths.hasNext()) {
-        String manifestOnlyPath = manifestOnlyPaths.next();
+      for (String manifestOnlyPath : zipPathSubset) {
         // assumption: all directories end with slash
         if (manifestOnlyPath.endsWith(SLASH)) {
           removeDirectory(manifestOnlyPath);
         } else {
           // if it is a nonexistent file
           logValidationError(
-              OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, getBaseURI(), manifestOnlyPath);
+            OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, getBaseURI(), manifestOnlyPath);
           // remove from the manifest Map
           OdfFileEntry manifestEntry = mManifestEntries.remove(manifestOnlyPath);
           // remove from the manifest DOM
@@ -706,9 +702,7 @@ public class OdfPackage implements Closeable {
       }
     }
     // remove none document directories
-    Iterator<String> sharedPathsIter = sharedPaths.iterator();
-    while (sharedPathsIter.hasNext()) {
-      String sharedPath = sharedPathsIter.next();
+    for (String sharedPath : sharedPaths) {
       // assumption: all directories end with slash
       if (sharedPath.endsWith(SLASH)) {
         removeDirectory(sharedPath);

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackage.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackage.java
@@ -152,7 +152,7 @@ public class OdfPackage implements Closeable {
   // save() will check 1) mPkgDoms, 2) if not check mMemoryFileCache
   private Map<String, Document> mPkgDoms;
   private Map<String, byte[]> mMemoryFileCache;
-  private Map<String, Object> mConfiguration = new HashMap<String, Object>();
+  private Map<String, Object> mConfiguration = new HashMap<>();
 
   private ErrorHandler mErrorHandler;
   private String mManifestVersion;
@@ -196,11 +196,11 @@ public class OdfPackage implements Closeable {
   private OdfPackage() {
     mMediaType = null;
     mResolver = null;
-    mPkgDocuments = new HashMap<String, OdfPackageDocument>();
-    mPkgDoms = new HashMap<String, Document>();
+    mPkgDocuments = new HashMap<>();
+    mPkgDoms = new HashMap<>();
     mTransientMarkupId = 0;
-    mMemoryFileCache = new HashMap<String, byte[]>();
-    mManifestEntries = new HashMap<String, OdfFileEntry>();
+    mMemoryFileCache = new HashMap<>();
+    mManifestEntries = new HashMap<>();
     // specify whether validation should be enabled and what SAX
     // ErrorHandler should be used.
     if (mErrorHandler == null) {
@@ -604,7 +604,7 @@ public class OdfPackage implements Closeable {
   // readZip();
   // }
   private void readZip() throws SAXException, IOException {
-    mZipEntries = new HashMap<String, ZipArchiveEntry>();
+    mZipEntries = new HashMap<>();
     String firstEntryName = mZipFile.entriesToMap(mZipEntries);
     if (mZipEntries.isEmpty()) {
       OdfValidationException ve =
@@ -622,7 +622,7 @@ public class OdfPackage implements Closeable {
 
       // ToDo: Remove all META-INF/* files from the fileEntries of
       // Manifest
-      mOriginalZipEntries = new HashMap<String, ZipArchiveEntry>();
+      mOriginalZipEntries = new HashMap<>();
       mOriginalZipEntries.putAll(mZipEntries);
       mZipEntries.remove(OdfPackage.OdfFile.MEDIA_TYPE.getPath());
       mZipEntries.remove(OdfPackage.OdfFile.MANIFEST.getPath());
@@ -656,13 +656,13 @@ public class OdfPackage implements Closeable {
   private void validateManifest() throws SAXException {
     Set<String> zipPaths = mZipEntries.keySet();
     Set<String> manifestPaths = mManifestEntries.keySet();
-    Set<String> sharedPaths = new HashSet<String>(zipPaths);
+    Set<String> sharedPaths = new HashSet<>(zipPaths);
     sharedPaths.retainAll(manifestPaths);
 
     if (sharedPaths.size() < zipPaths.size()) {
-      Set<String> zipPathSuperset = new HashSet<String>(mZipEntries.keySet());
+      Set<String> zipPathSuperset = new HashSet<>(mZipEntries.keySet());
       zipPathSuperset.removeAll(sharedPaths);
-      Set<String> sortedSet = new TreeSet<String>(zipPathSuperset);
+      Set<String> sortedSet = new TreeSet<>(zipPathSuperset);
       Iterator<String> iter = sortedSet.iterator();
       String documentURL = getBaseURI();
       String internalPath;
@@ -680,7 +680,7 @@ public class OdfPackage implements Closeable {
       }
     }
     if (sharedPaths.size() < manifestPaths.size()) {
-      Set<String> zipPathSubset = new HashSet<String>(mManifestEntries.keySet());
+      Set<String> zipPathSubset = new HashSet<>(mManifestEntries.keySet());
       zipPathSubset.removeAll(sharedPaths);
       // removing root directory
       zipPathSubset.remove(SLASH);
@@ -990,7 +990,7 @@ public class OdfPackage implements Closeable {
       remove(SLASH);
     } else {
       // remove all the stream of the directory, such as pictures
-      List<String> directoryEntryNames = new ArrayList<String>();
+      List<String> directoryEntryNames = new ArrayList<>();
       for (String entryName : allPackageFileNames) {
         if (entryName.startsWith(internalPath)) {
           directoryEntryNames.add(entryName);
@@ -1600,7 +1600,7 @@ public class OdfPackage implements Closeable {
   /** Get all the file entries from a sub directory */
   private Map<String, OdfFileEntry> getSubDirectoryEntries(String directory) {
     directory = normalizeDirectoryPath(directory);
-    Map<String, OdfFileEntry> subEntries = new HashMap<String, OdfFileEntry>();
+    Map<String, OdfFileEntry> subEntries = new HashMap<>();
     Map<String, OdfFileEntry> allEntries = getManifestEntries();
     Set<String> rootEntryNameSet = getFilePaths();
     for (String entryName : rootEntryNameSet) {
@@ -1643,7 +1643,7 @@ public class OdfPackage implements Closeable {
    *     the given parameter.
    */
   Set<String> getDocumentPaths(String mediaTypeString, String subDirectory) {
-    Set<String> innerDocuments = new HashSet<String>();
+    Set<String> innerDocuments = new HashSet<>();
     Set<String> packageFilePaths = getFilePaths();
     // check manifest for current embedded OdfPackageDocuments
     for (String filePath : packageFilePaths) {
@@ -1678,7 +1678,7 @@ public class OdfPackage implements Closeable {
     OdfFileEntry fileEntry = null;
     if (!OdfFile.MANIFEST.internalPath.equals(internalPath) && !internalPath.equals(EMPTY_STRING)) {
       if (mManifestEntries == null) {
-        mManifestEntries = new HashMap<String, OdfFileEntry>();
+        mManifestEntries = new HashMap<>();
       }
       fileEntry = mManifestEntries.get(internalPath);
       // for every new file entry
@@ -2479,7 +2479,7 @@ public class OdfPackage implements Closeable {
     boolean isDirectory = path.endsWith(SLASH);
     StringTokenizer tokenizer = new StringTokenizer(path, SLASH);
     int tokenCount = tokenizer.countTokens();
-    List<String> tokenList = new ArrayList<String>(tokenCount);
+    List<String> tokenList = new ArrayList<>(tokenCount);
     // add all paths to a list
     while (tokenizer.hasMoreTokens()) {
       String token = tokenizer.nextToken();

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackageConstraint.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackageConstraint.java
@@ -156,8 +156,8 @@ public enum OdfPackageConstraint implements ValidationConstraint {
   /**
    * Returns the detail message string of this Constraint.
    *
-   * @return the detail message string of this <tt>Constraint</tt> instance (which may be
-   *     <tt>null</tt>).
+   * @return the detail message string of this <code>Constraint</code> instance (which may be
+   *     <code>null</code>).
    */
   public String getMessage() {
     return mMessage;

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfXMLFactory.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfXMLFactory.java
@@ -51,8 +51,8 @@ import org.w3c.dom.DOMException;
 public class OdfXMLFactory {
 
   private static final Logger LOG = Logger.getLogger(OdfXMLFactory.class.getName());
-  private static ConcurrentMap<OdfName, Class> mElementTypes = new ConcurrentHashMap<>();
-  private static ConcurrentMap<OdfName, Class> mAttributeTypes = new ConcurrentHashMap<>();
+  private static ConcurrentMap<OdfName, Class<?>> mElementTypes = new ConcurrentHashMap<>();
+  private static ConcurrentMap<OdfName, Class<?>> mAttributeTypes = new ConcurrentHashMap<>();
   private static final Map<String, String> mElementRenames =
       Map.of(
           "text:h", "text:heading",
@@ -96,7 +96,7 @@ public class OdfXMLFactory {
    * @param odfName the name of the ODF attribute the desired DOM class should represent.
    * @return the Java DOM attribute class to be mapped to a certain ODF attribute.
    */
-  private static Class getOdfAttributeClass(OdfName odfName) {
+  private static Class<?> getOdfAttributeClass(OdfName odfName) {
     return getOdfNodeClass(odfName, ATTRIBUTE_PACKAGE_NAME, mAttributeTypes);
   }
 
@@ -104,13 +104,13 @@ public class OdfXMLFactory {
    * @param odfName the name of the ODF element the desired DOM class should represent.
    * @return the Java DOM element class to be mapped to a certain ODF element.
    */
-  private static Class getOdfElementClass(OdfName odfName) {
+  private static Class<?> getOdfElementClass(OdfName odfName) {
     return getOdfNodeClass(odfName, ELEMENT_PACKAGE_NAME, mElementTypes);
   }
 
-  private static Class getOdfNodeClass(
-      OdfName odfName, String nodeType, ConcurrentMap<OdfName, Class> classCache) {
-    Class c = null;
+  private static Class<?> getOdfNodeClass(
+      OdfName odfName, String nodeType, ConcurrentMap<OdfName, Class<?>> classCache) {
+    Class<?> c = null;
     String className = "";
 
     c = classCache.get(odfName);
@@ -215,7 +215,7 @@ public class OdfXMLFactory {
     OdfElement element = null;
 
     // lookup registered element class for qname
-    Class elementClass = getOdfElementClass(name);
+    Class<?> elementClass = getOdfElementClass(name);
 
     // if a class was registered create an instance of that class
     if (elementClass != null) {
@@ -253,7 +253,7 @@ public class OdfXMLFactory {
     // SJ: but there exists elements & attributes having the same qName ("style:style")
     // so it is not ensured to get a OdfAttribute ... in case of "style:style" you get a
     // OdfStyle which is not a OdfAttribute :-(
-    Class attributeClass = getOdfAttributeClass(name);
+    Class<?> attributeClass = getOdfAttributeClass(name);
 
     // if a class was registered create an instance of that class
     if (attributeClass != null) {
@@ -294,10 +294,10 @@ public class OdfXMLFactory {
    * @return an object instance of the XML node class being provided (usually an attribute or
    *     element).
    */
-  static Object getNodeFromClass(OdfFileDom dom, Class nodeClass) {
+  static Object getNodeFromClass(OdfFileDom dom, Class<?> nodeClass) {
     Object o = null;
     try {
-      Constructor ctor = nodeClass.getConstructor(new Class[] {OdfFileDom.class});
+      Constructor<?> ctor = nodeClass.getConstructor(new Class[] {OdfFileDom.class});
       o = ctor.newInstance(new Object[] {dom});
     } catch (Exception cause) {
       // an exception at this point is a bug. Throw an Error

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/ValidationConstraint.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/ValidationConstraint.java
@@ -41,8 +41,8 @@ public interface ValidationConstraint {
   /**
    * Returns the detail message string of this Constraint.
    *
-   * @return the detail message string of this <tt>Constraint</tt> instance (which may be
-   *     <tt>null</tt>).
+   * @return the detail message string of this <code>Constraint</code> instance (which may be
+   *     <code>null</code>).
    */
   public String getMessage();
 }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
@@ -50,8 +50,8 @@ final class EvalContext implements NamespaceContext {
     super();
     this.base = base;
     this.parentSubject = base;
-    this.forwardProperties = new ArrayList<String>();
-    this.backwardProperties = new ArrayList<String>();
+    this.forwardProperties = new ArrayList<>();
+    this.backwardProperties = new ArrayList<>();
   }
 
   public EvalContext(EvalContext toCopy) {
@@ -60,8 +60,8 @@ final class EvalContext implements NamespaceContext {
     this.parentSubject = toCopy.parentSubject;
     this.parentObject = toCopy.parentObject;
     this.language = toCopy.language;
-    this.forwardProperties = new ArrayList<String>(toCopy.forwardProperties);
-    this.backwardProperties = new ArrayList<String>(toCopy.backwardProperties);
+    this.forwardProperties = new ArrayList<>(toCopy.forwardProperties);
+    this.backwardProperties = new ArrayList<>(toCopy.backwardProperties);
     this.parent = toCopy;
     this.vocab = toCopy.vocab;
   }
@@ -110,7 +110,7 @@ final class EvalContext implements NamespaceContext {
     if (uri.length() == 0) {
       uri = base;
     }
-    if (prefixMap == Collections.EMPTY_MAP) prefixMap = new HashMap<String, String>();
+    if (prefixMap == Collections.EMPTY_MAP) prefixMap = new HashMap<>();
     prefixMap.put(prefix, uri);
   }
 
@@ -137,7 +137,7 @@ final class EvalContext implements NamespaceContext {
     if (uri.length() == 0) {
       uri = base;
     }
-    if (xmlnsMap == Collections.EMPTY_MAP) xmlnsMap = new HashMap<String, String>();
+    if (xmlnsMap == Collections.EMPTY_MAP) xmlnsMap = new HashMap<>();
     xmlnsMap.put(prefix, uri);
   }
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/EvalContext.java
@@ -155,7 +155,7 @@ final class EvalContext implements NamespaceContext {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
-  public Iterator getPrefixes(String uri) {
+  public Iterator<String> getPrefixes(String uri) {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/JenaSink.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/JenaSink.java
@@ -46,12 +46,12 @@ public class JenaSink implements StatementSink {
 
   public JenaSink(OdfFileDom mFileDom) {
     this.mFileDom = mFileDom;
-    this.bnodeLookup = new HashMap<String, Resource>();
+    this.bnodeLookup = new HashMap<>();
   }
 
   // @Override
   public void start() {
-    bnodeLookup = new HashMap<String, Resource>();
+    bnodeLookup = new HashMap<>();
   }
 
   // @Override

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/RDFaParser.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/RDFaParser.java
@@ -146,8 +146,8 @@ class RDFaParser extends net.rootdev.javardfa.Parser {
     boolean skipElement = false;
     String newSubject = null;
     String currentObject = null;
-    List<String> forwardProperties = new ArrayList();
-    List<String> backwardProperties = new ArrayList();
+    List<String> forwardProperties = new ArrayList<>();
+    List<String> backwardProperties = new ArrayList<>();
     String currentLanguage = context.language;
 
     if (settings.contains(Setting.OnePointOne)) {
@@ -339,8 +339,8 @@ class RDFaParser extends net.rootdev.javardfa.Parser {
     return qname.substring(prefix.length() + 1);
   }
 
-  private Iterator fromAttributes(Attributes attributes) {
-    List toReturn = new ArrayList();
+  private Iterator<Attribute> fromAttributes(Attributes attributes) {
+    List<Attribute> toReturn = new ArrayList<>();
 
     for (int i = 0; i < attributes.getLength(); i++) {
       String qname = attributes.getQName(i);
@@ -381,9 +381,9 @@ class RDFaParser extends net.rootdev.javardfa.Parser {
     if (name == null || element == null) {
       return null;
     }
-    Iterator it = element.getAttributes();
+    Iterator<Attribute> it = element.getAttributes();
     while (it.hasNext()) {
-      Attribute at = (Attribute) it.next();
+      Attribute at = it.next();
       if (Util.qNameEquals(at.getName(), name)) {
         return at;
       }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/URIExtractorImpl.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/rdfa/URIExtractorImpl.java
@@ -78,7 +78,7 @@ class URIExtractorImpl implements URIExtractor {
 
   public List<String> getURIs(StartElement element, Attribute attr, EvalContext context) {
 
-    List<String> uris = new ArrayList<String>();
+    List<String> uris = new ArrayList<>();
 
     String[] curies = attr.getValue().split("\\s+");
     boolean permitReserved =
@@ -124,7 +124,7 @@ class URIExtractorImpl implements URIExtractor {
       namespaceURI = element.getNamespaceURI(prefix);
       if (isForSAX) {
         if (namespaceURI != null) {
-          if (xmlnsMap == Collections.EMPTY_MAP) xmlnsMap = new HashMap<String, String>();
+          if (xmlnsMap == Collections.EMPTY_MAP) xmlnsMap = new HashMap<>();
           xmlnsMap.put(prefix, namespaceURI);
         }
       } else {
@@ -171,7 +171,7 @@ class URIExtractorImpl implements URIExtractor {
   }
 
   public void setNamespaceURI(String prefix, String namespaceURI) {
-    if (xmlnsMap == Collections.EMPTY_MAP) xmlnsMap = new HashMap<String, String>();
+    if (xmlnsMap == Collections.EMPTY_MAP) xmlnsMap = new HashMap<>();
     xmlnsMap.put(prefix, namespaceURI);
   }
 }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/CURIEs.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/CURIEs.java
@@ -71,7 +71,7 @@ public class CURIEs implements OdfDataType {
       throw new IllegalArgumentException("parameter is invalid for datatype CURIEs");
     }
 
-    List<CURIE> aRet = new ArrayList<CURIE>();
+    List<CURIE> aRet = new ArrayList<>();
     String[] names = stringValue.split(" ");
     for (int i = 0; i < names.length; i++) {
       aRet.add(new CURIE(names[i]));
@@ -85,7 +85,7 @@ public class CURIEs implements OdfDataType {
    * @return a list of CURIE
    */
   public List<CURIE> getCURIEList() {
-    List<CURIE> aRet = new ArrayList<CURIE>();
+    List<CURIE> aRet = new ArrayList<>();
     String[] names = mCURIEs.split(" ");
     for (int i = 0; i < names.length; i++) {
       aRet.add(new CURIE(names[i]));

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/CURIEs.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/CURIEs.java
@@ -19,8 +19,8 @@
 package org.odftoolkit.odfdom.type;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /** This class represents the in OpenDocument format used data type {@odf.datatype CURIEs} */
 public class CURIEs implements OdfDataType {
@@ -37,16 +37,7 @@ public class CURIEs implements OdfDataType {
     if ((curies == null) || (curies.size() == 0)) {
       throw new IllegalArgumentException("parameter can not be null for CURIEs");
     }
-    StringBuilder aRet = new StringBuilder();
-    Iterator<CURIE> aIter = curies.iterator();
-    while (aIter.hasNext()) {
-      if (aRet.length() > 0) {
-        aRet.append(' ');
-      }
-      String aCurie = aIter.next().toString();
-      aRet.append(aCurie);
-    }
-    mCURIEs = aRet.toString();
+    mCURIEs = curies.stream().map(CURIE::toString).collect(Collectors.joining(" "));
   }
 
   /**
@@ -73,8 +64,8 @@ public class CURIEs implements OdfDataType {
 
     List<CURIE> aRet = new ArrayList<>();
     String[] names = stringValue.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      aRet.add(new CURIE(names[i]));
+    for (String name : names) {
+      aRet.add(new CURIE(name));
     }
     return new CURIEs(aRet);
   }
@@ -87,8 +78,8 @@ public class CURIEs implements OdfDataType {
   public List<CURIE> getCURIEList() {
     List<CURIE> aRet = new ArrayList<>();
     String[] names = mCURIEs.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      aRet.add(new CURIE(names[i]));
+    for (String name : names) {
+      aRet.add(new CURIE(name));
     }
     return aRet;
   }
@@ -109,8 +100,8 @@ public class CURIEs implements OdfDataType {
     }
 
     String[] names = stringValue.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      if (!CURIE.isValid(names[i])) {
+    for (String name : names) {
+      if (!CURIE.isValid(name)) {
         return false;
       }
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/CellRangeAddressList.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/CellRangeAddressList.java
@@ -82,7 +82,7 @@ public class CellRangeAddressList implements OdfDataType {
       throw new IllegalArgumentException("parameter is invalid for datatype CellRangeAddressList");
     }
 
-    List<CellRangeAddress> aRet = new ArrayList<CellRangeAddress>();
+    List<CellRangeAddress> aRet = new ArrayList<>();
     String[] names = stringValue.split(" ");
     for (int i = 0; i < names.length; i++) {
       aRet.add(new CellRangeAddress(names[i]));
@@ -96,7 +96,7 @@ public class CellRangeAddressList implements OdfDataType {
    * @return a list of CellRangeAddress
    */
   public List<CellRangeAddress> getCellRangesAddressList() {
-    List<CellRangeAddress> aRet = new ArrayList<CellRangeAddress>();
+    List<CellRangeAddress> aRet = new ArrayList<>();
     String[] names = mCellRangeAddressList.split(" ");
     for (int i = 0; i < names.length; i++) {
       aRet.add(new CellRangeAddress(names[i]));

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/CellRangeAddressList.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/CellRangeAddressList.java
@@ -24,8 +24,8 @@
 package org.odftoolkit.odfdom.type;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This class represents the in OpenDocument format used data type {@odf.datatype
@@ -47,16 +47,9 @@ public class CellRangeAddressList implements OdfDataType {
       throw new IllegalArgumentException("parameter can not be null for CellRangeAddressList");
     }
 
-    StringBuilder aRet = new StringBuilder();
-    Iterator<CellRangeAddress> aIter = cellRangeAddressList.iterator();
-    while (aIter.hasNext()) {
-      if (aRet.length() > 0) {
-        aRet.append(' ');
-      }
-      String aAddress = aIter.next().toString();
-      aRet.append(aAddress);
-    }
-    mCellRangeAddressList = aRet.toString();
+    mCellRangeAddressList = cellRangeAddressList.stream()
+      .map(CellRangeAddress::toString)
+      .collect(Collectors.joining(" "));
   }
 
   // TODO: Should a cell address stay a string?
@@ -84,8 +77,8 @@ public class CellRangeAddressList implements OdfDataType {
 
     List<CellRangeAddress> aRet = new ArrayList<>();
     String[] names = stringValue.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      aRet.add(new CellRangeAddress(names[i]));
+    for (String name : names) {
+      aRet.add(new CellRangeAddress(name));
     }
     return new CellRangeAddressList(aRet);
   }
@@ -98,8 +91,8 @@ public class CellRangeAddressList implements OdfDataType {
   public List<CellRangeAddress> getCellRangesAddressList() {
     List<CellRangeAddress> aRet = new ArrayList<>();
     String[] names = mCellRangeAddressList.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      aRet.add(new CellRangeAddress(names[i]));
+    for (String name : names) {
+      aRet.add(new CellRangeAddress(name));
     }
     return aRet;
   }
@@ -120,8 +113,8 @@ public class CellRangeAddressList implements OdfDataType {
     }
 
     String[] names = stringValue.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      if (!CellRangeAddress.isValid(names[i])) {
+    for (String name : names) {
+      if (!CellRangeAddress.isValid(name)) {
         return false;
       }
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/IDREFS.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/IDREFS.java
@@ -24,8 +24,8 @@
 package org.odftoolkit.odfdom.type;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /** This class represents the in OpenDocument format used data type {@odf.datatype IDREFS} */
 public class IDREFS implements OdfDataType {
@@ -42,16 +42,7 @@ public class IDREFS implements OdfDataType {
     if ((idRefList == null) || (idRefList.size() == 0)) {
       throw new IllegalArgumentException("parameter can not be null for IDREFS");
     }
-    StringBuilder aRet = new StringBuilder();
-    Iterator<IDREF> aIter = idRefList.iterator();
-    while (aIter.hasNext()) {
-      if (aRet.length() > 0) {
-        aRet.append(' ');
-      }
-      String styleName = aIter.next().toString();
-      aRet.append(styleName);
-    }
-    mIdRefs = aRet.toString();
+    mIdRefs = idRefList.stream().map(IDREF::toString).collect(Collectors.joining(" "));
   }
 
   /**
@@ -78,8 +69,8 @@ public class IDREFS implements OdfDataType {
 
     List<IDREF> aRet = new ArrayList<>();
     String[] names = stringValue.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      aRet.add(new IDREF(names[i]));
+    for (String name : names) {
+      aRet.add(new IDREF(name));
     }
     return new IDREFS(aRet);
   }
@@ -92,8 +83,8 @@ public class IDREFS implements OdfDataType {
   public List<IDREF> getIDREFList() {
     List<IDREF> aRet = new ArrayList<>();
     String[] names = mIdRefs.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      aRet.add(new IDREF(names[i]));
+    for (String name : names) {
+      aRet.add(new IDREF(name));
     }
     return aRet;
   }
@@ -114,8 +105,8 @@ public class IDREFS implements OdfDataType {
     }
 
     String[] names = stringValue.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      if (!IDREF.isValid(names[i])) {
+    for (String name : names) {
+      if (!IDREF.isValid(name)) {
         return false;
       }
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/IDREFS.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/IDREFS.java
@@ -76,7 +76,7 @@ public class IDREFS implements OdfDataType {
       throw new IllegalArgumentException("parameter is invalid for datatype IDREFS");
     }
 
-    List<IDREF> aRet = new ArrayList<IDREF>();
+    List<IDREF> aRet = new ArrayList<>();
     String[] names = stringValue.split(" ");
     for (int i = 0; i < names.length; i++) {
       aRet.add(new IDREF(names[i]));
@@ -90,7 +90,7 @@ public class IDREFS implements OdfDataType {
    * @return a list of IDREF
    */
   public List<IDREF> getIDREFList() {
-    List<IDREF> aRet = new ArrayList<IDREF>();
+    List<IDREF> aRet = new ArrayList<>();
     String[] names = mIdRefs.split(" ");
     for (int i = 0; i < names.length; i++) {
       aRet.add(new IDREF(names[i]));

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/StyleNameRefs.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/StyleNameRefs.java
@@ -25,8 +25,8 @@ package org.odftoolkit.odfdom.type;
 
 /** This class represents the in OpenDocument format used data type {@odf.datatype styleNameRefs} */
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class StyleNameRefs implements OdfDataType {
 
@@ -42,16 +42,7 @@ public class StyleNameRefs implements OdfDataType {
     if (styleNames == null) {
       throw new IllegalArgumentException("parameter can not be null for StyleNameRefs");
     }
-    StringBuilder aRet = new StringBuilder();
-    Iterator<StyleName> aIter = styleNames.iterator();
-    while (aIter.hasNext()) {
-      if (aRet.length() > 0) {
-        aRet.append(' ');
-      }
-      String aStyleName = aIter.next().toString();
-      aRet.append(aStyleName);
-    }
-    mStyleNames = aRet.toString();
+    mStyleNames = styleNames.stream().map(StyleName::toString).collect(Collectors.joining(" "));
   }
 
   /**
@@ -79,8 +70,8 @@ public class StyleNameRefs implements OdfDataType {
     List<StyleName> aRet = new ArrayList<>();
     if (stringValue.length() > 0) {
       String[] names = stringValue.split(" ");
-      for (int i = 0; i < names.length; i++) {
-        aRet.add(new StyleName(names[i]));
+      for (String name : names) {
+        aRet.add(new StyleName(name));
       }
     }
     return new StyleNameRefs(aRet);
@@ -95,8 +86,8 @@ public class StyleNameRefs implements OdfDataType {
     List<StyleName> aRet = new ArrayList<>();
     if (mStyleNames.length() > 0) {
       String[] names = mStyleNames.split(" ");
-      for (int i = 0; i < names.length; i++) {
-        aRet.add(new StyleName(names[i]));
+      for (String name : names) {
+        aRet.add(new StyleName(name));
       }
     }
     return aRet;
@@ -118,8 +109,8 @@ public class StyleNameRefs implements OdfDataType {
     }
 
     String[] names = stringValue.split(" ");
-    for (int i = 0; i < names.length; i++) {
-      if (!StyleNameRef.isValid(names[i])) {
+    for (String name : names) {
+      if (!StyleNameRef.isValid(name)) {
         return false;
       }
     }

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/StyleNameRefs.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/StyleNameRefs.java
@@ -76,7 +76,7 @@ public class StyleNameRefs implements OdfDataType {
       throw new IllegalArgumentException("parameter is invalid for datatype StyleNameRefs");
     }
 
-    List<StyleName> aRet = new ArrayList<StyleName>();
+    List<StyleName> aRet = new ArrayList<>();
     if (stringValue.length() > 0) {
       String[] names = stringValue.split(" ");
       for (int i = 0; i < names.length; i++) {
@@ -92,7 +92,7 @@ public class StyleNameRefs implements OdfDataType {
    * @return a list of StyleNameRef
    */
   public List<StyleName> getStyleNameRefList() {
-    List<StyleName> aRet = new ArrayList<StyleName>();
+    List<StyleName> aRet = new ArrayList<>();
     if (mStyleNames.length() > 0) {
       String[] names = mStyleNames.split(" ");
       for (int i = 0; i < names.length; i++) {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/URITransformer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/URITransformer.java
@@ -142,7 +142,7 @@ import java.util.logging.Logger;
  * scheme-specific part, and possibly a fragment, but has no other components. A hierarchical URI
  * always has a path (though it may be empty) and a scheme-specific-part (which at least contains
  * the path), and may have any of the other components. If the authority component is present and is
- * server-based then the host component will be defined and the user-information and port components
+ * server-based, then the host component will be defined and the user-information and port components
  * may be defined.
  *
  * <p>See <a href="http://www.isi.edu/in-notes/rfc2396.txt"><i>RFC&nbsp;2396: Uniform Resource

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/URITransformer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/URITransformer.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
  * A URI is a uniform resource <i>identifier</i> while a URL is a uniform resource <i>locator</i>.
  * Hence every URL is a URI, abstractly speaking, but not every URI is a URL. This is because there
  * is another subcategory of URIs, uniform resource <i>names</i> (URNs), which name resources but do
- * not specify how to locate them. The <tt>mailto</tt>, <tt>news</tt>, and <tt>isbn</tt> URIs shown
+ * not specify how to locate them. The <code>mailto</code>, <code>news</code>, and <code>isbn</code> URIs shown
  * above are examples of URNs.
  *
  * <h4>URI syntax and components</h4>
@@ -46,27 +46,27 @@ import java.util.logging.Logger;
  *
  * <blockquote>
  *
- * [<i>scheme</i><tt><b>:</b></tt><i></i>]<i>scheme-specific-part</i>[<tt><b>#</b></tt><i>fragment</i>]
+ * [<i>scheme</i><code><b>:</b></code><i></i>]<i>scheme-specific-part</i>[<code><b>#</b></code><i>fragment</i>]
  *
  * </blockquote>
  *
- * where square brackets [...] delineate optional components and the characters <tt><b>:</b></tt>
- * and <tt><b>#</b></tt> stand for themselves.
+ * where square brackets [...] delineate optional components and the characters <code><b>:</b></code>
+ * and <code><b>#</b></code> stand for themselves.
  *
  * <p>An <i>absolute</i> URI specifies a scheme; a URI that is not absolute is said to be
  * <i>relative</i>. URIs are also classified according to whether they are <i>opaque</i> or
  * <i>hierarchical</i>.
  *
  * <p>An <i>opaque</i> URI is an absolute URI whose scheme-specific part does not begin with a slash
- * character (<tt>'/'</tt>). Opaque URIs are not subject to further parsing. Some examples of opaque
+ * character (<code>'/'</code>). Opaque URIs are not subject to further parsing. Some examples of opaque
  * URIs are:
  *
  * <blockquote>
  *
  * <table cellpadding=0 cellspacing=0>
- * <tr><td><tt>mailto:java-net@java.sun.com</tt><td></tr>
- * <tr><td><tt>news:comp.lang.java</tt><td></tr>
- * <tr><td><tt>urn:isbn:096139210x</td></tr>
+ * <tr><td><code>mailto:java-net@java.sun.com</code><td></tr>
+ * <tr><td><code>news:comp.lang.java</code><td></tr>
+ * <tr><td><code>urn:isbn:096139210x</code></td></tr>
  * </table>
  *
  * </blockquote>
@@ -77,9 +77,10 @@ import java.util.logging.Logger;
  *
  * <blockquote>
  *
- * <tt>http://java.sun.com/j2se/1.3/</tt><br>
- * <tt>docs/guide/collections/designfaq.html#28</tt></br>
- * <tt>../../../demo/jfc/SwingSet2/src/SwingSet2.java</tt></br> <tt>file:///~/calendar</tt>
+ * <code>http://java.sun.com/j2se/1.3/</code><br>
+ * <code>docs/guide/collections/designfaq.html#28</code><br>
+ * <code>../../../demo/jfc/SwingSet2/src/SwingSet2.java</code><br>
+ * <code>file:///~/calendar</code>
  *
  * </blockquote>
  *
@@ -87,12 +88,12 @@ import java.util.logging.Logger;
  *
  * <blockquote>
  *
- * [<i>scheme</i><tt><b>:</b></tt>][<tt><b>//</b></tt><i>authority</i>][<i>path</i>][<tt><b>?</b></tt><i>query</i>][<tt><b>#</b></tt><i>fragment</i>]
+ * [<i>scheme</i><code><b>:</b></code>][<code><b>//</b></code><i>authority</i>][<i>path</i>][<code><b>?</b></code><i>query</i>][<code><b>#</b></code><i>fragment</i>]
  *
  * </blockquote>
  *
- * where the characters <tt><b>:</b></tt>, <tt><b>/</b></tt>, <tt><b>?</b></tt>, and
- * <tt><b>#</b></tt> stand for themselves. The scheme-specific part of a hierarchical URI consists
+ * where the characters <code><b>:</b></code>, <code><b>/</b></code>, <code><b>?</b></code>, and
+ * <code><b>#</b></code> stand for themselves. The scheme-specific part of a hierarchical URI consists
  * of the characters between the scheme and fragment components.
  *
  * <p>The authority component of a hierarchical URI is, if specified, either <i>server-based</i> or
@@ -100,16 +101,16 @@ import java.util.logging.Logger;
  *
  * <blockquote>
  *
- * [<i>user-info</i><tt><b>@</b></tt>]<i>host</i>[<tt><b>:</b></tt><i>port</i>]
+ * [<i>user-info</i><code><b>@</b></code>]<i>host</i>[<code><b>:</b></code><i>port</i>]
  *
  * </blockquote>
  *
- * where the characters <tt><b>@</b></tt> and <tt><b>:</b></tt> stand for themselves. Nearly all URI
+ * where the characters <code><b>@</b></code> and <code><b>:</b></code> stand for themselves. Nearly all URI
  * schemes currently in use are server-based. An authority component that does not parse in this way
  * is considered to be registry-based.
  *
  * <p>The path component of a hierarchical URI is itself said to be absolute if it begins with a
- * slash character (<tt>'/'</tt>); otherwise it is relative. The path of a hierarchical URI that is
+ * slash character (<code>'/'</code>); otherwise it is relative. The path of a hierarchical URI that is
  * either absolute or specifies an authority is always absolute.
  *
  * <p>All told, then, a URI instance has the following nine components:
@@ -118,22 +119,22 @@ import java.util.logging.Logger;
  *
  * <table>
  * <tr><td><i>Component</i></td><td><i>Type</i></td></tr>
- * <tr><td>scheme</td><td><tt>String</tt></td></tr>
- * <tr><td>scheme-specific-part&nbsp;&nbsp;&nbsp;&nbsp;</td><td><tt>String</tt></td></tr>
- * <tr><td>authority</td><td><tt>String</tt></td></tr>
- * <tr><td>user-info</td><td><tt>String</tt></td></tr>
- * <tr><td>host</td><td><tt>String</tt></td></tr>
- * <tr><td>port</td><td><tt>int</tt></td></tr>
- * <tr><td>path</td><td><tt>String</tt></td></tr>
- * <tr><td>query</td><td><tt>String</tt></td></tr>
- * <tr><td>fragment</td><td><tt>String</tt></td></tr>
+ * <tr><td>scheme</td><td><code>String</code></td></tr>
+ * <tr><td>scheme-specific-part&nbsp;&nbsp;&nbsp;&nbsp;</td><td><code>String</code></td></tr>
+ * <tr><td>authority</td><td><code>String</code></td></tr>
+ * <tr><td>user-info</td><td><code>String</code></td></tr>
+ * <tr><td>host</td><td><code>String</code></td></tr>
+ * <tr><td>port</td><td><code>int</code></td></tr>
+ * <tr><td>path</td><td><code>String</code></td></tr>
+ * <tr><td>query</td><td><code>String</code></td></tr>
+ * <tr><td>fragment</td><td><code>String</code></td></tr>
  * </table>
  *
  * </blockquote>
  *
  * In a given instance any particular component is either <i>undefined</i> or <i>defined</i> with a
- * distinct value. Undefined string components are represented by <tt>null</tt>, while undefined
- * integer components are represented by <tt>-1</tt>. A string component may be defined to have the
+ * distinct value. Undefined string components are represented by <code>null</code>, while undefined
+ * integer components are represented by <code>-1</code>. A string component may be defined to have the
  * empty string as its value; this is not equivalent to that component being undefined.
  *
  * <p>Whether a particular component is or is not defined in an instance depends upon the type of
@@ -144,7 +145,7 @@ import java.util.logging.Logger;
  * server-based then the host component will be defined and the user-information and port components
  * may be defined.
  *
- * <p>See <a href="http://www.isi.edu/in-notes/rfc2396.txt""><i>RFC&nbsp;2396: Uniform Resource
+ * <p>See <a href="http://www.isi.edu/in-notes/rfc2396.txt"><i>RFC&nbsp;2396: Uniform Resource
  * Identifiers (URI): Generic Syntax</i></a>
  */
 class URITransformer {

--- a/odfdom/src/main/java/org/odftoolkit/odfdom/type/URITransformer.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/type/URITransformer.java
@@ -206,8 +206,8 @@ class URITransformer {
       StringBuilder pathc = new StringBuilder();
       byte[] bytes = null;
       bytes = path.getBytes("UTF-8");
-      for (int i = 0; i < bytes.length; i++) {
-        int v = bytes[i];
+      for (int aByte : bytes) {
+        int v = aByte;
         if (v < 0) {
           v += 256;
         }

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/changes/EditingRegressionTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/changes/EditingRegressionTest.java
@@ -661,7 +661,7 @@ public class EditingRegressionTest extends RoundtripTestHelper {
     final String SOURCE_FILE_NAME_TRUNC = "image-attributes";
     final String UID = "d03f7d7218eb";
     final String INTERNAL_IMAGE_PATH = "Pictures/uid" + UID + ".jpg";
-    Map<Long, byte[]> resourceMap = new HashMap<Long, byte[]>();
+    Map<Long, byte[]> resourceMap = new HashMap<>();
     byte[] imageBytes = null;
     try {
       imageBytes =

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/changes/RoundtripTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/changes/RoundtripTest.java
@@ -59,7 +59,7 @@ public class RoundtripTest extends RoundtripTestHelper {
 
   @Parameters(name = "Test# {index}: {0}")
   public static Collection<Object[]> data() {
-    Collection<Object[]> testSuiteData = new ArrayList<Object[]>();
+    Collection<Object[]> testSuiteData = new ArrayList<>();
     addFilesFromFolder(new File(TEST_INPUT_DIR), testSuiteData);
     return testSuiteData;
   }

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/changes/RoundtripTestHelper.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/changes/RoundtripTestHelper.java
@@ -265,7 +265,7 @@ class RoundtripTestHelper {
         testFile = ResourceUtilities.getTestInputFile(testFileNameTrunc + testfileNameSuffix);
       }
       FileInputStream fis = new FileInputStream(testFile);
-      Map<String, Object> configuration = new HashMap<String, Object>();
+      Map<String, Object> configuration = new HashMap<>();
       configuration.put(CONFIG_MAX_TABLE_COLUMNS, 0);
       configuration.put(CONFIG_MAX_TABLE_CELLS, 0);
       configuration.put(CONFIG_MAX_TABLE_ROWS, 0);
@@ -402,7 +402,7 @@ class RoundtripTestHelper {
         FileInputStream emptyDocFis = null;
         emptyDocFis =
             new FileInputStream(ResourceUtilities.getTestInputFile(EMPTY_AS_CAN_BE + ODT_SUFFIX));
-        Map<String, Object> configuration = new HashMap<String, Object>();
+        Map<String, Object> configuration = new HashMap<>();
         configuration.put("debugoperations", operationDebugMode);
         if (resourceMap != null) {
           emptyDoc = new CollabTextDocument(emptyDocFis, resourceMap, configuration);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentTest.java
@@ -474,47 +474,53 @@ public class DocumentTest {
   @Test
   public void validationTest() {
     // TESTDOC2: Expected ODF Warnings
-    Map expectedWarning2 = new HashMap();
-    expectedWarning2.put(OdfPackageConstraint.MIMETYPE_NOT_IN_PACKAGE, 1);
-    expectedWarning2.put(OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 10);
+    Map<ValidationConstraint, Integer> expectedWarning2 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MIMETYPE_NOT_IN_PACKAGE, 1,
+      OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 10
+    ));
 
     // TESTDOC2: Expected ODF Errors
-    Map expectedErrors2 = new HashMap();
-    expectedErrors2.put(OdfPackageConstraint.MANIFEST_DOES_NOT_LIST_FILE, 1);
-    expectedErrors2.put(OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 3);
-    expectedErrors2.put(OdfSchemaConstraint.DOCUMENT_WITHOUT_CONTENT_NOR_STYLES_XML, 1);
-    expectedErrors2.put(OdfSchemaConstraint.PACKAGE_SHALL_CONTAIN_MIMETYPE, 1);
+    Map<ValidationConstraint, Integer> expectedErrors2 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MANIFEST_DOES_NOT_LIST_FILE, 1,
+      OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 3,
+      OdfSchemaConstraint.DOCUMENT_WITHOUT_CONTENT_NOR_STYLES_XML, 1,
+      OdfSchemaConstraint.PACKAGE_SHALL_CONTAIN_MIMETYPE, 1
+    ));
     ErrorHandlerStub handler2 = new ErrorHandlerStub(expectedWarning2, expectedErrors2, null);
     handler2.setTestFilePath("testInvalidPkg2.odt");
 
     // TESTDOC3: Expected ODF Warnings
-    Map expectedWarning3 = new HashMap();
-    expectedWarning3.put(OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 21);
+    Map<ValidationConstraint, Integer> expectedWarning3 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 21
+    ));
 
     // TESTDOC3: Expected ODF Errors
-    Map expectedErrors3 = new HashMap();
-    expectedErrors3.put(OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 2);
-    expectedErrors3.put(OdfSchemaConstraint.DOCUMENT_WITHOUT_CONTENT_NOR_STYLES_XML, 1);
-    expectedErrors3.put(OdfPackageConstraint.MANIFEST_WITH_EMPTY_PATH, 1);
+    Map<ValidationConstraint, Integer> expectedErrors3 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 2,
+      OdfSchemaConstraint.DOCUMENT_WITHOUT_CONTENT_NOR_STYLES_XML, 1,
+      OdfPackageConstraint.MANIFEST_WITH_EMPTY_PATH, 1
+    ));
     ErrorHandlerStub handler3 = new ErrorHandlerStub(expectedWarning3, expectedErrors3, null);
     handler3.setTestFilePath("performance/Presentation1_INVALID.odp");
 
     // TESTDOC1: Expected ODF Warnings
-    Map expectedWarning1 = new HashMap();
-    expectedWarning1.put(OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 10);
+    Map<ValidationConstraint, Integer> expectedWarning1 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 10
+    ));
 
     // TESTDOC1: Expected ODF Errors
-    Map expectedErrors1 = new HashMap();
-    expectedErrors1.put(OdfPackageConstraint.MIMETYPE_NOT_FIRST_IN_PACKAGE, 1);
-    expectedErrors1.put(OdfPackageConstraint.MIMETYPE_IS_COMPRESSED, 1);
-    expectedErrors1.put(OdfPackageConstraint.MIMETYPE_HAS_EXTRA_FIELD, 1);
-    expectedErrors1.put(OdfPackageConstraint.MIMETYPE_DIFFERS_FROM_PACKAGE, 1);
-    expectedErrors1.put(OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 1);
+    Map<ValidationConstraint, Integer> expectedErrors1 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MIMETYPE_NOT_FIRST_IN_PACKAGE, 1,
+      OdfPackageConstraint.MIMETYPE_IS_COMPRESSED, 1,
+      OdfPackageConstraint.MIMETYPE_HAS_EXTRA_FIELD, 1,
+      OdfPackageConstraint.MIMETYPE_DIFFERS_FROM_PACKAGE, 1,
+      OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 1
+    ));
 
     // TESTDOC1: Expected ODF FatalErrors
-    Map<ValidationConstraint, Integer> expectedFatalErrors1 =
-      new HashMap<>();
-    expectedFatalErrors1.put(OdfSchemaConstraint.DOCUMENT_WITHOUT_ODF_MIMETYPE, 1);
+    Map<ValidationConstraint, Integer> expectedFatalErrors1 = new HashMap<>(Map.of(
+      OdfSchemaConstraint.DOCUMENT_WITHOUT_ODF_MIMETYPE, 1
+    ));
 
     ErrorHandlerStub handler1 =
         new ErrorHandlerStub(expectedWarning1, expectedErrors1, expectedFatalErrors1);
@@ -537,7 +543,7 @@ public class DocumentTest {
               handler3);
       OdfDocument doc3 = OdfDocument.loadDocument(pkg3);
       Assert.assertNotNull(doc3);
-      Map subDocs = doc3.loadSubDocuments();
+      Map<String, OdfDocument> subDocs = doc3.loadSubDocuments();
       Assert.assertNotNull(subDocs);
       Assert.assertEquals(PRESENTATION1_DOC_COUNT, subDocs.size());
 

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/DocumentTest.java
@@ -513,7 +513,7 @@ public class DocumentTest {
 
     // TESTDOC1: Expected ODF FatalErrors
     Map<ValidationConstraint, Integer> expectedFatalErrors1 =
-        new HashMap<ValidationConstraint, Integer>();
+      new HashMap<>();
     expectedFatalErrors1.put(OdfSchemaConstraint.DOCUMENT_WITHOUT_ODF_MIMETYPE, 1);
 
     ErrorHandlerStub handler1 =

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/ImageTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/ImageTest.java
@@ -115,18 +115,18 @@ public class ImageTest {
     OdfDocument doc = OdfDocument.loadDocument(ResourceUtilities.getAbsoluteInputPath("image.odt"));
     final OdfPackage pkg = doc.getPackage();
     NodeAction<?> removeImages =
-        new NodeAction<Object>() {
+      new NodeAction<>() {
 
-          @Override
-          protected void apply(Node node, Object arg, int depth) {
-            if (node instanceof OdfDrawImage) {
-              OdfDrawImage img = (OdfDrawImage) node;
-              String ref = img.getAttributeNS(OdfDocumentNamespace.XLINK.getUri(), "href");
-              pkg.remove(ref);
-              img.getParentNode().removeChild(img);
-            }
+        @Override
+        protected void apply(Node node, Object arg, int depth) {
+          if (node instanceof OdfDrawImage) {
+            OdfDrawImage img = (OdfDrawImage) node;
+            String ref = img.getAttributeNS(OdfDocumentNamespace.XLINK.getUri(), "href");
+            pkg.remove(ref);
+            img.getParentNode().removeChild(img);
           }
-        };
+        }
+      };
     removeImages.performAction(doc.getContentDom().getDocumentElement(), null);
     pkg.save(ResourceUtilities.getTestOutputFile("remove-images_output.odt"));
   }

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/ImageTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/ImageTest.java
@@ -73,8 +73,8 @@ public class ImageTest {
       OdfDocument doc =
           OdfDocument.loadDocument(ResourceUtilities.getAbsoluteInputPath("image.odt"));
       final OdfPackage pkg = doc.getPackage();
-      NodeAction addImages =
-          new NodeAction() {
+      NodeAction<?> addImages =
+          new NodeAction<>() {
 
             @Override
             protected void apply(Node node, Object arg, int depth) {

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
@@ -1220,7 +1220,7 @@ public class TableTest {
       NodeList lstMasterPages =
           stylesDoc.getElementsByTagNameNS(OdfDocumentNamespace.STYLE.getUri(), "master-page");
       if (lstMasterPages != null && lstMasterPages.getLength() > 0) {
-        masterPages = new HashMap<String, StyleMasterPageElement>();
+        masterPages = new HashMap<>();
         for (int i = 0; i < lstMasterPages.getLength(); i++) {
           StyleMasterPageElement masterPage =
               (StyleMasterPageElement) lstMasterPages.item(i); // Take the node from the list
@@ -1249,7 +1249,7 @@ public class TableTest {
     Assert.assertNotNull(pagePropsElement);
 
     // fill map with header attributes name/values
-    HashMap<String, String> pageProps = new HashMap<String, String>();
+    HashMap<String, String> pageProps = new HashMap<>();
     NamedNodeMap pageAttrs = pagePropsElement.getAttributes();
     for (int i = 0; i < pageAttrs.getLength(); i++) {
       pageProps.put(
@@ -1273,7 +1273,7 @@ public class TableTest {
         OdfElement.findFirstChildNode(StyleHeaderFooterPropertiesElement.class, headerStyle);
     Assert.assertNotNull(headerStyleProps);
     // fill map with header attributes name/values
-    HashMap<String, String> headerProps = new HashMap<String, String>();
+    HashMap<String, String> headerProps = new HashMap<>();
     NamedNodeMap headerAttrs = headerStyleProps.getAttributes();
     for (int i = 0; i < headerAttrs.getLength(); i++) {
       headerProps.put(
@@ -1298,7 +1298,7 @@ public class TableTest {
     Assert.assertNotNull(footerStyleProps);
 
     // fill map with header attributes name/values
-    HashMap<String, String> footerProps = new HashMap<String, String>();
+    HashMap<String, String> footerProps = new HashMap<>();
     NamedNodeMap footerAttrs = footerStyleProps.getAttributes();
     for (int i = 0; i < footerAttrs.getLength(); i++) {
       footerProps.put(

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/doc/table/TableTest.java
@@ -369,8 +369,7 @@ public class TableTest {
           OdfTextDocument.loadDocument(
               ResourceUtilities.getAbsoluteInputPath(mOdtTestFileName + ".odt"));
       List<OdfTable> tableList = mOdtDoc.getTableList(true);
-      for (int i = 0; i < tableList.size(); i++) {
-        OdfTable table = tableList.get(i);
+      for (OdfTable table : tableList) {
         int clmnum = table.getColumnCount();
         table.appendColumn();
         Assert.assertEquals(clmnum + 1, table.getColumnCount());

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/dom/example/StyleExamplesTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/dom/example/StyleExamplesTest.java
@@ -96,7 +96,7 @@ public class StyleExamplesTest {
 
     OdfElement documentRoot = (OdfElement) odfDocument.getContentDom().getDocumentElement();
 
-    ArrayList<String> fontAndText = new ArrayList<String>();
+    ArrayList<String> fontAndText = new ArrayList<>();
 
     DumpPropertyAndText dumpFontAndText =
         new DumpPropertyAndText(StyleTextPropertiesElement.FontName);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/dom/example/StyleExamplesTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/dom/example/StyleExamplesTest.java
@@ -125,8 +125,8 @@ public class StyleExamplesTest {
       LOG.info("Parsed document.");
 
       OdfElement e = (OdfElement) odfdoc.getContentDom().getDocumentElement();
-      NodeAction dumpStyles =
-          new NodeAction() {
+      NodeAction<?> dumpStyles =
+          new NodeAction<>() {
 
             @Override
             protected void apply(Node node, Object arg, int depth) {

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/meta/OfficeMetaTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/meta/OfficeMetaTest.java
@@ -52,7 +52,7 @@ public class OfficeMetaTest {
   private String dctitle = "dctitle";
   private String dcdescription = "dcdescription";
   private String subject = "dcsubject";
-  private List<String> keywords = new ArrayList<String>();
+  private List<String> keywords = new ArrayList<>();
   private String initialCreator = "creator";
   private String dccreator = "Mr. fictionalTestUser";
   private String printedBy = "persia p";
@@ -279,7 +279,7 @@ public class OfficeMetaTest {
 
   @Test
   public void testEmptyKeyword() throws Exception {
-    List<String> emptyKeyword = new ArrayList<String>();
+    List<String> emptyKeyword = new ArrayList<>();
     fMetadata.setKeywords(emptyKeyword);
     tearDown();
     setUp();
@@ -301,7 +301,7 @@ public class OfficeMetaTest {
     List<String> names;
     names = fMetadata.getUserDefinedDataNames();
     if (names == null) {
-      names = new ArrayList<String>();
+      names = new ArrayList<>();
     } else {
       for (String name : names) {
         fMetadata.removeUserDefinedDataByName(name);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigationTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/incubator/search/TextStyleNavigationTest.java
@@ -85,7 +85,7 @@ public class TextStyleNavigationTest {
 
     // search the text of specified style, then insert it before specified text (delete)
     styleNavigator = null;
-    TreeMap<OdfStyleProperty, String> searchProps = new TreeMap<OdfStyleProperty, String>();
+    TreeMap<OdfStyleProperty, String> searchProps = new TreeMap<>();
     searchProps.put(StyleTextPropertiesElement.FontName, "Times New Roman1");
     searchProps.put(StyleTextPropertiesElement.FontSize, "16pt");
     styleNavigator = new TextStyleNavigation(searchProps, doc);
@@ -133,7 +133,7 @@ public class TextStyleNavigationTest {
   public void testPasteAtEndOf() {
 
     // search the text of specified style, then insert it after specified text (delete)
-    TreeMap<OdfStyleProperty, String> searchProps = new TreeMap<OdfStyleProperty, String>();
+    TreeMap<OdfStyleProperty, String> searchProps = new TreeMap<>();
     searchProps.put(StyleTextPropertiesElement.FontName, "Times New Roman1");
     searchProps.put(StyleTextPropertiesElement.FontSize, "16pt");
     styleNavigator = new TextStyleNavigation(searchProps, doc);
@@ -188,7 +188,7 @@ public class TextStyleNavigationTest {
   public void testCut() {
 
     // delete all text with specified style
-    TreeMap<OdfStyleProperty, String> searchProps = new TreeMap<OdfStyleProperty, String>();
+    TreeMap<OdfStyleProperty, String> searchProps = new TreeMap<>();
     searchProps.put(StyleTextPropertiesElement.FontName, "Century1");
     searchProps.put(StyleTextPropertiesElement.FontSize, "22pt");
     styleNavigator = new TextStyleNavigation(searchProps, doc);
@@ -217,7 +217,7 @@ public class TextStyleNavigationTest {
   @Test
   public void testApplyStyle() {
     // select the text specified style and apply the text with new style.
-    TreeMap<OdfStyleProperty, String> searchProps = new TreeMap<OdfStyleProperty, String>();
+    TreeMap<OdfStyleProperty, String> searchProps = new TreeMap<>();
     searchProps.put(StyleTextPropertiesElement.FontName, "Arial");
     searchProps.put(StyleTextPropertiesElement.FontSize, "12pt");
     styleNavigator = new TextStyleNavigation(searchProps, doc);
@@ -245,7 +245,7 @@ public class TextStyleNavigationTest {
       }
     }
 
-    TreeMap<OdfStyleProperty, String> chgProps = new TreeMap<OdfStyleProperty, String>();
+    TreeMap<OdfStyleProperty, String> chgProps = new TreeMap<>();
     chgProps.put(StyleTextPropertiesElement.FontSize, "23pt");
     chgProps.put(StyleTextPropertiesElement.FontWeight, "bold");
     search4 = new TextStyleNavigation(chgProps, doc);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/integrationtest/PerformanceIT.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/integrationtest/PerformanceIT.java
@@ -143,8 +143,8 @@ public class PerformanceIT {
     File[] files = myFolder.listFiles();
     List<String> myList = new ArrayList<>();
 
-    for (int i = 0; i < files.length; i++) {
-      filename = files[i].getName();
+    for (File file : files) {
+      filename = file.getName();
       if (filename.endsWith("ods") || filename.endsWith("odp") || filename.endsWith("odt")) {
         myList.add(filename);
       }
@@ -312,8 +312,8 @@ public class PerformanceIT {
     OdfFileDom dom = null;
     String filename = null;
 
-    for (int j = 0; j < TEST_FILE_NAME.length; j++) {
-      filename = TEST_FILE_FOLDER + TEST_FILE_NAME[j];
+    for (String s : TEST_FILE_NAME) {
+      filename = TEST_FILE_FOLDER + s;
       LOG.log(Level.INFO, "filename:{0}", filename);
       doc = OdfDocument.loadDocument(filename);
       dom = doc.getContentDom();

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/integrationtest/PerformanceIT.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/integrationtest/PerformanceIT.java
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Test;
@@ -140,7 +141,7 @@ public class PerformanceIT {
       return;
     }
     File[] files = myFolder.listFiles();
-    ArrayList myList = new ArrayList();
+    List<String> myList = new ArrayList<>();
 
     for (int i = 0; i < files.length; i++) {
       filename = files[i].getName();

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/EmbeddedDocumentTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/EmbeddedDocumentTest.java
@@ -92,7 +92,7 @@ public class EmbeddedDocumentTest {
           OdfDocument.loadDocument(ResourceUtilities.getAbsoluteInputPath(TEST_FILE_EMBEDDED));
       OdfDocument saveDoc = OdfTextDocument.newTextDocument();
       Map<String, OdfDocument> subDocs = doc.loadSubDocuments();
-      List<String> subDocNames = new ArrayList<String>();
+      List<String> subDocNames = new ArrayList<>();
       for (OdfDocument childDoc : subDocs.values()) {
         String embeddedDocPath = childDoc.getDocumentPath();
         saveDoc.insertDocument(childDoc, embeddedDocPath);
@@ -333,7 +333,7 @@ public class EmbeddedDocumentTest {
       OdfDocument doc =
           OdfDocument.loadDocument(ResourceUtilities.getAbsoluteInputPath(TEST_FILE_EMBEDDED));
       Map<String, OdfDocument> embeddedDocs = doc.loadSubDocuments();
-      List<String> subDocNames = new ArrayList<String>();
+      List<String> subDocNames = new ArrayList<>();
       for (OdfDocument childDoc : embeddedDocs.values()) {
         Assert.assertNotNull(childDoc);
         String embedFileName = childDoc.getDocumentPath();

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/EmbeddedDocumentTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/EmbeddedDocumentTest.java
@@ -350,13 +350,8 @@ public class EmbeddedDocumentTest {
       Assert.assertTrue(0 == reloadedSubDocs.size());
       Set<String> entries = doc.getPackage().getFilePaths();
       Iterator<String> entryIter = null;
-      for (int i = 0; i < subDocNames.size(); i++) {
-        entryIter = entries.iterator();
-        String embeddedDocPath = subDocNames.get(i);
-        while (entryIter.hasNext()) {
-          String entry = entryIter.next();
-          Assert.assertFalse(entry.startsWith(embeddedDocPath));
-        }
+      for (String subDocName : subDocNames) {
+        entries.forEach(entry -> Assert.assertFalse(entry.startsWith(subDocName)));
       }
       doc.close();
     } catch (Exception ex) {

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/PackageTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/PackageTest.java
@@ -318,44 +318,49 @@ public class PackageTest {
   public void validationTest() {
 
     // TESTDOC1: Expected ODF Warnings
-    Map expectedWarning1 = new HashMap();
-    expectedWarning1.put(OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 10);
+    Map<ValidationConstraint, Integer> expectedWarning1 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 10
+    ));
 
     // TESTDOC1: Expected ODF Errors
-    Map expectedErrors1 = new HashMap();
-    expectedErrors1.put(OdfPackageConstraint.MIMETYPE_NOT_FIRST_IN_PACKAGE, 1);
-    expectedErrors1.put(OdfPackageConstraint.MIMETYPE_IS_COMPRESSED, 1);
-    expectedErrors1.put(OdfPackageConstraint.MIMETYPE_HAS_EXTRA_FIELD, 1);
-    expectedErrors1.put(OdfPackageConstraint.MIMETYPE_DIFFERS_FROM_PACKAGE, 1);
-    expectedErrors1.put(OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 1);
+    Map<ValidationConstraint, Integer> expectedErrors1 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MIMETYPE_NOT_FIRST_IN_PACKAGE, 1,
+      OdfPackageConstraint.MIMETYPE_IS_COMPRESSED, 1,
+      OdfPackageConstraint.MIMETYPE_HAS_EXTRA_FIELD, 1,
+      OdfPackageConstraint.MIMETYPE_DIFFERS_FROM_PACKAGE, 1,
+      OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 1
+    ));
     ErrorHandlerStub handler1 = new ErrorHandlerStub(expectedWarning1, expectedErrors1, null);
     handler1.setTestFilePath("testInvalidPkg1.odt");
 
     // TESTDOC2: Expected ODF Warnings
-    Map expectedWarning2 = new HashMap();
-    expectedWarning2.put(OdfPackageConstraint.MIMETYPE_NOT_IN_PACKAGE, 1);
-    expectedWarning2.put(OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 10);
+    Map<ValidationConstraint, Integer> expectedWarning2 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MIMETYPE_NOT_IN_PACKAGE, 1,
+      OdfPackageConstraint.MANIFEST_LISTS_DIRECTORY, 10
+    ));
 
     // TESTDOC2: Expected ODF Errors
-    Map expectedErrors2 = new HashMap();
-    expectedErrors2.put(OdfPackageConstraint.MANIFEST_DOES_NOT_LIST_FILE, 1);
-    expectedErrors2.put(OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 3);
+    Map<ValidationConstraint, Integer> expectedErrors2 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MANIFEST_DOES_NOT_LIST_FILE, 1,
+      OdfPackageConstraint.MANIFEST_LISTS_NONEXISTENT_FILE, 3
+    ));
     ErrorHandlerStub handler2 = new ErrorHandlerStub(expectedWarning2, expectedErrors2, null);
     handler2.setTestFilePath("testInvalidPkg2.odt");
 
     // TESTDOC3 DESCRIPTION - only mimetype file in package
     // TESTDOC3: Expected ODF Errors
-    Map expectedErrors3 = new HashMap();
-    expectedErrors3.put(OdfPackageConstraint.MANIFEST_NOT_IN_PACKAGE, 1);
-    expectedErrors3.put(OdfPackageConstraint.MIMETYPE_WITHOUT_MANIFEST_MEDIATYPE, 1);
+    Map<ValidationConstraint, Integer> expectedErrors3 = new HashMap<>(Map.of(
+      OdfPackageConstraint.MANIFEST_NOT_IN_PACKAGE, 1,
+      OdfPackageConstraint.MIMETYPE_WITHOUT_MANIFEST_MEDIATYPE, 1
+    ));
     ErrorHandlerStub handler3 = new ErrorHandlerStub(null, expectedErrors3, null);
     handler3.setTestFilePath("testInvalidPkg3.odt");
 
     // TESTDOC4: Expected ODF FatalErrors
-    Map<ValidationConstraint, Integer> expectedFatalErrors4 =
-      new HashMap<>();
-    // loading a graphic instead an ODF document
-    expectedFatalErrors4.put(OdfPackageConstraint.PACKAGE_IS_NO_ZIP, 1);
+    Map<ValidationConstraint, Integer> expectedFatalErrors4 = new HashMap<>(Map.of(
+      // loading a graphic instead an ODF document
+      OdfPackageConstraint.PACKAGE_IS_NO_ZIP, 1
+    ));
     ErrorHandlerStub handler4 = new ErrorHandlerStub(null, null, expectedFatalErrors4);
 
     try {

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/PackageTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/pkg/PackageTest.java
@@ -101,7 +101,7 @@ public class PackageTest {
     // test if the image is not compressed
     ZipArchiveInputStream zinput =
         createZipInputStream(ResourceUtilities.getTestOutputAsStream(IMAGE_PRESENTATION));
-    ZipArchiveEntry entry = zinput.getNextZipEntry();
+    ZipArchiveEntry entry = zinput.getNextEntry();
     while (entry != null) {
       String entryName = entry.getName();
       if (entryName.endsWith(".jpg")) {
@@ -109,7 +109,7 @@ public class PackageTest {
         Assert.assertEquals(ZipArchiveEntry.STORED, entry.getMethod());
         Assert.assertEquals(f.length(), entry.getSize());
       }
-      entry = zinput.getNextZipEntry();
+      entry = zinput.getNextEntry();
     }
   }
 
@@ -353,7 +353,7 @@ public class PackageTest {
 
     // TESTDOC4: Expected ODF FatalErrors
     Map<ValidationConstraint, Integer> expectedFatalErrors4 =
-        new HashMap<ValidationConstraint, Integer>();
+      new HashMap<>();
     // loading a graphic instead an ODF document
     expectedFatalErrors4.put(OdfPackageConstraint.PACKAGE_IS_NO_ZIP, 1);
     ErrorHandlerStub handler4 = new ErrorHandlerStub(null, null, expectedFatalErrors4);
@@ -401,7 +401,7 @@ public class PackageTest {
   public void validationTest5() {
     // TESTDOC5: duplicate ZIP entries
     Map<ValidationConstraint, Integer> expectedFatalErrors =
-        new HashMap<ValidationConstraint, Integer>();
+      new HashMap<>();
     expectedFatalErrors.put(OdfPackageConstraint.PACKAGE_ENTRY_DUPLICATE, 1);
     ErrorHandlerStub handler = new ErrorHandlerStub(null, null, expectedFatalErrors);
     handler.setTestFilePath("duplicate-files.odt");
@@ -430,7 +430,7 @@ public class PackageTest {
   public void validationTest6() {
     // TESTDOC6: Info-ZIP Unicode Path Extra Field with different name
     Map<ValidationConstraint, Integer> expectedErrors =
-        new HashMap<ValidationConstraint, Integer>();
+      new HashMap<>();
     // depending on setUseUnicodeExtraFields this would be reported as
     // MANIFEST_DOES_NOT_LIST_FILE or as PACKAGE_ENTRY_DUPLICATE
     expectedErrors.put(OdfPackageConstraint.MANIFEST_DOES_NOT_LIST_FILE, 1);
@@ -455,7 +455,7 @@ public class PackageTest {
   public void validationTest7() {
     // TESTDOC7: invalid file name
     Map<ValidationConstraint, Integer> expectedFatalErrors =
-        new HashMap<ValidationConstraint, Integer>();
+      new HashMap<>();
     expectedFatalErrors.put(OdfPackageConstraint.PACKAGE_ENTRY_INVALID_FILE_NAME, 1);
     ErrorHandlerStub handler = new ErrorHandlerStub(null, null, expectedFatalErrors);
     handler.setTestFilePath("slash.odt");
@@ -484,7 +484,7 @@ public class PackageTest {
   public void validationTest8() {
     // TESTDOC8: 2 concatenated zips
     Map<ValidationConstraint, Integer> expectedErrors =
-        new HashMap<ValidationConstraint, Integer>();
+      new HashMap<>();
     expectedErrors.put(OdfPackageConstraint.MIMETYPE_NOT_FIRST_IN_PACKAGE, 1);
     ErrorHandlerStub handler = new ErrorHandlerStub(null, expectedErrors, null);
     handler.setTestFilePath("two-zips.odt");

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/type/DataTypeTest.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/type/DataTypeTest.java
@@ -158,7 +158,7 @@ public class DataTypeTest {
     Assert.assertFalse(StyleName.isValid("t:1"));
     StyleNameRef styleNameRef1 = StyleNameRef.valueOf("ce1");
     Assert.assertTrue(StyleNameRef.isValid(""));
-    List<StyleName> styleList = new ArrayList<StyleName>();
+    List<StyleName> styleList = new ArrayList<>();
     styleList.add(StyleName.valueOf(styleNameRef1.toString()));
     styleList.add(styleName1);
     styleList.add(styleName2);

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/utils/ErrorHandlerStub.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/utils/ErrorHandlerStub.java
@@ -71,21 +71,21 @@ public class ErrorHandlerStub implements ErrorHandler {
 
   public void warning(SAXParseException exception) throws SAXException {
     if (mExpectedWarning == null) {
-      mExpectedWarning = new HashMap<ValidationConstraint, Integer>();
+      mExpectedWarning = new HashMap<>();
     }
     registerProblem(exception, mExpectedWarning);
   }
 
   public void error(SAXParseException exception) throws SAXException {
     if (mExpectedError == null) {
-      mExpectedError = new HashMap<ValidationConstraint, Integer>();
+      mExpectedError = new HashMap<>();
     }
     registerProblem(exception, mExpectedError);
   }
 
   public void fatalError(SAXParseException exception) throws SAXException {
     if (mExpectedFatalError == null) {
-      mExpectedFatalError = new HashMap<ValidationConstraint, Integer>();
+      mExpectedFatalError = new HashMap<>();
     }
     registerProblem(exception, mExpectedFatalError);
   }

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/utils/ErrorHandlerStub.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/utils/ErrorHandlerStub.java
@@ -24,7 +24,6 @@
 package org.odftoolkit.odfdom.utils;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -103,10 +102,9 @@ public class ErrorHandlerStub implements ErrorHandler {
   }
 
   private void validateProblem(Map<ValidationConstraint, Integer> expectedProblems, String level) {
-    Iterator<ValidationConstraint> constraints = expectedProblems.keySet().iterator();
-    while (constraints.hasNext()) {
-      ValidationConstraint constraint = constraints.next();
-      Integer problemOccurance = expectedProblems.get(constraint);
+    for (Map.Entry<ValidationConstraint, Integer> entry : expectedProblems.entrySet()) {
+      ValidationConstraint constraint = entry.getKey();
+      int problemOccurance = entry.getValue();
       if (problemOccurance > 0) {
         logMissingConstraint(constraint, level, problemOccurance);
       } else if (problemOccurance < 0) {

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/utils/ResourceUtilities.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/utils/ResourceUtilities.java
@@ -398,8 +398,7 @@ public final class ResourceUtilities {
     StringBuilder output = new StringBuilder(encodedString.length());
     char[] charArray = encodedString.toCharArray();
 
-    for (int i = 0; i < charArray.length; i++) {
-      char c = charArray[i];
+    for (char c : charArray) {
       if ((int) c > 127) {
         encodedString = "000" + Integer.toHexString((int) c).toUpperCase();
         output.append("\\u").append(encodedString.substring(encodedString.length() - 4));

--- a/odfdom/src/test/java/org/odftoolkit/odfdom/utils/ResourceUtilities.java
+++ b/odfdom/src/test/java/org/odftoolkit/odfdom/utils/ResourceUtilities.java
@@ -51,7 +51,7 @@ public final class ResourceUtilities {
   static final String RELOADED_OPS_SUFFIX = "-reloaded_ops.json";
   static final String HYPEN = "-";
   static final String ODT_SUFFIX = ".odt";
-  static final List<String> NO_OPERATIONS = new ArrayList<String>(0);
+  static final List<String> NO_OPERATIONS = new ArrayList<>(0);
   static final String NO_METHOD_NAME = "";
   // the smallest possible test document of this ODF type. Edited manually and proofed valid by
   // Apache ODF Validator.

--- a/taglets/src/main/java/org/odftoolkit/odfdom/taglet/OdfAttributeTaglet.java
+++ b/taglets/src/main/java/org/odftoolkit/odfdom/taglet/OdfAttributeTaglet.java
@@ -53,7 +53,7 @@ public class OdfAttributeTaglet implements Taglet {
       "../../../../../resources/OpenDocument-v1.2-part3.html";
   private static String mOdfSpecPart1Path = null;
   private static String mOdfSpecPart3Path = null;
-  private static Set<String> mNS_IN_PART3 = new HashSet<String>();
+  private static Set<String> mNS_IN_PART3 = new HashSet<>();
 
   // initial attribute set which should be search in part3.
   static {

--- a/taglets/src/main/java/org/odftoolkit/odfdom/taglet/OdfElementTaglet.java
+++ b/taglets/src/main/java/org/odftoolkit/odfdom/taglet/OdfElementTaglet.java
@@ -53,7 +53,7 @@ public class OdfElementTaglet implements Taglet {
       "../../../../../resources/OpenDocument-v1.2-part3.html";
   private static String mOdfSpecPart1Path = null;
   private static String mOdfSpecPart3Path = null;
-  private static Set<String> mNS_IN_PART3 = new HashSet<String>();
+  private static Set<String> mNS_IN_PART3 = new HashSet<>();
 
   // initial attribute set which should be search in part3.
   static {

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/Configuration.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/Configuration.java
@@ -29,7 +29,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.TreeSet;
@@ -76,8 +75,9 @@ public class Configuration extends Properties {
     }
 
     List<String> aValues = new Vector<>(aSortedPropNames.size());
-    Iterator<String> aIter = aSortedPropNames.iterator();
-    while (aIter.hasNext()) aValues.add(getProperty(aIter.next()));
+    for (String aSortedPropName : aSortedPropNames) {
+      aValues.add(getProperty(aSortedPropName));
+    }
 
     return aValues;
   }

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/Configuration.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/Configuration.java
@@ -68,7 +68,7 @@ public class Configuration extends Properties {
   }
 
   public List<String> getListPropety(String aPropNamePrefix) {
-    TreeSet<String> aSortedPropNames = new TreeSet<String>();
+    TreeSet<String> aSortedPropNames = new TreeSet<>();
     Enumeration<?> aPropNames = propertyNames();
     while (aPropNames.hasMoreElements()) {
       String aPropName = (String) aPropNames.nextElement();

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ForeignContentFilter.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ForeignContentFilter.java
@@ -70,10 +70,10 @@ class ForeignContentFilter extends XMLFilterImpl {
     m_aVersion = aVersion;
     m_aForeignContentListener = aForeignContentListener;
 
-    m_aAlienElementProcessContents = new Vector<Boolean>();
-    m_aParagraphAncestorElements = new Vector<Boolean>();
+    m_aAlienElementProcessContents = new Vector<>();
+    m_aParagraphAncestorElements = new Vector<>();
 
-    m_aODFNamespaceSet = new HashSet<String>();
+    m_aODFNamespaceSet = new HashSet<>();
     m_aODFNamespaceSet.add(OdfDocumentNamespace.OFFICE.getUri());
     m_aODFNamespaceSet.add(OdfDocumentNamespace.STYLE.getUri());
     m_aODFNamespaceSet.add(OdfDocumentNamespace.TEXT.getUri());

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/Logger.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/Logger.java
@@ -245,10 +245,10 @@ public class Logger {
               errorLine.substring(
                   Math.max(0, e.getColumnNumber() - 40),
                   Math.min(len - 1, e.getColumnNumber() + 39)));
-          aOut.println(String.format("%1$38s", "----^"));
+          aOut.format("%1$38s%n", "----^");
         } else {
           aOut.println(errorLine);
-          aOut.println(String.format("%1$" + Math.max(0, e.getColumnNumber() - 2) + "s", "----^"));
+          aOut.format("%1$" + Math.max(0, e.getColumnNumber() - 2) + "s%n", "----^");
         }
       } catch (IOException x) {
       }

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/Main.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/Main.java
@@ -65,7 +65,7 @@ public class Main {
     boolean bRecursive = false;
     Logger.LogLevel nLogLevel = Logger.LogLevel.ERROR;
     OdfValidatorMode eMode = OdfValidatorMode.VALIDATE;
-    List<String> aFileNames = new Vector<String>();
+    List<String> aFileNames = new Vector<>();
     OdfVersion aVersion = null;
 
     boolean bCommandLineValid = true;

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/Main.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/Main.java
@@ -162,8 +162,7 @@ public class Main {
       // Print generator (does not require config file)
       if (bPrintGenerator) {
         MetaInformation aMetaInformation = new MetaInformation(System.out);
-        Iterator<String> aIter = aFileNames.iterator();
-        while (aIter.hasNext()) aMetaInformation.getInformation(aIter.next());
+        for (String aFileName : aFileNames) aMetaInformation.getInformation(aFileName);
         System.exit(0);
       }
 

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFPackageErrorHandler.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFPackageErrorHandler.java
@@ -35,7 +35,7 @@ import org.xml.sax.SAXParseException;
 
 class ODFPackageErrorHandler implements ErrorHandler {
 
-  List<SAXParseException> m_aExceptionList = new ArrayList<SAXParseException>();
+  List<SAXParseException> m_aExceptionList = new ArrayList<>();
 
   ODFPackageErrorHandler() {}
 

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFPackageValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFPackageValidator.java
@@ -342,9 +342,7 @@ abstract class ODFPackageValidator {
     if (m_aResult.hasForeignElements()) {
       Set<String> aForeignElementURISet = m_aResult.getForeignElements().keySet();
       StringBuilder aBuffer = new StringBuilder();
-      Iterator<String> aIter = aForeignElementURISet.iterator();
-      while (aIter.hasNext()) {
-        String aURI = aIter.next();
+      for (String aURI : aForeignElementURISet) {
         aBuffer.setLength(0);
         aBuffer.append(m_aResult.getForeignElements().get(aURI));
         aBuffer.append(" extension elements from the following namespace were found: ");

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFRootPackageValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFRootPackageValidator.java
@@ -148,7 +148,7 @@ abstract class ODFRootPackageValidator extends ODFPackageValidator
   public void foundManifestEntry(ManifestEntry aManifestEntry) {
     if (aManifestEntry.isOpenDocumentMediaType()) {
       if (m_aSubDocs == null) {
-        m_aSubDocs = new ArrayList<ManifestEntry>();
+        m_aSubDocs = new ArrayList<>();
       }
       m_aSubDocs.add(aManifestEntry);
     }

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFRootPackageValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFRootPackageValidator.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.zip.ZipException;
 import javax.xml.validation.Validator;
@@ -110,21 +109,19 @@ abstract class ODFRootPackageValidator extends ODFPackageValidator
       throws ODFValidatorException, IOException {
     boolean bHasErrors = false;
     if (m_aSubDocs != null) {
-      Iterator<ManifestEntry> aIter = m_aSubDocs.iterator();
-      while (aIter.hasNext()) {
-        ManifestEntry aEntry = aIter.next();
+      for (ManifestEntry aEntry : m_aSubDocs) {
         ODFPackageValidator aPackageValidator =
-            new ODFSubPackageValidator(
-                getPackage(aLogger),
-                getLoggerName(),
-                aEntry.getFullPath(),
-                aEntry.getMediaType(),
-                m_nLogLevel,
-                m_eMode,
-                m_aConfigVersion,
-                m_aFilter,
-                m_aResult.getGenerator(),
-                m_aValidatorProvider);
+          new ODFSubPackageValidator(
+            getPackage(aLogger),
+            getLoggerName(),
+            aEntry.getFullPath(),
+            aEntry.getMediaType(),
+            m_nLogLevel,
+            m_eMode,
+            m_aConfigVersion,
+            m_aFilter,
+            m_aResult.getGenerator(),
+            m_aValidatorProvider);
         bHasErrors |= aPackageValidator.validate(aLogger);
       }
     }

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidationResult.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidationResult.java
@@ -69,7 +69,7 @@ public class ODFValidationResult
 
   public void foreignElementDetected(
       String aUri, String aLocalName, String aQName, Attributes aAtts) {
-    if (m_aForeignElementMap == null) m_aForeignElementMap = new HashMap<String, Long>();
+    if (m_aForeignElementMap == null) m_aForeignElementMap = new HashMap<>();
 
     Long aCount = m_aForeignElementMap.get(aUri);
     if (aCount == null) aCount = 0L;
@@ -78,7 +78,7 @@ public class ODFValidationResult
 
   public void foreignAttributeDetected(
       String aUri, String aLocalName, String aQName, String aValue) {
-    if (m_aForeignAttributeMap == null) m_aForeignAttributeMap = new HashMap<String, Long>();
+    if (m_aForeignAttributeMap == null) m_aForeignAttributeMap = new HashMap<>();
 
     Long aCount = m_aForeignAttributeMap.get(aUri);
     if (aCount == null) aCount = 0L;

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
@@ -307,7 +307,7 @@ public class ODFValidator implements ODFValidatorProvider {
   private Validator getValidatorForSchema(PrintStream aOut, String aSchemaFileName)
       throws ODFValidatorException {
     if (m_aSchemaMap == null) {
-      m_aSchemaMap = new HashMap<String, Schema>();
+      m_aSchemaMap = new HashMap<>();
     }
 
     Schema aSchema = m_aSchemaMap.get(aSchemaFileName);

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ODFValidator.java
@@ -30,7 +30,6 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.xml.XMLConstants;
@@ -122,13 +121,12 @@ public class ODFValidator implements ODFValidatorProvider {
 
     FileFilter aFileFilter = new ODFFileFilter(aExcludeRegExp, bRecursive);
 
-    Iterator<String> aIter = aFileNames.iterator();
-    while (aIter.hasNext()) {
-      File aFile = new File(aIter.next());
+    for (String aFileName : aFileNames) {
+      File aFile = new File(aFileName);
       bRet |=
-          aFile.isDirectory()
-              ? validateDir(aOut, aFile, aFileFilter, eMode, aFilter)
-              : validateFile(aOut, aFile, eMode, aFilter);
+        aFile.isDirectory()
+          ? validateDir(aOut, aFile, aFileFilter, eMode, aFilter)
+          : validateFile(aOut, aFile, eMode, aFilter);
     }
 
     return bRet;
@@ -155,8 +153,7 @@ public class ODFValidator implements ODFValidatorProvider {
     File[] aFiles = aDir.listFiles(aFileFilter);
 
     if (aFiles != null) {
-      for (int i = 0; i < aFiles.length; ++i) {
-        File aFile = aFiles[i];
+      for (File aFile : aFiles) {
         if (aFile.isDirectory()) {
           bRet |= validateDir(aOut, aFile, aFileFilter, eMode, aFilter);
         } else {

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ValidationMessageCollectorErrorFilter.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ValidationMessageCollectorErrorFilter.java
@@ -34,7 +34,7 @@ public class ValidationMessageCollectorErrorFilter implements SAXParseExceptionF
 
   /** Creates a new instance of ValidationErrorFilter */
   public ValidationMessageCollectorErrorFilter() throws ODFValidatorException {
-    m_aMsgsReported = new HashSet<String>();
+    m_aMsgsReported = new HashSet<>();
   }
 
   public SAXParseException filterException(SAXParseException aExc) {

--- a/validator/src/main/java/org/odftoolkit/odfvalidator/ValidationOOoTaskIdErrorFilter.java
+++ b/validator/src/main/java/org/odftoolkit/odfvalidator/ValidationOOoTaskIdErrorFilter.java
@@ -110,8 +110,8 @@ public class ValidationOOoTaskIdErrorFilter implements SAXParseExceptionFilter {
   /** Creates a new instance of ValidationErrorFilter */
   public ValidationOOoTaskIdErrorFilter(File aFilterFile, PrintStream aOut)
       throws ODFValidatorException {
-    m_aFilterEntries = new HashMap<String, FilterEntry>();
-    m_aTaskIdsReported = new HashSet<String>();
+    m_aFilterEntries = new HashMap<>();
+    m_aTaskIdsReported = new HashSet<>();
     SAXParser aParser = null;
     Logger aLogger = new Logger(aFilterFile.getAbsolutePath(), "", aOut, Logger.LogLevel.ERROR);
     try {
@@ -157,7 +157,7 @@ public class ValidationOOoTaskIdErrorFilter implements SAXParseExceptionFilter {
   }
 
   public void startSubFile() {
-    m_aTaskIdsReported = new HashSet<String>();
+    m_aTaskIdsReported = new HashSet<>();
     // the build id is kept
   }
 

--- a/xslt-runner/src/main/java/org/odftoolkit/odfxsltrunner/Main.java
+++ b/xslt-runner/src/main/java/org/odftoolkit/odfxsltrunner/Main.java
@@ -88,7 +88,7 @@ public class Main {
         nLogLevel = CommandLineLogger.INFO;
       } else if (aArg.equals("-x")) {
         if (aArgIter.hasNext()) {
-          if (aExtractFileNames == null) aExtractFileNames = new Vector<String>();
+          if (aExtractFileNames == null) aExtractFileNames = new Vector<>();
           aExtractFileNames.add(aArgIter.next());
         } else bCommandLineValid = false;
       } else if (aArg.startsWith("-")) {
@@ -104,7 +104,7 @@ public class Main {
           && aOutputName == null) {
         aOutputName = aArg;
       } else if (aArg.indexOf('=') != -1) {
-        if (aParams == null) aParams = new Vector<XSLTParameter>();
+        if (aParams == null) aParams = new Vector<>();
         aParams.add(new XSLTCommandLineParameter(aArg));
       } else {
         bCommandLineValid = false;

--- a/xslt-runner/src/main/java/org/odftoolkit/odfxsltrunner/ODFXSLTRunner.java
+++ b/xslt-runner/src/main/java/org/odftoolkit/odfxsltrunner/ODFXSLTRunner.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -321,9 +320,7 @@ public class ODFXSLTRunner {
       Transformer aTransformer = aFactory.newTransformer(aStyleSheetSource);
 
       if (aParams != null) {
-        Iterator<XSLTParameter> aIter = aParams.iterator();
-        while (aIter.hasNext()) {
-          XSLTParameter aParam = aIter.next();
+        for (XSLTParameter aParam : aParams) {
           aTransformer.setParameter(aParam.getName(), aParam.getValue());
           aLogger.logInfo("Using parameter: " + aParam.getName() + "=" + aParam.getValue());
         }
@@ -343,25 +340,20 @@ public class ODFXSLTRunner {
       OdfPackage aInputPkg, File aTargetDir, List<String> aExtractFileNames, Logger aLogger) {
     Set<String> aInputPkgEntries = aInputPkg.getFilePaths();
 
-    Iterator<String> aInputPkgEntryIter = aInputPkgEntries.iterator();
-    while (aInputPkgEntryIter.hasNext()) {
-      String aInputFileName = aInputPkgEntryIter.next();
-
-      Iterator<String> aExtractFileNameIter = aExtractFileNames.iterator();
-      while (aExtractFileNameIter.hasNext()) {
-        String aExtractFileName = aExtractFileNameIter.next();
+    for (String aInputFileName : aInputPkgEntries) {
+      for (String aExtractFileName : aExtractFileNames) {
         if (!aInputFileName.endsWith("/")
-            && (aInputFileName.equals(aExtractFileName)
-                || (aExtractFileName.endsWith("/")
-                    ? aInputFileName.startsWith(aExtractFileName)
-                    : aInputFileName.startsWith(aExtractFileName + "/")))) {
+          && (aInputFileName.equals(aExtractFileName)
+          || (aExtractFileName.endsWith("/")
+          ? aInputFileName.startsWith(aExtractFileName)
+          : aInputFileName.startsWith(aExtractFileName + "/")))) {
           try {
             File aTargetFile = new File(aTargetDir, aInputFileName);
             File aTargetFileDir = aTargetFile.getParentFile();
             if (aTargetFileDir != null) aTargetFileDir.mkdirs();
 
             aLogger.logInfo(
-                "Extracting file " + aInputFileName + " to " + aTargetFile.getAbsolutePath());
+              "Extracting file " + aInputFileName + " to " + aTargetFile.getAbsolutePath());
             InputStream aInputStream = aInputPkg.getInputStream(aInputFileName);
             OutputStream aTargetStream = new FileOutputStream(aTargetFile);
             byte[] aBuffer = new byte[FILE_COPY_BUFFER_SIZE];
@@ -371,7 +363,7 @@ public class ODFXSLTRunner {
             }
             aTargetStream.close();
             aInputStream.close();
-          } catch (java.lang.Exception e) {
+          } catch (Exception e) {
             aLogger.logError(e.getMessage());
           }
           break;

--- a/xslt-runner/src/main/java/org/odftoolkit/odfxsltrunner/ODFXSLTRunner.java
+++ b/xslt-runner/src/main/java/org/odftoolkit/odfxsltrunner/ODFXSLTRunner.java
@@ -301,7 +301,7 @@ public class ODFXSLTRunner {
       try {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         if (cl == null) cl = ClassLoader.getSystemClassLoader();
-        Class classInstance = cl.loadClass(aTransformerFactoryClassName);
+        Class<?> classInstance = cl.loadClass(aTransformerFactoryClassName);
         aFactory = (TransformerFactory) classInstance.getDeclaredConstructor().newInstance();
       } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ce) {
         aLogger.logFatalError(ce.getMessage());


### PR DESCRIPTION
Sorry, this looks huge. But it's just small refactorings that bring the code up-to-date with Java 11 and should make it more readable.

- I fixed some errors and deprecations in Javadoc
- fixed all "raw use of parametrized class" warnings
- replaced loops with extended for loops
- replaced manual list-of-strings to string conversion by using Collectors.joining
- replaced creating and manual filling maps by bulk operations (`new HashMap<>(Map.of(...))`instead of just `Map.of(...)`is necessary to create mutable maps).
- some other small refactorings