### PR TITLE
Fix #443: add missing % to nonNegativePercent pattern in ODF 1.4 schema

### DIFF
--- a/validator/src/main/resources/schema/odf1.4/OpenDocument-v1.4-schema.rng
+++ b/validator/src/main/resources/schema/odf1.4/OpenDocument-v1.4-schema.rng
@@ -7075,7 +7075,7 @@
   <!-- https://issues.oasis-open.org/browse/OFFICE-4122 nonNegativePercent -->
   <rng:define name="nonNegativePercent">
   <rng:data type="string">
-    <rng:param name="pattern">([0-9]+(\.[0-9]*)?|\.[0-9]+)</rng:param>
+    <rng:param name="pattern">([0-9]+(\.[0-9]*)?|\.[0-9]+)%</rng:param>
   </rng:data>
 </rng:define>
   <rng:define name="nonNegativePixelLength">


### PR DESCRIPTION
The pattern for `nonNegativePercent` in `validator/src/main/resources/schema/odf1.4/OpenDocument-v1.4-schema.rng` is missing the `%` sign. This is the same fix Regina Henschel made in LibreOffice core for tdf#162687.

I ran into this because LibreOffice writes `draw:extrusion-specularity="0%"` whenever a shape has a 3D extrusion, so any ODF 1.4 document with an extruded shape gets reported as invalid.

I tested with odfvalidator 0.13.0 on a small .odt from LibreOffice 26.2 containing one extruded rectangle — it fails before this change and passes after. Happy to attach the file if it's useful.