### PR TITLE
replace legacy OSSRH stuff with Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,13 +228,12 @@
     </ciManagement>
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
         <!-- not used for deployment but only for site:stage goal -->
         <site>
@@ -458,15 +457,13 @@
                     </dependencies>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.13</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    </configuration>
+                  <groupId>org.sonatype.central</groupId>
+                  <artifactId>central-publishing-maven-plugin</artifactId>
+                  <version>0.8.0</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                    <publishingServerId>central</publishingServerId>
+                  </configuration>
                 </plugin>
                 <plugin>
                     <!-- https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/ -->
@@ -711,7 +708,7 @@
                 1) You need to have a GPG Signature specified:
                     Best in your <USR_HOME>/.m2/settings.xml
                         <profile>
-                            <id>ossrh</id>
+                            <id>central</id>
                             <activation>
                                 <activeByDefault>true</activeByDefault>
                             </activation>

--- a/src/site/site/content/odftoolkit_website/docs/settings-example.xml
+++ b/src/site/site/content/odftoolkit_website/docs/settings-example.xml
@@ -128,7 +128,7 @@ under the License.
     </server>
     -->
         <server>
-            <id>ossrh</id>
+            <id>central</id>
             <directoryPermissions>775</directoryPermissions>
             <filePermissions>644</filePermissions>
             <username>YOUR_USER_NAME</username>
@@ -261,12 +261,13 @@ under the License.
         </profile>
 
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
                 <gpg.keyname>YOUR_GPG_SIGNATURE_KEY_ID</gpg.keyname>
+                <!-- note: better omit pass, maven uses gpg-agent by default -->
                 <gpg.passphraseServerId>YOUR_PASSPHRASE</gpg.passphraseServerId>
             </properties>
         </profile>

--- a/src/site/site/content/odftoolkit_website/release-guide.mdtext
+++ b/src/site/site/content/odftoolkit_website/release-guide.mdtext
@@ -11,15 +11,15 @@ The release artifacts for each project are deployed to the Maven repository. Mak
 
 ### Only once your configuration Setup
 
-1. **Maven Repro Access**</br>Make sure you have access to Maven repro via our [Sonatype JIRA issue](https://issues.sonatype.org/browse/OSSRH-960). After this, you should be able to log in at <https://oss.sonatype.org/#welcome>.
-When logged in, will find in your profile a [user token](https://oss.sonatype.org/#profile;User%20Token). This token along with the according user name have to be added to your local [&lt;USER_HOME&gt;/.m2/settings.xml](https://maven.apache.org/settings.html) file.
+1. **Maven Repro Access**</br>Make sure you have access to Maven repro via our [Sonatype JIRA issue](https://issues.sonatype.org/browse/OSSRH-960). After this, you should be able to log in at <https://central.sonatype.com/>.
+When logged in, [generate a token](https://central.sonatype.org/publish/generate-portal-token/). This token consists of a generated user name and password; add it to your local [&lt;USER_HOME&gt;/.m2/settings.xml](https://maven.apache.org/settings.html) file.
 Something equivalent to:
 
-```shell
+```xml
     <server>
-      <id>ossrh</id>
-      <username>YOUR_USER_NAME</username><!-- from your profile -->
-      <password>YOUR_PASSWORD</password><!-- being the given token -->
+      <id>central</id>
+      <username>YOUR_USER_NAME</username><!-- as generated -->
+      <password>YOUR_PASSWORD</password><!-- as generated -->
     </server>
    ```
 
@@ -164,7 +164,7 @@ There are two kinds of releases a quick SNAPSHOT release, where the SNAPSHOT wil
 
 1. **Review and approve the Maven Nexus Deliverables**
 
-    Log into <https://oss.sonatype.org/#welcome> and review the artefacts of the release, if it is erroneous drop it.
+    Log into <https://central.sonatype.com/> and review the artefacts of the release, if it is erroneous drop it.
     1. If the release artefacts are correct, [close the repository](https://help.sonatype.com/repomanager2/staging-releases/managing-staging-repositories).
     2. After the closing process is done, you may release the repository.
     3. You may find the artefacts of the release among on Maven, e.g.: <https://repo1.maven.org/maven2/org/odftoolkit/odftoolkit/>


### PR DESCRIPTION
Sonatype is retiring OSSRH and the namespace was migrated to Maven Central already.

Try to adapt docs and pom.xml with snippets copied from various docs and hope it will work...

[... just typed "mvn deploy" and the result is at https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/odftoolkit/ ]