### PR TITLE
add sonarqube static analysis and jacoco code coverage

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,5 +57,5 @@ jobs:
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.projectKey=xzel23_odftoolkit
           -Dsonar.organization=xzel23
-          -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco-aggregate/jacoco.xml
+          -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco-ut/jacoco.xml
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/generator/schema2template/pom.xml
+++ b/generator/schema2template/pom.xml
@@ -102,6 +102,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>${surefireArgLine}</argLine>
                     <skipTests>${codegen}</skipTests>
                     <systemPropertyVariables>
                         <!-- see https://cwiki.apache.org/confluence/display/MAVEN/Maven+Properties+Guide -->
@@ -161,6 +162,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/odfdom/pom.xml
+++ b/odfdom/pom.xml
@@ -200,10 +200,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/coverage-reports/jacoco-ut.exec</argLine>
                     <systemPropertyVariables>
                         <org.odftoolkit.odfdom.validation>true</org.odftoolkit.odfdom.validation>
                     </systemPropertyVariables>
-                    <exclude>**/integrationtest/PerformanceIT.java</exclude>
+                    <excludes>
+                        <exclude>**/integrationtest/PerformanceIT.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -326,6 +329,22 @@
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
+                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -574,6 +593,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <argLine>${surefireArgLine}</argLine>
                             <systemPropertyVariables>
                                 <org.odftoolkit.odfdom.validation>true</org.odftoolkit.odfdom.validation>
                             </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
                     <configuration>
                         <!-- <forkCount>3</forkCount>
                             <reuseForks>true</reuseForks>-->
-                        <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                        <argLine>${surefireArgLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                         <systemPropertyVariables>
                             <odftoolkit.version>${project.version}</odftoolkit.version>
                             <odftoolkit.git.branch>${git.branch}</odftoolkit.git.branch>
@@ -519,6 +519,47 @@
                                 </formats>
                             </configuration>
                         </execution>
+                        <!--
+                            Prepares the property pointing to the JaCoCo runtime agent which
+                            is passed as VM argument when Maven the Failsafe plugin is executed.
+                        -->
+                        <execution>
+                            <id>pre-integration-test</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                                <goal>prepare-agent-integration</goal>
+                            </goals>
+                            <configuration>
+                                <!-- Sets the path to the file which contains the execution data. -->
+                                <destFile>${project.build.directory}/coverage-reports/jacoco-it.exec</destFile>
+                                <!--
+                                    Sets the name of the property containing the settings
+                                    for JaCoCo runtime agent.
+                                -->
+                                <propertyName>failsafeArgLine</propertyName>
+                            </configuration>
+                        </execution>
+                        <!--
+                            Ensures that the code coverage report for integration tests is created after
+                            integration tests have been run.
+                        -->
+                        <execution>
+                            <id>post-integration-test</id>
+                            <phase>post-integration-test</phase>
+                            <goals>
+                                <goal>report-integration</goal>
+                            </goals>
+                            <configuration>
+                                <!-- Sets the path to the file which contains the execution data. -->
+                                <dataFile>${project.build.directory}/coverage-reports/jacoco-it.exec</dataFile>
+                                <!-- Sets the output directory for the code coverage report. -->
+                                <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+                                <formats>
+                                    <format>XML</format>
+                                    <format>CSV</format>
+                                </formats>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
             </plugins>
@@ -542,6 +583,7 @@
                                     <directory>${project.basedir}</directory>
                                     <includes>
                                         <include>**/target/coverage-reports/jacoco-ut.exec</include>
+                                        <include>**/target/coverage-reports/jacoco-it.exec</include>
                                     </includes>
                                 </fileSet>
                             </fileSets>

--- a/taglets/pom.xml
+++ b/taglets/pom.xml
@@ -97,6 +97,10 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -135,6 +135,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>${surefireArgLine}</argLine>
                     <excludes>
                         <exclude>**/IntegrationTest.java</exclude>
                         <exclude>**/ITJarTest.java</exclude>
@@ -227,6 +228,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
+                    <argLine>${failsafeArgLine}</argLine>
                     <includes>
                         <include>**/IntegrationTest.java</include>
                         <include>**/ITJarTest.java</include>
@@ -247,6 +249,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/xslt-runner/pom.xml
+++ b/xslt-runner/pom.xml
@@ -307,6 +307,10 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
This PR adds sonarqube scanning and code coverage. Getting JaCoCo to work correctly took some time -  but I think this is really important to have, otherwise we cannot easily tell if a change we integrate is covered by unit tests.

This is the first part of implementing #386. After integrating the PR, a secret has to be added in the GitHub configuration by the main maintainer for the scan to work. I have included the instructions on how to add in the linked issue.

These two lines in maven.yml have to be changed too to match the Sonar configuration:

          -Dsonar.projectKey=xzel23_odftoolkit
          -Dsonar.organization=xzel23

