### PR TITLE
run sonar when merging pull requests into master

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,7 +27,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     # Only run SonarCloud on the main branch
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.base_ref == 'master'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
sonar should also run when pull requests are merged.

@svanteschubert since I do not have access to the settings in Git, do you know if the configuration described in #386 has been done? We only need the secrets.SONAR_TOKEN and change the sonar credentials in `Maven.yml`:

```
      - name: Build and analyze
        env:
          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
        run: >
          mvn -B verify
          -Dsonar.host.url=https://sonarcloud.io
          -Dsonar.projectKey=<FILL IN>
          -Dsonar.organization=<FILL_IN>
          -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco-ut/jacoco.xml
          org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
```

If you cannot change the settings and  update the configuration, can you tell me who I should contact?